### PR TITLE
Fix Product Name tvOS, watchOS, macOS frameworks

### DIFF
--- a/SwiftSoup.xcodeproj/project.pbxproj
+++ b/SwiftSoup.xcodeproj/project.pbxproj
@@ -359,11 +359,11 @@
 		8CE418571DAA568600240B42 /* SwiftSoup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSoup.swift; sourceTree = "<group>"; };
 		8CEA29581DAC112B0064A341 /* CharacterReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CharacterReader.swift; sourceTree = "<group>"; };
 		8CEA295A1DAC23820064A341 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
-		BD3B5BA91FBED933001FDB3B /* SwitSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwitSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD3B5BA91FBED933001FDB3B /* SwiftSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD3B5BAA1FBED934001FDB3B /* InfoMac.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = InfoMac.plist; path = /Users/nabil/Documents/nabil/SwiftSoup/Sources/InfoMac.plist; sourceTree = "<absolute>"; };
-		BD3B5BEC1FC063BD001FDB3B /* SwitSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwitSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD3B5BEC1FC063BD001FDB3B /* SwiftSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD3B5BED1FC063BD001FDB3B /* InfotvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = InfotvOS.plist; path = /Users/nabil/Documents/nabil/SwiftSoup/Sources/InfotvOS.plist; sourceTree = "<absolute>"; };
-		BD3B5C2F1FC06423001FDB3B /* SwitSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwitSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD3B5C2F1FC06423001FDB3B /* SwiftSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD3B5C301FC06424001FDB3B /* InfoWatchOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = InfoWatchOS.plist; path = /Users/nabil/Documents/nabil/SwiftSoup/Sources/InfoWatchOS.plist; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
@@ -533,9 +533,9 @@
 			children = (
 				8CE418161DAA54A900240B42 /* SwiftSoup.framework */,
 				8CE4181F1DAA54A900240B42 /* SwiftSoupTests.xctest */,
-				BD3B5BA91FBED933001FDB3B /* SwitSoup.framework */,
-				BD3B5BEC1FC063BD001FDB3B /* SwitSoup.framework */,
-				BD3B5C2F1FC06423001FDB3B /* SwitSoup.framework */,
+				BD3B5BA91FBED933001FDB3B /* SwiftSoup.framework */,
+				BD3B5BEC1FC063BD001FDB3B /* SwiftSoup.framework */,
+				BD3B5C2F1FC06423001FDB3B /* SwiftSoup.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -708,7 +708,7 @@
 			);
 			name = "SwiftSoup-macOS";
 			productName = SwiftSoup;
-			productReference = BD3B5BA91FBED933001FDB3B /* SwitSoup.framework */;
+			productReference = BD3B5BA91FBED933001FDB3B /* SwiftSoup.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		BD3B5BAB1FC063BD001FDB3B /* SwiftSoup-tvOS */ = {
@@ -726,7 +726,7 @@
 			);
 			name = "SwiftSoup-tvOS";
 			productName = SwiftSoup;
-			productReference = BD3B5BEC1FC063BD001FDB3B /* SwitSoup.framework */;
+			productReference = BD3B5BEC1FC063BD001FDB3B /* SwiftSoup.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		BD3B5BEE1FC06423001FDB3B /* SwiftSoup-watchOS */ = {
@@ -744,7 +744,7 @@
 			);
 			name = "SwiftSoup-watchOS";
 			productName = SwiftSoup;
-			productReference = BD3B5C2F1FC06423001FDB3B /* SwitSoup.framework */;
+			productReference = BD3B5C2F1FC06423001FDB3B /* SwiftSoup.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -1366,7 +1366,7 @@
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scinfu.SwiftSoup;
-				PRODUCT_NAME = SwitSoup;
+				PRODUCT_NAME = SwiftSoup;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
@@ -1393,7 +1393,7 @@
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scinfu.SwiftSoup;
-				PRODUCT_NAME = SwitSoup;
+				PRODUCT_NAME = SwiftSoup;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
@@ -1422,7 +1422,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.scinfu.SwiftSoup;
-				PRODUCT_NAME = SwitSoup;
+				PRODUCT_NAME = SwiftSoup;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -1454,7 +1454,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.scinfu.SwiftSoup;
-				PRODUCT_NAME = SwitSoup;
+				PRODUCT_NAME = SwiftSoup;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -1485,7 +1485,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.scinfu.SwiftSoup;
-				PRODUCT_NAME = SwitSoup;
+				PRODUCT_NAME = SwiftSoup;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1517,7 +1517,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.scinfu.SwiftSoup;
-				PRODUCT_NAME = SwitSoup;
+				PRODUCT_NAME = SwiftSoup;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
The Product Name field for the tvOS, watchOS, and macOS framework targets was misspelled `SwitSoup`, which causes an issue when linking to the compiled framework(e.g. by using Carthage) on those platforms as described in #52.