### PR TITLE
[WIP] Remove StringBuilder

### DIFF
--- a/Sources/Entities.swift
+++ b/Sources/Entities.swift
@@ -274,18 +274,19 @@ public class Entities {
             }
         }
 
+        var reachedNonWhite = false
         let escapedString = string.unicodeScalars.reduce(into: "") { (accumString, codePoint) in
             let lastWasWhite = accumString.last?.isWhitespace
 
-            switch (normaliseWhite, stripLeadingWhite, lastWasWhite, codePoint.isWhitespace) {
-            case (true, _, true?, true), (true, true, .none, true):
+            switch (normaliseWhite, codePoint.isWhitespace, stripLeadingWhite, reachedNonWhite, lastWasWhite) {
+            case (true, true, true, false, _), (true, true, _, _, true?):
+                return
+            case (true, true, _, _, _):
+                accumString.unicodeScalars.append(UnicodeScalar.Space)
                 return
             default:
-                if codePoint.value < Character.MIN_SUPPLEMENTARY_CODE_POINT {
-                    foo(codePoint, &accumString)
-                } else {
-                    accumString.unicodeScalars.append(codePoint)
-                }
+                reachedNonWhite = true
+                foo(codePoint, &accumString)
             }
         }
 

--- a/Tests/SwiftSoupTests/EntitiesTest.swift
+++ b/Tests/SwiftSoupTests/EntitiesTest.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-import SwiftSoup
+@testable import SwiftSoup
 
 class EntitiesTest: XCTestCase {
 
@@ -47,6 +47,35 @@ class EntitiesTest: XCTestCase {
         XCTAssertEqual(text, try Entities.unescape(escapedUtfFull2))
 		XCTAssertEqual(text, try Entities.unescape(escapedUtfMin))
 	}
+
+    func testEscapeInAttribute() {
+        let text = "H   ello &<> Å å π 新 there ¾ © »"
+        let accum = StringBuilder()
+        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), true, false, false)
+        XCTAssertEqual("H   ello &amp;<> &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+    }
+
+    func testEscapeNormalizeWhiteSpace() {
+        let text = "H   ello &<> Å å π 新 there ¾ © »"
+        let accum = StringBuilder()
+        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, true, false)
+        XCTAssertEqual("H ello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+
+        accum.clear()
+        Entities.escape(accum, "Hello\nthere", OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, true, true)
+        XCTAssertEqual("Hello there", accum.toString())
+    }
+
+    func testEscapeStripLeadingWhitespace() {
+        let text = "     Hello &<> Å å π 新 there ¾ © »"
+        let accum = StringBuilder()
+        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, false, true)
+        XCTAssertEqual("     Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+
+        accum.clear()
+        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, true, true)
+        XCTAssertEqual("Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+    }
 
 	func testXhtml() {
 		//let text = "&amp; &gt; &lt; &quot;";
@@ -153,6 +182,10 @@ class EntitiesTest: XCTestCase {
 		return [
             ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
             ("testEscape", testEscape),
+            ("testEscapeInAttribute", testEscapeInAttribute),
+            ("testEscapeBenchmark", testEscapeBenchmark),
+            ("testEscapeNormalizeWhiteSpace", testEscapeNormalizeWhiteSpace),
+            ("testEscapeStripLeadingWhitespace", testEscapeStripLeadingWhitespace),
 			("testXhtml", testXhtml),
 			("testGetByName", testGetByName),
 			("testEscapeSupplementaryCharacter", testEscapeSupplementaryCharacter),

--- a/Tests/SwiftSoupTests/EntitiesTest.swift
+++ b/Tests/SwiftSoupTests/EntitiesTest.swift
@@ -55,6 +55,17 @@ class EntitiesTest: XCTestCase {
         XCTAssertEqual("H   ello &amp;<> &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
     }
 
+    func testEscapeBenchmark() {
+        let text = "   Hello      &<> Å å π 新 there ¾ © »"
+        let accum = StringBuilder()
+        let settings = OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base)
+        measure {
+            accum.clear()
+            Entities.escape(accum, text, settings, true, true, true)
+        }
+        XCTAssertEqual("Hello &amp;<> &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+    }
+
     func testEscapeNormalizeWhiteSpace() {
         let text = "H   ello &<> Å å π 新 there ¾ © »"
         let accum = StringBuilder()


### PR DESCRIPTION
- [ ] Remove `StringBuilder` from [`Entities.escape`](https://github.com/scinfu/SwiftSoup/blob/6e12e9238c4564ddb131d38e87fd87ce0415bdd6/Sources/Entities.swift#L252-L329)
  - [ ] Write explicit tests to cover `Entities.escape`
  - [ ] Write benchmarks to document improvement