### PR TITLE
Remove all reference to StringBuilder in Entities.escape

### DIFF
--- a/Sources/Attribute.swift
+++ b/Sources/Attribute.swift
@@ -78,7 +78,7 @@ open class Attribute {
         accum.append(key)
         if (!shouldCollapseAttribute(out: out)) {
             accum.append("=\"")
-            Entities.escape(accum, value, out, true, false, false)
+            accum.append(Entities.escape(value, out, true, false, false))
             accum.append("\"")
         }
     }

--- a/Sources/Entities.swift
+++ b/Sources/Entities.swift
@@ -238,13 +238,11 @@ public class Entities {
     }
     
     open static func escape(_ string: String, _ out: OutputSettings) -> String {
-        let accum = StringBuilder()
-        escape(accum, string, out, false, false, false)
-        return accum.toString()
+        return escape(string, out, false, false, false)
     }
     
-    // this method is ugly, and does a lot. but other breakups cause rescanning and stringbuilder generations
-    static func escape(_ accum: StringBuilder, _ string: String, _ out: OutputSettings, _ inAttribute: Bool, _ normaliseWhite: Bool, _ stripLeadingWhite: Bool ) {
+    // this method is ugly, and does a lot.
+    static func escape(_ string: String, _ out: OutputSettings, _ inAttribute: Bool, _ normaliseWhite: Bool, _ stripLeadingWhite: Bool ) -> String {
         func foo(_ codePoint: UnicodeScalar, _ accumString: inout String) {
             switch (codePoint, inAttribute, out.escapeMode()) {
             case (.Ampersand, _, _):
@@ -290,7 +288,7 @@ public class Entities {
             }
         }
 
-        accum.append(escapedString)
+        return escapedString
     }
     
     public static func unescape(_ string: String)throws-> String {

--- a/Sources/TextNode.swift
+++ b/Sources/TextNode.swift
@@ -112,7 +112,7 @@ open class TextNode: Node {
         let par: Element? = parent() as? Element
         let normaliseWhite = out.prettyPrint() && par != nil && !Element.preserveWhitespace(par!)
 
-        Entities.escape(accum, getWholeText(), out, false, normaliseWhite, false)
+        accum.append(Entities.escape(getWholeText(), out, false, normaliseWhite, false))
     }
 
     override func outerHtmlTail(_ accum: StringBuilder, _ depth: Int, _ out: OutputSettings) {

--- a/Tests/SwiftSoupTests/EntitiesTest.swift
+++ b/Tests/SwiftSoupTests/EntitiesTest.swift
@@ -50,42 +50,39 @@ class EntitiesTest: XCTestCase {
 
     func testEscapeInAttribute() {
         let text = "H   ello &<> Å å π 新 there ¾ © »"
-        let accum = StringBuilder()
-        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), true, false, false)
-        XCTAssertEqual("H   ello &amp;<> &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+        let settings = OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base)
+        let result = Entities.escape(text, settings, true, false, false)
+        XCTAssertEqual("H   ello &amp;<> &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", result)
     }
 
     func testEscapeBenchmark() {
         let text = "   Hello      &<> Å å π 新 there ¾ © »"
-        let accum = StringBuilder()
         let settings = OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base)
+        var result: String = ""
         measure {
-            accum.clear()
-            Entities.escape(accum, text, settings, true, true, true)
+            result = Entities.escape(text, settings, true, true, true)
         }
-        XCTAssertEqual("Hello &amp;<> &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+        XCTAssertEqual("Hello &amp;<> &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", result)
     }
 
     func testEscapeNormalizeWhiteSpace() {
         let text = "H   ello &<> Å å π 新 there ¾ © »"
-        let accum = StringBuilder()
-        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, true, false)
-        XCTAssertEqual("H ello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+        let settings = OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base)
+        let result = Entities.escape(text, settings, false, true, false)
+        XCTAssertEqual("H ello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", result)
 
-        accum.clear()
-        Entities.escape(accum, "Hello\nthere", OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, true, true)
-        XCTAssertEqual("Hello there", accum.toString())
+        let result2 = Entities.escape("Hello\nthere", settings, false, true, true)
+        XCTAssertEqual("Hello there", result2)
     }
 
     func testEscapeStripLeadingWhitespace() {
         let text = "     Hello &<> Å å π 新 there ¾ © »"
-        let accum = StringBuilder()
-        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, false, true)
-        XCTAssertEqual("     Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+        let settings = OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base)
+        let result = Entities.escape(text, settings, false, false, true)
+        XCTAssertEqual("     Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", result)
 
-        accum.clear()
-        Entities.escape(accum, text, OutputSettings().encoder(String.Encoding.ascii).escapeMode(Entities.EscapeMode.base), false, true, true)
-        XCTAssertEqual("Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", accum.toString())
+        let result2 = Entities.escape(text, settings, false, true, true)
+        XCTAssertEqual("Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", result2)
     }
 
 	func testXhtml() {


### PR DESCRIPTION
This is a follow on PR to #70 that actually stops the `Entities.escape` method from using `StringBuilder`.