### PR TITLE
Remove forced runtime errors in do/catch blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,19 @@ After parsing a document, and finding some elements, you'll want to get at the d
 - To get the value of an attribute, use `Node.attr(_ String key)` method
 - For the text on an element (and its combined children), use `Element.text()`
 - For HTML, use `Element.html()`, or `Node.outerHtml()¡ as appropriate
+
 ```swift
 do {
     let html: String = "<p>An <a href='http://example.com/'><b>example</b></a> link.</p>";
-    let doc: Document = try! SwiftSoup.parse(html)
-    let link: Element = try! doc.select("a").first()!
+    let doc: Document = try SwiftSoup.parse(html)
+    let link: Element = try doc.select("a").first()!
     
-    let text: String = try! doc.body()!.text(); // "An example link"
-    let linkHref: String = try! link.attr("href"); // "http://example.com/"
-    let linkText: String = try! link.text(); // "example""
+    let text: String = try doc.body()!.text(); // "An example link"
+    let linkHref: String = try link.attr("href"); // "http://example.com/"
+    let linkText: String = try link.text(); // "example""
     
-    let linkOuterH: String = try! link.outerHtml(); // "<a href="http://example.com"><b>example</b></a>"
-    let linkInnerH: String = try! link.html(); // "<b>example</b>"
+    let linkOuterH: String = try link.outerHtml(); // "<a href="http://example.com"><b>example</b></a>"
+    let linkInnerH: String = try link.html(); // "<b>example</b>"
 } catch Exception.Error(let type, let message) {
     print(message)
 } catch {
@@ -294,8 +295,8 @@ Use the text setter methods of `Element`:
 
 ```swift
 do {
-    let doc: Document = try! SwiftSoup.parse("")
-    let div: Element = try! doc.select("div").first()! // <div></div>
+    let doc: Document = try SwiftSoup.parse("")
+    let div: Element = try doc.select("div").first()! // <div></div>
     try div.text("five > four") // <div>five &gt; four</div>
     try div.prepend("First ")
     try div.append(" Last")


### PR DESCRIPTION
The try statements in the README are already handled within do/catch blocks, so there's no need to disable error propagation and force a runtime error.

Thanks for the library!