### PR TITLE
Fix for "Static declarations are implicitly 'final'" waring 

### DIFF
--- a/Sources/Attribute.swift
+++ b/Sources/Attribute.swift
@@ -97,7 +97,7 @@ open class Attribute {
      * @param encodedValue HTML attribute encoded value
      * @return attribute
      */
-    open static func createFromEncoded(unencodedKey: String, encodedValue: String) throws ->Attribute {
+    public static func createFromEncoded(unencodedKey: String, encodedValue: String) throws ->Attribute {
         let value = try Entities.unescape(string: encodedValue, strict: true)
         return try Attribute(key: unencodedKey, value: value)
     }

--- a/Sources/Attributes.swift
+++ b/Sources/Attributes.swift
@@ -23,7 +23,7 @@ import Foundation
  */
 open class Attributes: NSCopying {
 
-    open static var dataPrefix: String = "data-"
+    public static var dataPrefix: String = "data-"
 
     var attributes: OrderedDictionary<String, Attribute>  = OrderedDictionary<String, Attribute>()
     // linked hash map to preserve insertion order.

--- a/Sources/Collector.swift
+++ b/Sources/Collector.swift
@@ -23,7 +23,7 @@ open class Collector {
      @param root root of tree to descend
      @return list of matches; empty if none
      */
-    open static func collect (_ eval: Evaluator, _ root: Element)throws->Elements {
+    public static func collect (_ eval: Evaluator, _ root: Element)throws->Elements {
         let elements: Elements = Elements()
         try NodeTraversor(Accumulator(root, elements, eval)).traverse(root)
         return elements
@@ -42,7 +42,7 @@ private final class Accumulator: NodeVisitor {
         self.eval = eval
     }
 
-    open func head(_ node: Node, _ depth: Int) {
+    public func head(_ node: Node, _ depth: Int) {
         guard let el = node as? Element else {
             return
         }
@@ -53,7 +53,7 @@ private final class Accumulator: NodeVisitor {
         } catch {}
     }
 
-    open func tail(_ node: Node, _ depth: Int) {
+    public func tail(_ node: Node, _ depth: Int) {
         // void
     }
 }

--- a/Sources/DataNode.swift
+++ b/Sources/DataNode.swift
@@ -64,7 +64,7 @@ open class DataNode: Node {
      @param baseUri bass URI
      @return new DataNode
      */
-    open static func createFromEncoded(_ encodedData: String, _ baseUri: String)throws->DataNode {
+    public static func createFromEncoded(_ encodedData: String, _ baseUri: String)throws->DataNode {
         let data = try Entities.unescape(encodedData)
         return DataNode(data, baseUri)
     }

--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -34,7 +34,7 @@ open class Document: Element {
      @param baseUri baseUri of document
      @return document with html, head, and body elements.
      */
-    static open func createShell(_ baseUri: String) -> Document {
+    static public func createShell(_ baseUri: String) -> Document {
         let doc: Document = Document(baseUri)
         let html: Element = try! doc.appendElement("html")
         try! html.appendElement("head")

--- a/Sources/Entities.swift
+++ b/Sources/Entities.swift
@@ -175,7 +175,7 @@ public class Entities {
      * @param name the possible entity name (e.g. "lt" or "amp")
      * @return true if a known named entity
      */
-    open static func isNamedEntity(_ name: String ) -> Bool {
+    public static func isNamedEntity(_ name: String ) -> Bool {
         return (EscapeMode.extended.codepointForName(name) != empty)
     }
 
@@ -185,7 +185,7 @@ public class Entities {
      * @return true if a known named entity in the base set
      * @see #isNamedEntity(String)
      */
-    open static func isBaseNamedEntity(_ name: String) -> Bool {
+    public static func isBaseNamedEntity(_ name: String) -> Bool {
         return EscapeMode.base.codepointForName(name) != empty
     }
 
@@ -195,7 +195,7 @@ public class Entities {
      * @return the Character value of the named entity (e.g. '{@literal <}' or '{@literal &}')
      * @deprecated does not support characters outside the BMP or multiple character names
      */
-    open static func getCharacterByName(name: String) -> Character {
+    public static func getCharacterByName(name: String) -> Character {
         return Character.convertFromIntegerLiteral(value: EscapeMode.extended.codepointForName(name))
     }
 
@@ -204,7 +204,7 @@ public class Entities {
      * @param name entity (e.g. "lt" or "amp")
      * @return the string value of the character(s) represented by this entity, or "" if not defined
      */
-    open static func getByName(name: String) -> String {
+    public static func getByName(name: String) -> String {
         let val = multipoints[name]
         if (val != nil) {return val!}
         let codepoint = EscapeMode.extended.codepointForName(name)
@@ -214,7 +214,7 @@ public class Entities {
         return emptyName
     }
 
-    open static func codepointsForName(_ name: String, codepoints: inout [UnicodeScalar]) -> Int {
+    public static func codepointsForName(_ name: String, codepoints: inout [UnicodeScalar]) -> Int {
 
         if let val: String = multipoints[name] {
             codepoints[0] = val.unicodeScalar(0)
@@ -230,11 +230,11 @@ public class Entities {
         return 0
     }
 
-    open static func escape(_ string: String, _ encode: String.Encoding = .utf8 ) -> String {
+    public static func escape(_ string: String, _ encode: String.Encoding = .utf8 ) -> String {
         return Entities.escape(string, OutputSettings().charset(encode).escapeMode(Entities.EscapeMode.extended))
     }
 
-    open static func escape(_ string: String, _ out: OutputSettings) -> String {
+    public static func escape(_ string: String, _ out: OutputSettings) -> String {
         let accum = StringBuilder()//string.characters.count * 2
         escape(accum, string, out, false, false, false)
         //        try {

--- a/Sources/Evaluator.swift
+++ b/Sources/Evaluator.swift
@@ -61,11 +61,11 @@ public class Evaluator {
             self.tagName = tagName
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return (element.tagName().hasSuffix(tagName))
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return String(tagName)
         }
     }
@@ -80,11 +80,11 @@ public class Evaluator {
             self.id = id
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return (id == element.id())
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "#\(id)"
         }
 
@@ -100,11 +100,11 @@ public class Evaluator {
             self.className = className
         }
 
-        open override func matches(_ root: Element, _ element: Element) -> Bool {
+        public override func matches(_ root: Element, _ element: Element) -> Bool {
             return (element.hasClass(className))
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ".\(className)"
         }
 
@@ -120,11 +120,11 @@ public class Evaluator {
             self.key = key
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return element.hasAttr(key)
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[\(key)]"
         }
 
@@ -141,7 +141,7 @@ public class Evaluator {
             self.keyPrefix = keyPrefix.lowercased()
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             if let values = element.getAttributes() {
                 for attribute in values where attribute.getKey().lowercased().hasPrefix(keyPrefix) {
                     return true
@@ -150,7 +150,7 @@ public class Evaluator {
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[^\(keyPrefix)]"
         }
 
@@ -164,7 +164,7 @@ public class Evaluator {
             try super.init(key, value)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             if element.hasAttr(key) {
                 let string = try element.attr(key)
                 return value.equalsIgnoreCase(string: string.trim())
@@ -172,7 +172,7 @@ public class Evaluator {
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[\(key)=\(value)]"
         }
 
@@ -186,12 +186,12 @@ public class Evaluator {
             try super.init(key, value)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let string = try element.attr(key)
             return !value.equalsIgnoreCase(string: string)
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[\(key)!=\(value)]"
         }
 
@@ -205,14 +205,14 @@ public class Evaluator {
             try super.init(key, value)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             if element.hasAttr(key) {
                 return try element.attr(key).lowercased().hasPrefix(value)  // value is lower case already
             }
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[\(key)^=\(value)]"
         }
 
@@ -226,14 +226,14 @@ public class Evaluator {
             try super.init(key, value)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             if element.hasAttr(key) {
                 return try element.attr(key).lowercased().hasSuffix(value) // value is lower case
             }
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[\(key)$=\(value)]"
         }
 
@@ -247,14 +247,14 @@ public class Evaluator {
             try super.init(key, value)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             if element.hasAttr(key) {
                 return try element.attr(key).lowercased().contains(value) // value is lower case
             }
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[\(key)*=\(value)]"
         }
 
@@ -273,7 +273,7 @@ public class Evaluator {
             super.init()
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             if element.hasAttr(key) {
                 let string = try element.attr(key)
                 return pattern.matcher(in: string).find()
@@ -281,7 +281,7 @@ public class Evaluator {
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "[\(key)~=\(pattern.toString())]"
         }
 
@@ -316,11 +316,11 @@ public class Evaluator {
      */
     public final class AllElements: Evaluator {
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return true
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return "*"
         }
     }
@@ -333,11 +333,11 @@ public class Evaluator {
             super.init(index)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return try element.elementSiblingIndex() < index
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":lt(\(index))"
         }
 
@@ -351,11 +351,11 @@ public class Evaluator {
             super.init(index)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return try element.elementSiblingIndex() > index
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":gt(\(index))"
         }
 
@@ -369,11 +369,11 @@ public class Evaluator {
             super.init(index)
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return try element.elementSiblingIndex() == index
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":eq(\(index))"
         }
 
@@ -383,7 +383,7 @@ public class Evaluator {
      * Evaluator for matching the last sibling (css :last-child)
      */
     public final class IsLastChild: Evaluator {
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
 
             if let parent = element.parent() {
                 let index = try element.elementSiblingIndex()
@@ -392,7 +392,7 @@ public class Evaluator {
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":last-child"
         }
     }
@@ -401,7 +401,7 @@ public class Evaluator {
         public init() {
             super.init(0, 1)
         }
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":first-of-type"
         }
     }
@@ -410,7 +410,7 @@ public class Evaluator {
         public init() {
             super.init(0, 1)
         }
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":last-of-type"
         }
     }
@@ -467,11 +467,11 @@ public class Evaluator {
             super.init(a, b)
         }
 
-        open override func calculatePosition(_ root: Element, _ element: Element)throws->Int {
+        public override func calculatePosition(_ root: Element, _ element: Element)throws->Int {
             return try element.elementSiblingIndex()+1
         }
 
-        open override func getPseudoClass() -> String {
+        public override func getPseudoClass() -> String {
             return "nth-child"
         }
     }
@@ -486,7 +486,7 @@ public class Evaluator {
             super.init(a, b)
         }
 
-        open override func calculatePosition(_ root: Element, _ element: Element)throws->Int {
+        public override func calculatePosition(_ root: Element, _ element: Element)throws->Int {
             var i = 0
 
             if let l = element.parent() {
@@ -495,7 +495,7 @@ public class Evaluator {
             return i - (try element.elementSiblingIndex())
         }
 
-        open override func getPseudoClass() -> String {
+        public override func getPseudoClass() -> String {
             return "nth-last-child"
         }
     }
@@ -556,7 +556,7 @@ public class Evaluator {
      * Evaluator for matching the first sibling (css :first-child)
      */
     public final class IsFirstChild: Evaluator {
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let p = element.parent()
             if(p != nil && !(((p as? Document) != nil))) {
                 return (try element.elementSiblingIndex()) == 0
@@ -564,7 +564,7 @@ public class Evaluator {
             return false
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":first-child"
         }
     }
@@ -575,27 +575,27 @@ public class Evaluator {
      *
      */
     public final class IsRoot: Evaluator {
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let r: Element = ((root as? Document) != nil) ? root.child(0) : root
             return element === r
         }
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":root"
         }
     }
 
     public final class IsOnlyChild: Evaluator {
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let p = element.parent()
             return p != nil && !((p as? Document) != nil) && element.siblingElements().array().count == 0
         }
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":only-child"
         }
     }
 
     public final class IsOnlyOfType: Evaluator {
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let p = element.parent()
             if (p == nil || (p as? Document) != nil) {return false}
 
@@ -607,20 +607,22 @@ public class Evaluator {
             }
             return pos == 1
         }
-        open override func toString() -> String {
+
+        public override func toString() -> String {
             return ":only-of-type"
         }
     }
 
     public final class IsEmpty: Evaluator {
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let family: Array<Node> = element.getChildNodes()
             for n in family {
                 if (!((n as? Comment) != nil || (n as? XmlDeclaration) != nil || (n as? DocumentType) != nil)) {return false}
             }
             return true
         }
-        open override func toString() -> String {
+
+        public override func toString() -> String {
             return ":empty"
         }
     }
@@ -648,11 +650,11 @@ public class Evaluator {
             self.searchText = searchText.lowercased()
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return (try element.text().lowercased().contains(searchText))
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":contains(\(searchText)"
         }
     }
@@ -667,11 +669,11 @@ public class Evaluator {
             self.searchText = searchText.lowercased()
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             return (element.ownText().lowercased().contains(searchText))
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":containsOwn(\(searchText)"
         }
     }
@@ -686,12 +688,12 @@ public class Evaluator {
             self.pattern = pattern
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let m = try pattern.matcher(in: element.text())
             return m.find()
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":matches(\(pattern)"
         }
     }
@@ -706,12 +708,12 @@ public class Evaluator {
             self.pattern = pattern
         }
 
-        open override func matches(_ root: Element, _ element: Element)throws->Bool {
+        public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let m = pattern.matcher(in: element.ownText())
             return m.find()
         }
 
-        open override func toString() -> String {
+        public override func toString() -> String {
             return ":matchesOwn(\(pattern.toString())"
         }
     }

--- a/Sources/StringUtil.swift
+++ b/Sources/StringUtil.swift
@@ -27,14 +27,14 @@ open class StringUtil {
      * @param sep string to place between strings
      * @return joined string
      */
-    open static func join(_ strings: [String], sep: String) -> String {
+    public static func join(_ strings: [String], sep: String) -> String {
         return strings.joined(separator: sep)
     }
-    open static func join(_ strings: Set<String>, sep: String) -> String {
+    public static func join(_ strings: Set<String>, sep: String) -> String {
         return strings.joined(separator: sep)
     }
 
-	open static func join(_ strings: OrderedSet<String>, sep: String) -> String {
+    public static func join(_ strings: OrderedSet<String>, sep: String) -> String {
 		return strings.joined(separator: sep)
 	}
 
@@ -64,7 +64,7 @@ open class StringUtil {
      * @param width amount of padding desired
      * @return string of spaces * width
      */
-    open static func padding(_ width: Int) -> String {
+    public static func padding(_ width: Int) -> String {
 
         if(width <= 0) {
             return ""
@@ -87,7 +87,7 @@ open class StringUtil {
      * @param string string to test
      * @return if string is blank
      */
-    open static func isBlank(_ string: String) -> Bool {
+    public static func isBlank(_ string: String) -> Bool {
         if (string.count == 0) {
             return true
         }
@@ -105,7 +105,7 @@ open class StringUtil {
      * @param string string to test
      * @return true if only digit chars, false if empty or null or contains non-digit chrs
      */
-    open static func isNumeric(_ string: String) -> Bool {
+    public static func isNumeric(_ string: String) -> Bool {
         if (string.count == 0) {
             return false
         }
@@ -123,7 +123,7 @@ open class StringUtil {
      * @param c code point to test
      * @return true if code point is whitespace, false otherwise
      */
-    open static func isWhitespace(_ c: Character) -> Bool {
+    public static func isWhitespace(_ c: Character) -> Bool {
         //(c == " " || c == UnicodeScalar.BackslashT || c == "\n" || (c == "\f" ) || c == "\r")
         return c.isWhitespace
     }
@@ -134,7 +134,7 @@ open class StringUtil {
      * @param string content to normalise
      * @return normalised string
      */
-    open static func normaliseWhitespace(_ string: String) -> String {
+    public static func normaliseWhitespace(_ string: String) -> String {
         let sb: StringBuilder  = StringBuilder.init()
         appendNormalisedWhitespace(sb, string: string, stripLeading: false)
         return sb.toString()
@@ -146,7 +146,7 @@ open class StringUtil {
      * @param string string to normalize whitespace within
      * @param stripLeading set to true if you wish to remove any leading whitespace
      */
-    open static func appendNormalisedWhitespace(_ accum: StringBuilder, string: String, stripLeading: Bool ) {
+    public static func appendNormalisedWhitespace(_ accum: StringBuilder, string: String, stripLeading: Bool ) {
         var lastWasWhite: Bool = false
         var reachedNonWhite: Bool  = false
 
@@ -165,10 +165,10 @@ open class StringUtil {
         }
     }
 
-    open static func inString(_ needle: String?, haystack: String...) -> Bool {
+    public static func inString(_ needle: String?, haystack: String...) -> Bool {
         return inString(needle, haystack)
     }
-    open static func inString(_ needle: String?, _ haystack: [String?]) -> Bool {
+    public static func inString(_ needle: String?, _ haystack: [String?]) -> Bool {
         if(needle == nil) {return false}
         for hay in haystack {
             if(hay != nil  && hay! == needle!) {
@@ -210,7 +210,7 @@ open class StringUtil {
      * @throws MalformedURLException if an error occurred generating the URL
      */
     //NOTE: Not sure it work
-    open static func resolve(_ base: URL, relUrl: String ) -> URL? {
+    public static func resolve(_ base: URL, relUrl: String ) -> URL? {
         var base = base
         if(base.pathComponents.count == 0 && base.absoluteString.last != "/" && !base.isFileURL) {
             base = base.appendingPathComponent("/", isDirectory: false)
@@ -225,7 +225,7 @@ open class StringUtil {
      * @param relUrl the relative URL to resolve. (If it's already absolute, it will be returned)
      * @return an absolute URL if one was able to be generated, or the empty string if not
      */
-    open static func resolve(_ baseUrl: String, relUrl: String ) -> String {
+    public static func resolve(_ baseUrl: String, relUrl: String ) -> String {
 
         let base = URL(string: baseUrl)
 

--- a/Sources/Tag.swift
+++ b/Sources/Tag.swift
@@ -58,7 +58,7 @@ open class Tag: Hashable {
      * @param settings used to control tag name sensitivity
      * @return The tag, either defined or new generic.
      */
-    open static func valueOf(_ tagName: String, _ settings: ParseSettings)throws->Tag {
+    public static func valueOf(_ tagName: String, _ settings: ParseSettings)throws->Tag {
         var tagName = tagName
         var tag: Tag? = Tag.tags[tagName]
 
@@ -86,7 +86,7 @@ open class Tag: Hashable {
      * @param tagName Name of tag, e.g. "p". <b>Case sensitive</b>.
      * @return The tag, either defined or new generic.
      */
-    open static func valueOf(_ tagName: String)throws->Tag {
+    public static func valueOf(_ tagName: String)throws->Tag {
         return try valueOf(tagName, ParseSettings.preserveCase)
     }
 
@@ -168,7 +168,7 @@ open class Tag: Hashable {
      * @param tagName name of tag
      * @return if known HTML tag
      */
-    open static func isKnownTag(_ tagName: String) -> Bool {
+    public static func isKnownTag(_ tagName: String) -> Bool {
         return Tag.tags[tagName] != nil
     }
 

--- a/Sources/TextNode.swift
+++ b/Sources/TextNode.swift
@@ -124,22 +124,22 @@ open class TextNode: Node {
      * @param baseUri Base uri
      * @return TextNode containing unencoded data (e.g. &lt;)
      */
-    open static func createFromEncoded(_ encodedText: String, _ baseUri: String)throws->TextNode {
+    public static func createFromEncoded(_ encodedText: String, _ baseUri: String)throws->TextNode {
         let text: String = try Entities.unescape(encodedText)
         return TextNode(text, baseUri)
     }
 
-    static open func normaliseWhitespace(_ text: String) -> String {
+    static public func normaliseWhitespace(_ text: String) -> String {
         let _text = StringUtil.normaliseWhitespace(text)
         return _text
     }
 
-    static open func stripLeadingWhitespace(_ text: String) -> String {
+    static public func stripLeadingWhitespace(_ text: String) -> String {
         return text.replaceFirst(of: "^\\s+", with: "")
         //return text.replaceFirst("^\\s+", "")
     }
 
-    static open func lastCharIsWhitespace(_ sb: StringBuilder) -> Bool {
+    static public func lastCharIsWhitespace(_ sb: StringBuilder) -> Bool {
         return sb.toString().last == " "
     }
 

--- a/Sources/Token.swift
+++ b/Sources/Token.swift
@@ -69,11 +69,11 @@ open class Token {
 			return publicIdentifier.toString()
 		}
 
-		open func getSystemIdentifier() -> String {
+        public func getSystemIdentifier() -> String {
 			return systemIdentifier.toString()
 		}
 
-		open func isForceQuirks() -> Bool {
+        public func isForceQuirks() -> Bool {
 			return forceQuirks
 		}
 	}
@@ -244,7 +244,7 @@ open class Token {
 			return self
 		}
 
-		open override func toString()throws->String {
+        public override func toString()throws->String {
 			if (_attributes.size() > 0) {
 				return try "<" + (name()) + " " + (_attributes.toString()) + ">"
 			} else {
@@ -259,7 +259,7 @@ open class Token {
 			type = TokenType.EndTag
 		}
 
-		open override func toString()throws->String {
+        public override func toString()throws->String {
 			return "</" + (try name()) + ">"
 		}
 	}
@@ -284,7 +284,7 @@ open class Token {
 			return data.toString()
 		}
 
-		open override func toString()throws->String {
+        public override func toString()throws->String {
 			return "<!--" + getData() + "-->"
 		}
 	}
@@ -313,7 +313,7 @@ open class Token {
 			return data
 		}
 
-		open override func toString()throws->String {
+        public override func toString()throws->String {
 			try Validate.notNull(obj: data)
 			return getData()!
 		}

--- a/Sources/TokenQueue.swift
+++ b/Sources/TokenQueue.swift
@@ -314,7 +314,7 @@ open class TokenQueue {
      * @param in backslash escaped string
      * @return unescaped string
      */
-    open static func unescape(_ input: String) -> String {
+    public static func unescape(_ input: String) -> String {
         let out = StringBuilder()
         var last = empty
         for c in input {


### PR DESCRIPTION
Fix for "Static declarations are implicitly 'final'; use 'public' instead" warning. Methods that are 'static' or inside a 'final' class can not by nature be declared as open. These methods are not overridable.