### PR TITLE
Fixes #101 - SwiftSoup builds in "release" mode on swift linux 4.2.

### DIFF
--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -750,9 +750,15 @@ open class Node: Equatable, Hashable {
         }
 
         open func tail(_ node: Node, _ depth: Int)throws {
+            // When compiling a release optimized swift linux 4.2 version the "saves a void hit."
+            // causes a SIL error. Removing optimization on linux until a fix is found.
+            #if os(Linux)
+            try node.outerHtmlTail(accum, depth, out)
+            #else
             if (!(node.nodeName() == OuterHtmlVisitor.text)) { // saves a void hit.
                 try node.outerHtmlTail(accum, depth, out)
             }
+            #endif
         }
     }
 


### PR DESCRIPTION
SwiftSoup does not build on swift linux 4.2 in "release" mode, see https://travis-ci.org/scinfu/SwiftSoup/jobs/438795328. SIL doesn't like the code (though it looks fine). 

This PR removes what appears to be an optimization when compiling for linux, which appears to resolve the issue for linux.

MacOS is not affected by this issue or this PR.

This PR resolves #101.
