### PR TITLE
Provide a RandomAccessCollection extension for Elements

### DIFF
--- a/Sources/Elements.swift
+++ b/Sources/Elements.swift
@@ -584,33 +584,24 @@ extension Elements: Equatable {
 }
 
 /**
-* Elements IteratorProtocol.
+* Elements RandomAccessCollection
 */
-public struct ElementsIterator: IteratorProtocol {
-	/// Elements reference
-	let elements: Elements
-	//current element index
-	var index = 0
-
-	/// Initializer
-	init(_ countdown: Elements) {
-		self.elements = countdown
+extension Elements: RandomAccessCollection {
+	public subscript(position: Int) -> Element {
+		return this[position]
 	}
 
-	/// Advances to the next element and returns it, or `nil` if no next element
-	mutating public func next() -> Element? {
-		let result = index < elements.size() ? elements.get(index) : nil
-		index += 1
-		return result
+	public var startIndex: Int {
+		return this.startIndex
 	}
-}
 
-/**
-* Elements Extension Sequence.
-*/
-extension Elements: Sequence {
-	/// Returns an iterator over the elements of this sequence.
-	public func makeIterator() -> ElementsIterator {
-		return ElementsIterator(self)
+	public var endIndex: Int {
+		return this.endIndex
+	}
+
+	/// The number of Element objects in the collection.
+	/// Equivalent to `size()`
+	public var count: Int {
+		return this.count
 	}
 }

--- a/Tests/SwiftSoupTests/ElementsTest.swift
+++ b/Tests/SwiftSoupTests/ElementsTest.swift
@@ -30,6 +30,17 @@ class ElementsTest: XCTestCase {
 		try XCTAssertEqual("There", els.get(1).text())
 	}
 
+	func testRandomAccessCollection()throws {
+		let h: String = "<div><p>one</p><div class=headline><p>two</p><p>three</p></div><p>four</p></div>"
+		let doc: Document = try SwiftSoup.parse(h)
+		let els: Elements = try doc.select("p")
+		XCTAssertEqual(els.count, 4)
+		for i in (els.startIndex ..< els.endIndex).shuffled() {
+			let el = els[i]
+			XCTAssertEqual(el.tag().getName(), "p")
+		}
+	}
+
 	func testAttributes()throws {
 		let h = "<p title=foo><p title=bar><p class=foo><p class=bar>"
 		let doc: Document = try SwiftSoup.parse(h)
@@ -297,6 +308,7 @@ class ElementsTest: XCTestCase {
 		return [
             ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
             ("testFilter", testFilter),
+			("testRandomAccessCollection", testRandomAccessCollection),
 			("testAttributes", testAttributes),
 			("testHasAttr", testHasAttr),
 			("testHasAbsAttr", testHasAbsAttr),


### PR DESCRIPTION
I replaced the Sequence extension on Elements with RandomAccessCollection.
The makes the Elements class more like a Swift Array, and gets Sequence
support for free, removing the need for ElementsIterator.