### PR TITLE
joined() seems to be much more efficient than reduce()

### DIFF
--- a/Sources/StringBuilder.swift
+++ b/Sources/StringBuilder.swift
@@ -26,7 +26,7 @@ open class StringBuilder {
      :return: String
      */
     open func toString() -> String {
-        return buffer.reduce("", +)
+        return buffer.joined()
     }
 
     /**


### PR DESCRIPTION
In my tests with a large html file `document.html()` was taking 5 seconds. With the change to use `join` rather than `reduce` that time was cut down to 0.072 seconds (almost 100x better).

I'm assuming that `join` is smarter about allocating the memory needed up front, where as `reduce` could spend a lot of time re-allocating and moving things in memory.