### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0.2-xenial SWIFT_TEST_ARGS="--parallel"
+      env: DOCKER_IMAGE=swift:5.0.3-xenial SWIFT_SNAPSHOT=5.0.3 SWIFT_TEST_ARGS="--parallel"
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0.2 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
+      env: DOCKER_IMAGE=swift:5.1.5-xenial SWIFT_SNAPSHOT=5.1.5 SWIFT_TEST_ARGS="--parallel"
     - os: osx
       osx_image: xcode10.1
       sudo: required
@@ -37,13 +37,9 @@ matrix:
       sudo: required
       env: SWIFT_SNAPSHOT=5.0.1 SWIFT_TEST_ARGS="--parallel"
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode11.3
       sudo: required
-      env: SWIFT_SNAPSHOT=5.1 SWIFT_TEST_ARGS="--parallel"
-    - os: osx
-      osx_image: xcode11
-      sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
+      env: SWIFT_SNAPSHOT=5.1.3 SWIFT_TEST_ARGS="--parallel"
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/HtmlTreeBuilderState.swift
+++ b/Sources/HtmlTreeBuilderState.swift
@@ -162,7 +162,7 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
                 return false
             case .StartTag:
                 let start: Token.StartTag = t.asStartTag()
-                var name: String = start.normalName()!
+                let name: String = start.normalName()!
                 if (name.equals("html")) {
                     return try HtmlTreeBuilderState.InBody.process(t, tb)
                 } else if TagSets.baseEtc.contains(name) {
@@ -172,7 +172,7 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
                         try tb.maybeSetBaseUri(el)
                     }
                 } else if (name.equals("meta")) {
-                    let meta: Element = try tb.insertEmpty(start)
+                    let _: Element = try tb.insertEmpty(start)
                     // todo: charset switches
                 } else if (name.equals("title")) {
                     try HtmlTreeBuilderState.handleRcData(start, tb)
@@ -638,7 +638,7 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
                 if let name = endTag.normalName() {
                     if Constants.InBodyEndAdoptionFormatters.contains(name) {
                         // Adoption Agency Algorithm.
-                        for i in 0..<8 {
+                        for _ in 0..<8 {
                             let formatEl: Element? = tb.getActiveFormattingElement(name)
                             if (formatEl == nil) {
                                 return anyOtherEndTag(t, tb)
@@ -681,7 +681,7 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
                             // does that mean: int pos of format el in list?
                             var node: Element? = furthestBlock
                             var lastNode: Element? = furthestBlock
-                            for j in 0..<3 {
+                            for _ in 0..<3 {
                                 if (node != nil && tb.onStack(node!)) {
                                     node = tb.aboveOnStack(node!)
                                 }
@@ -725,7 +725,7 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
 
                             let adopter: Element = Element(formatEl!.tag(), tb.getBaseUri())
                             adopter.getAttributes()?.addAll(incoming: formatEl!.getAttributes())
-                            var childNodes: [Node] = furthestBlock!.getChildNodes()
+                            let childNodes: [Node] = furthestBlock!.getChildNodes()
                             for childNode: Node in childNodes {
                                 try adopter.appendChild(childNode) // append will reparent. thus the clone to avoid concurrent mod.
                             }


### PR DESCRIPTION
I've fixed and updated travis-ci tests, they failed for some reason. Now they working on:
- linux, swift 4.2.4
- linux, swift 5.0.3
- linux, swift 5.1.5
- osx, xcode 10.1, swift 4.2.1
- osx, xcode 10.2, swift 5.0.1
- osx, xcode 11.3, swift 5.1.3

Yet there's no development sanpshots. e.g. swift 5.2. But i'll be glad to add it with another PR when they'll be released.

Also there were compilation warnings in `Sources/HtmlTreeBuilderState.swift` so i've fixed them too.