### PR TITLE
swift-tools 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 


### PR DESCRIPTION
Xcode 13.2 generates a warning now for packages which don't use Swift 5.0 or higher.
<img width="1512" alt="Screen Shot 2021-12-17 at 23 44 18" src="https://user-images.githubusercontent.com/42500484/146617241-5318f282-0490-46e8-8f72-c1ed2492f75f.png">
