### PR TITLE
selfclosing for html too

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -1226,9 +1226,9 @@ open class Element: Node {
         // selfclosing includes unknown tags, isEmpty defines tags that are always empty
         if (childNodes.isEmpty && _tag.isSelfClosing()) {
             if (out.syntax() == OutputSettings.Syntax.html && _tag.isEmpty()) {
-                accum.append(">")
+                accum.append(" />") // <img /> for "always empty" tags. selfclosing is ignored but retained for xml/xhtml compatibility
             } else {
-                accum.append(" />") // <img> in html, <img /> in xml
+                accum.append(" />") // <img /> in xml
             }
         } else {
             accum.append(">")


### PR DESCRIPTION
this is valid in html for many years now and is ignored. this makes it easier to use the output in both html and xhtml pages, which otherwise fail for eg `<img>`.