### PR TITLE
Allow rctext / rcdata tags to self-close.

### DIFF
--- a/Sources/HtmlTreeBuilderState.swift
+++ b/Sources/HtmlTreeBuilderState.swift
@@ -1530,17 +1530,17 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
     }
 
     private static func handleRcData(_ startTag: Token.StartTag, _ tb: HtmlTreeBuilder)throws {
-        try tb.insert(startTag)
         tb.tokeniser.transition(TokeniserState.Rcdata)
         tb.markInsertionMode()
         tb.transition(.Text)
+        try tb.insert(startTag)
     }
 
     private static func handleRawtext(_ startTag: Token.StartTag, _ tb: HtmlTreeBuilder)throws {
-        try tb.insert(startTag)
         tb.tokeniser.transition(TokeniserState.Rawtext)
         tb.markInsertionMode()
         tb.transition(.Text)
+        try tb.insert(startTag)
     }
 
     // lists of tags to search through. A little harder to read here, but causes less GC than dynamic varargs.

--- a/Tests/SwiftSoupTests/HtmlParserTest.swift
+++ b/Tests/SwiftSoupTests/HtmlParserTest.swift
@@ -349,6 +349,24 @@ class HtmlParserTest: XCTestCase {
 		let doc = try SwiftSoup.parse(h)
 		XCTAssertEqual("<div id=\"1\"></div><script src=\"/foo\"></script><div id=\"2\"><img><img></div><a id=\"3\"></a><i></i><foo /><foo>One</foo> <hr> hr text <hr> hr text two", try TextUtil.stripNewlines(doc.body()!.html()))
 	}
+    
+    func testHandlesKnownEmptyNoFrames() throws {
+        let h = "<html><head><noframes /><meta name=foo></head><body>One</body></html>";
+        let doc = try SwiftSoup.parse(h);
+        XCTAssertEqual("<html><head><noframes></noframes><meta name=\"foo\"></head><body>One</body></html>", try TextUtil.stripNewlines(doc.html()));
+    }
+    
+    func testHandlesKnownEmptyStyle() throws {
+        let h = "<html><head><style /><meta name=foo></head><body>One</body></html>";
+        let doc = try SwiftSoup.parse(h);
+        XCTAssertEqual("<html><head><style></style><meta name=\"foo\"></head><body>One</body></html>", try TextUtil.stripNewlines(doc.html()));
+    }
+
+    func testHandlesKnownEmptyTitle() throws {
+        let h = "<html><head><title /><meta name=foo></head><body>One</body></html>";
+        let doc = try SwiftSoup.parse(h);
+        XCTAssertEqual("<html><head><title></title><meta name=\"foo\"></head><body>One</body></html>", try TextUtil.stripNewlines(doc.html()));
+    }
 
 	func testHandlesSolidusAtAttributeEnd()throws {
 		// this test makes sure [<a href=/>link</a>] is parsed as [<a href="/">link</a>], not [<a href="" /><a>link</a>]


### PR DESCRIPTION
This fixes #253 - backported from jhy/jsoup#906 