### PR TITLE
Add explicit fallthrough in `Doctype` state

### DIFF
--- a/Sources/TokeniserState.swift
+++ b/Sources/TokeniserState.swift
@@ -1097,7 +1097,8 @@ enum TokeniserState: TokeniserStateProtocol {
                 break
             case TokeniserStateVars.eof:
                 t.eofError(self)
-            // note: fall through to > case
+                // note: fall through to > case
+                fallthrough
             case ">": // catch invalid <!DOCTYPE>
                 t.error(self)
                 t.createDoctypePending()


### PR DESCRIPTION
In Swift, there's [no implicit fallthrough](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/controlflow/#No-Implicit-Fallthrough) in `switch` cases. You have to make the [fallthrough](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/controlflow/#No-Implicit-Fallthrough) explicit by using `fallthrough` at the end of the case.

Tests are passing and this aligns with Jsoup.