### PR TITLE
Remove political references from the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
   <img src="https://raw.githubusercontent.com/scinfu/SwiftSoup/master/swiftsoup.png" alt="SwiftSoup" title="SwiftSoup">
 </p>
 
-[![StandWithPalestine](https://github.com/Safouene1/support-palestine-banner/blob/master/StandWithPalestine.svg)](https://bdsmovement.net/)
 ![Platform OS X | iOS | tvOS | watchOS | Linux](https://img.shields.io/badge/platform-Linux%20%7C%20OS%20X%20%7C%20iOS%20%7C%20tvOS%20%7C%20watchOS-orange.svg)
 [![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
 ![🐧 linux: ready](https://img.shields.io/badge/%F0%9F%90%A7%20linux-ready-red.svg)
@@ -11,9 +10,6 @@
 [![Version](https://img.shields.io/cocoapods/v/SwiftSoup.svg?style=flat)](http://cocoapods.org/pods/SwiftSoup)
 [![License](https://img.shields.io/cocoapods/l/SwiftSoup.svg?style=flat)](http://cocoapods.org/pods/SwiftSoup)
 [![Twitter](https://img.shields.io/badge/twitter-@scinfu-blue.svg?style=flat)](http://twitter.com/scinfu)
-
-[![ReadMeSupportPalestine](https://github.com/Safouene1/support-palestine-banner/blob/master/banner-support.svg)](https://bdsmovement.net/)
-
 
 `SwiftSoup` is a pure Swift library, cross-platform (macOS, iOS, tvOS, watchOS and Linux!), for working with real-world HTML. It provides a very convenient API for extracting and manipulating data, using the best of DOM, CSS, and jQuery-like methods.
 `SwiftSoup` implements the WHATWG HTML5 specification, and parses HTML to the same DOM as modern browsers do.


### PR DESCRIPTION
This PR addresses an issue that came up in our university software project team in the Netherlands regarding the political reference found within the readme.

First of all, thank you for developing and maintaining this library, we audited many HTML parsing libraries and we found this one the best, from usability, ease of installation and well-maintainedness perspectives. 

We have an Israeli team member in our team, and he was strongly opposed to using this library because of the BDS promotion. I myself usually stand very far from politics, but I wanted to dig a bit deeper to see why he was opposing so much, even though he is very much advocating against the war between Palestine and Israel. 

> I am not an expert in politics, and I want to restate that all my information on this topic is based on a 2 hour research considering sources from both sides of the argument, and wikipedia as an independent source. https://en.wikipedia.org/wiki/Boycott,_Divestment_and_Sanctions

I found that BDS, aside from being an advocate for peace and boycott of Israel in the war, is criticized for misinformation, cherry-picking information, antisemitism and others. https://en.wikipedia.org/wiki/Boycott,_Divestment_and_Sanctions#Criticism
Because of this, I feel/speculate that many people, especially Jews and people from Israel or just fighting against misinformation and against antisemitism (who of course also might have a distorted world view) are strongly disliking the BDS, even though they have the same intent and best interest to arrive at peace.

Because of this, we had to have an unfortunately bit heated discussion about this in our team (all of us not being fully aware of the exact political situation). My Israeli teammate was strongly opposing using this library as in his eyes, it promotes misinformation. 

We as a team believe that the authors of this library acted from their best interest, and displayed the BDS banner from their best interest for advocating human rights and peace. I suppose no political party, movement or organization can be perfect and not have any controversy around it. I don't have the wisdom of knowing whether there is a better, non-controversial movement that advocates for peace that could replace the BDS banner but until someone finds one, I would recommend removing the political references from the library's main page because as of now, even though the core intent behind it is nice, the banner for BDS is inappropriate for an HTML parsing library.

We believe that while supporting peace is important, separating controversy and politics from professional life and technology is important, as it causes the like-minded people to be divided, and might cause conflicts within the team, or if they want to avoid conflicts and having a proper argument to understand each other's perspectives they might make the team accept to use a library that is not as good and well-maintained as this one.

For now I would recommend to remove all political references from the repository, and possibly later add back some links or banner that somehow captures the pure intent of the authors of promoting peace without causing controversy between people who also stand for peace.