### PR TITLE
require watchOS v6 or higher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftSoup",
-    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v4)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "SwiftSoup", targets: ["SwiftSoup"])
     ],

--- a/SwiftSoup.podspec
+++ b/SwiftSoup.podspec
@@ -12,10 +12,10 @@ SwiftSoup is a Swift library for working with real-world HTML. It provides a ver
   s.source           = { :git => 'https://github.com/scinfu/SwiftSoup.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/scinfu'
 
-  s.ios.deployment_target = '12.0'
-  s.osx.deployment_target = '10.13'
-  s.watchos.deployment_target = '4.0'
-  s.tvos.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
+  s.osx.deployment_target = '10.15'
+  s.watchos.deployment_target = '6.0'
+  s.tvos.deployment_target = '13.0'
 
   s.source_files = 'Sources/**/*.swift'
   s.swift_versions = ['4.0', '4.2', '5.0', '5.1']


### PR DESCRIPTION
After #276, package compilation now fails with
'UTF8View' is only available in watchOS 6.0 or newer
'utf8' is only available in watchOS 6.0 or newer

Bumps required version to watchOS 6, which came out at the same time that iOS 13 did.
