### PR TITLE
Fix 'utf8' is only available in watchOS 6.0 or newer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftSoup",
-    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v4)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "SwiftSoup", targets: ["SwiftSoup"])
     ],


### PR DESCRIPTION
### Fix follow:

1. 'UTF8View' is only available in watchOS 6.0 or newer 

1. 'utf8' is only available in watchOS 6.0 or newer