### PR TITLE
Remove unused keys from privacy manifest

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -2,15 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyTracking</key>
-	<false/>
-	<key>NSPrivacyTrackingDomains</key>
-	<array/>
-	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-	</array>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-	</array>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Hi, we're getting this Privacy manifest issue on review. Would be great to fix that) My guess it's about the unused keys which have to have values.


> Although submission for App Store review was successful, you may want to correct the following issues in your next submission for App Store review. Once you've corrected the issues, upload a new binary to App Store Connect.
> 
> ITMS-91108: Invalid privacy manifest - The PrivacyInfo.xcprivacy file from the following path is invalid: “SwiftSoup_SwiftSoup.bundle/PrivacyInfo.xcprivacy”. In addition to the privacy manifest files in the locations outlined in the documentation, starting November 12, 2024, all privacy manifests you submit must have valid content. Keys and values in any privacy manifest must be in a valid format. For more details about privacy manifest files, visit: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files and https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk.
> 
> Apple Developer Relations
