### PR TITLE
Exclude Info plists from SwiftPM target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,12 @@ let package = Package(
     targets: [
         .target(name: "SwiftSoup",
                 path: "Sources",
-                exclude: [],
+                exclude: [
+                    "Info.plist",
+                    "InfoMac.plist",
+                    "InfotvOS.plist",
+                    "InfoWatchOS.plist",
+                ],
                 resources: [.copy("PrivacyInfo.xcprivacy")]),
         .testTarget(name: "SwiftSoupTests", dependencies: ["SwiftSoup"])
     ]


### PR DESCRIPTION
When building the project from the command-line using `swift build`, SwiftPM currently warns about not excluding a couple of plists:

```
$ swift build
warning: 'swiftsoup': found 4 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    <path to swiftsoup>/Sources/InfoMac.plist
    <path to swiftsoup>/Sources/InfotvOS.plist
    <path to swiftsoup>/Sources/Info.plist
    <path to swiftsoup>/Sources/InfoWatchOS.plist
Building for debugging...
[63/63] Compiling SwiftSoup resource_bundle_accessor.swift
Build complete! (5.22s)
```

This PR fixes the issue by adding the missing excludes (I assume the plists are used by some other build mechanism).