### PR TITLE
Add SwiftPM's `.build` to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # OS X
 .DS_Store
 
+# Swift Package Manager
+.build
+
 # Xcode user settings
 xcuserdata/


### PR DESCRIPTION
This the folder where SwiftPM stores build artifacts when building from the command line (e.g. with `swift build`), hence we should ignore it to avoid accidentally committing it.