### PR TITLE
Remove copying missing PrivacyInfo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
                     "InfoMac.plist",
                     "InfotvOS.plist",
                     "InfoWatchOS.plist",
-                ],
-                resources: [.copy("PrivacyInfo.xcprivacy")]),
+                ]),
         .testTarget(name: "SwiftSoupTests", dependencies: ["SwiftSoup"])
     ]
 )


### PR DESCRIPTION
This PR fixes the warning about missing PrivacyInfo.xcprivary mentioned in package manifest
```
No files found at: /Users/.../.../Tuist/.build/checkouts/SwiftSoup/Sources/PrivacyInfo.xcprivacy
```