### PR TITLE
fix: make NodeTraversor class open for proper subclassing

### DIFF
--- a/Sources/NodeTraversor.swift
+++ b/Sources/NodeTraversor.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class NodeTraversor {
+open class NodeTraversor {
     private let visitor: NodeVisitor
 
     /**


### PR DESCRIPTION
NodeTraversor was internal while traverse(_:) was open, making subclassing impossible outside the module. This change makes NodeTraversor open to allow proper subclassing and method overriding.

Resolves #293 