### PR TITLE
Fix for UTF8 character counting in class names

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -1158,7 +1158,7 @@ open class Element: Node {
         var inClass: Bool = false
         var start: Int = 0
         for i in 0..<len {
-            if (classAttr.charAt(i).isWhitespace) {
+            if (classAttr.utf8CharAt(i).isWhitespace) {
                 if (inClass) {
                     // white space ends a class name, compare it with the requested one, ignore case
                     if (i - start == wantLen && classAttr.regionMatches(ignoreCase: true, selfOffset: start,

--- a/Sources/String.swift
+++ b/Sources/String.swift
@@ -282,6 +282,10 @@ extension String {
         return self[i] as Character
     }
 
+    func utf8CharAt(_ i: Int) -> UTF8Char {
+      return self.utf8Array[i]
+    }
+
 	func substring(_ beginIndex: Int) -> String {
         return String.split(self, beginIndex, self.count-beginIndex)
     }


### PR DESCRIPTION
I was getting a crash with an HTML document that had a class name with an e-acute (`é`) in. This was due to an assumption in the SwiftSoup code that UTF8 codepoint count could be used to count Swift string characters.