### PR TITLE
fix: correct utf8 string length in `hasClass`

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -1372,7 +1372,7 @@ open class Element: Node {
     public func hasClass(_ className: String) -> Bool {
         let classAtt: [UInt8]? = attributes?.get(key: Element.classString)
         let len: Int = (classAtt != nil) ? classAtt!.count : 0
-        let wantLen: Int = className.count
+        let wantLen: Int = className.utf8.count
         
         if (len == 0 || len < wantLen) {
             return false

--- a/Tests/SwiftSoupTests/ElementTest.swift
+++ b/Tests/SwiftSoupTests/ElementTest.swift
@@ -269,6 +269,11 @@ class ElementTest: XCTestCase {
         try attribs.put("class", " abcd efgh raulpismuth ")
         hasClass = el.hasClass("raulpismuth")
         XCTAssertTrue(hasClass)
+
+        let s = String(Character(UnicodeScalar(135361)!))
+        try attribs.put("class", s)
+        hasClass = el.hasClass(s)
+        XCTAssertTrue(hasClass)
     }
 
     func testClassUpdates() throws {


### PR DESCRIPTION
closes #312 

turned out to be a simpler issue than i thought. 

not sure why there's a second `hasClass` with identical logic. is there a tiny performance gain that warrants not doing `hasClass(className.utf8Array)` in the `String` version..?