### PR TITLE
Fix encoding of U+00A0 No-Break Space

### DIFF
--- a/Sources/Entities.swift
+++ b/Sources/Entities.swift
@@ -301,13 +301,11 @@ public class Entities {
                     for j in i..<end {
                         charBytes.append(base[j])
                     }
-                    if canEncode(bytes: charBytes, encoder: encoder) {
-                        switch charBytes {
-                        case [0xC2, 0xA0]: // UTF-8 encoding of "\u{A0}"
-                            accum.append(escapeMode == .xhtml ? xa0EntityUTF8 : nbspEntityUTF8)
-                        default:
-                            accum.append(charBytes)
-                        }
+                    if charBytes == [0xC2, 0xA0] {
+                        // UTF-8 encoding of "\u{A0}"
+                        accum.append(escapeMode == .xhtml ? xa0EntityUTF8 : nbspEntityUTF8)
+                    } else if canEncode(bytes: charBytes, encoder: encoder) {
+                        accum.append(charBytes)
                     } else {
                         appendEncoded(accum: accum, escapeMode: escapeMode, bytes: charBytes)
                     }

--- a/Sources/Entities.swift
+++ b/Sources/Entities.swift
@@ -268,8 +268,6 @@ public class Entities {
                     switch b {
                     case 0x26:
                         accum.append(ampEntityUTF8)
-                    case 0xA0:
-                        accum.append(escapeMode == .xhtml ? xa0EntityUTF8 : nbspEntityUTF8)
                     case 0x3C:
                         if !inAttribute || escapeMode == .xhtml {
                             accum.append(ltEntityUTF8)
@@ -304,7 +302,12 @@ public class Entities {
                         charBytes.append(base[j])
                     }
                     if canEncode(bytes: charBytes, encoder: encoder) {
-                        accum.append(charBytes)
+                        switch charBytes {
+                        case [0xC2, 0xA0]: // UTF-8 encoding of "\u{A0}"
+                            accum.append(escapeMode == .xhtml ? xa0EntityUTF8 : nbspEntityUTF8)
+                        default:
+                            accum.append(charBytes)
+                        }
                     } else {
                         appendEncoded(accum: accum, escapeMode: escapeMode, bytes: charBytes)
                     }

--- a/Tests/SwiftSoupTests/BuildEntities.swift
+++ b/Tests/SwiftSoupTests/BuildEntities.swift
@@ -5,5 +5,16 @@
 //  Created by Nabil Chatbi on 31/10/16.
 //
 
-import Foundation
-//todo:
+import XCTest
+import SwiftSoup
+
+class BuildEntitiesTests: XCTestCase {
+    
+    func testEscapeEntities() {
+        XCTAssertEqual(Entities.escape("foo<\u{A0}>bar"), "foo&lt;&nbsp;&gt;bar")
+        
+        let xhtml = OutputSettings().charset(.utf8).escapeMode(Entities.EscapeMode.xhtml)
+        XCTAssertEqual(Entities.escape("foo<\u{A0}>bar", xhtml), "foo&lt;&#xa0;&gt;bar")
+    }
+    
+}


### PR DESCRIPTION
Fix detecting and escaping the No-Break Space Unicode character, which is a two-byte UTF-8 sequence and needs special handling.

Fixes #313.