### PR TITLE
Make :first-child ignore the root node

### DIFF
--- a/Sources/Evaluator.swift
+++ b/Sources/Evaluator.swift
@@ -564,7 +564,7 @@ open class Evaluator {
     public final class IsFirstChild: Evaluator {
         public override func matches(_ root: Element, _ element: Element)throws->Bool {
             let p = element.parent()
-            if(p != nil && !(((p as? Document) != nil))) {
+            if element !== root, p != nil, !(p is Document) {
                 return (try element.elementSiblingIndex()) == 0
             }
             return false


### PR DESCRIPTION
This resolves #274 : the `:first-child` selector included the root node if that node was itself a first child of a non-document node.