### PR TITLE
Fix :last-child selector

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -677,7 +677,8 @@ open class Element: Node {
             if (siblings.count > index!+1) {
                 return siblings[index!+1]
             } else {
-                return nil}
+                return nil
+            }
         }
         return nil
     }

--- a/Sources/Evaluator.swift
+++ b/Sources/Evaluator.swift
@@ -390,10 +390,8 @@ open class Evaluator {
      */
     public final class IsLastChild: Evaluator {
         public override func matches(_ root: Element, _ element: Element)throws->Bool {
-
-            if let parent = element.parent() {
-                let index = try element.elementSiblingIndex()
-                return !(parent is Document) && index == (parent.getChildNodes().count - 1)
+            if let parent = element.parent(), !(parent is Document), element !== root {
+                return (try element.nextElementSibling()) == nil
             }
             return false
         }

--- a/Tests/SwiftSoupTests/CssTest.swift
+++ b/Tests/SwiftSoupTests/CssTest.swift
@@ -51,8 +51,36 @@ class CssTest: XCTestCase {
 	}
 
 	func testLastChild() throws {
-        try! check(html.select("#pseudo :last-child"), "10")
-        try! check(html.select("html:last-child"))
+		try check(html.select("#pseudo :last-child"), "10")
+		try check(html.select("html:last-child"))
+		
+		let html = """
+		<div class="info-wrap">
+			<div>
+				<p>Author (s): </p>
+				<p>
+					<a href="###">John Doe</a>
+				</p>
+			</div>
+		</div>
+		"""
+		
+		let doc: Document = try SwiftSoup.parse(html)
+		let elementArray = try doc.select("div.info-wrap > div")
+		XCTAssertEqual(elementArray.count, 1)
+		
+		let div = elementArray.first()!
+		let label = try div.select("> p:first-child").text()
+		XCTAssertEqual(label, "Author (s):")
+		
+		let value = try div.select("> p:last-child").text()
+		XCTAssertEqual(value, "John Doe")
+		
+		// Should match the second `p` and its `a` since the later is also a last child. The `div` itself should not get matched.
+		let matched = try div.select(":last-child")
+		XCTAssertEqual(matched.count, 2)
+		XCTAssertEqual(matched.first()?.tagName(), "p")
+		XCTAssertEqual(matched.last?.tagName(), "a")
 	}
 
 	func testNthChild_simple() throws {


### PR DESCRIPTION
Resolves #310 . The evaluator was mixing element and node indices. Simply check whether the element has a next element sibling. Also don't match the root node.