### PR TITLE
Add explicit support for tvOS 13+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftSoup",
-    platforms: [.macOS(.v10_15), .iOS(.v13), .watchOS(.v6)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "SwiftSoup", targets: ["SwiftSoup"])
     ],


### PR DESCRIPTION
Due to not specified explicitly in `Package.swift` SwiftPM defaults to minimal tvOS version – 12. This leads to being unable to build project for tvOS because minimal required version is 13.