### PR TITLE
compile fix for freebsd

### DIFF
--- a/Sources/Mutex.swift
+++ b/Sources/Mutex.swift
@@ -55,6 +55,25 @@ final class Mutex: NSLocking, @unchecked Sendable {
     func unlock() {
         LeaveCriticalSection(&mutex)
     }
+#elseif os(FreeBSD)
+    private var mutex:  pthread_mutex_t? = nil
+
+    init() {
+        var attr = pthread_mutexattr_t(bitPattern: 0)
+        pthread_mutexattr_init(&attr)
+    }
+
+    deinit {
+        pthread_mutex_destroy(&mutex)
+    }
+
+    func lock() {
+        pthread_mutex_lock(&mutex)
+    }
+
+    func unlock() {
+        pthread_mutex_unlock(&mutex)
+    }
     
 #else
     private var mutex = pthread_mutex_t()


### PR DESCRIPTION
the following changeset fixes compilation for FreeBSD

tested on FreeBSD 14.3 using the [following](https://forums.swift.org/t/swift-on-freebsd-preview/83064) build of Swift.

Sample (elided for length) run:

```
 $ uname -a
FreeBSD quincy 14.3-RELEASE FreeBSD 14.3-RELEASE releng/14.3-n271432-8c9ce319fef7 GENERIC amd64

$ swift -version
Swift version 6.3-dev (LLVM 7c51e5dc68daf76, Swift cc8e6fd8770ad14)
Target: x86_64-unknown-freebsd14.3
Build config: +assertions

$ swift test
Fetching https://github.com/nicklockwood/LRUCache.git from cache
Fetching https://github.com/apple/swift-atomics.git from cache
Fetched https://github.com/nicklockwood/LRUCache.git from cache (0.36s)
Fetched https://github.com/apple/swift-atomics.git from cache (0.39s)
Computing version for https://github.com/apple/swift-atomics.git
Computed https://github.com/apple/swift-atomics.git at 1.3.0 (1.79s)
Computing version for https://github.com/nicklockwood/LRUCache.git
Computed https://github.com/nicklockwood/LRUCache.git at 1.2.0 (1.33s)
Creating working copy for https://github.com/apple/swift-atomics.git
Working copy of https://github.com/apple/swift-atomics.git resolved at 1.3.0
Creating working copy for https://github.com/nicklockwood/LRUCache.git
Working copy of https://github.com/nicklockwood/LRUCache.git resolved at 1.2.0
Building for debugging...
[133/133] Linking SwiftSoupPackageTests.xctest
Build complete! (194.98s)
...
...
...
Test Suite 'debug.xctest' passed at 2025-11-12 10:36:20.151
         Executed 436 tests, with 0 failures (0 unexpected) in 3.179 (3.179) seconds
Test Suite 'All tests' passed at 2025-11-12 10:36:20.152
         Executed 436 tests, with 0 failures (0 unexpected) in 3.179 (3.179) seconds
◇ Test run started.
↳ Testing Library Version: 6.3-dev (564e4f2f33b3cc1)
↳ Target Platform: x86_64-unknown-freebsd
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
```