### PR TITLE
Fix URL resolution being applied to non-URL attributes

### DIFF
--- a/Sources/Whitelist.swift
+++ b/Sources/Whitelist.swift
@@ -564,8 +564,17 @@ import Foundation
         guard try isSafeAttribute(tagName, el, attr) else {
             return nil
         }
-        
+
         let clonedAttr = attr.clone()
+
+        // Only apply URL resolution and whitespace handling to attributes that
+        // have protocols defined (i.e., URL attributes like href, src). Applying
+        // URL resolution to non-URL attributes like `style` corrupts values
+        // containing `#` (e.g., CSS colors) by percent-encoding them to `%23`.
+        guard isURLAttribute(tagName, attr) else {
+            return clonedAttr
+        }
+
         if !preserveRelativeLinks {
             let resolved = resolveWithTrimmedURL(el, attr)
             if !resolved.isEmpty {
@@ -582,6 +591,16 @@ import Foundation
         }
 
         return clonedAttr
+    }
+
+    /// Check if the attribute has protocols defined in the whitelist, indicating it's a URL attribute.
+    private func isURLAttribute(_ tagName: String, _ attr: Attribute) -> Bool {
+        let tag = TagName.valueOf(tagName)
+        let key = AttributeKey.valueOf(attr.getKey())
+        if protocols[tag]?[key] != nil {
+            return true
+        }
+        return tagName != ":all" && isURLAttribute(":all", attr)
     }
 
     /// Resolve a URL attribute, trimming whitespace before resolution when a base URI

--- a/Tests/SwiftSoupTests/CleanerTest.swift
+++ b/Tests/SwiftSoupTests/CleanerTest.swift
@@ -490,4 +490,44 @@ class CleanerTest: XCTestCase {
         )
     }
 
+    // MARK: - Non-URL attribute preservation
+
+    func testDoesNotApplyURLResolutionToNonURLAttributes() throws {
+        // The `style` attribute is not a URL attribute — it should not be
+        // passed through URL resolution, which would percent-encode the `#`
+        // in CSS color values like `#E9EAEB`.
+        let html = #"<div style="background-color:#E9EAEB;">content</div>"#
+        let whitelist = try Whitelist()
+            .addTags("div")
+            .addAttributes("div", "style")
+        let cleaned = try SwiftSoup.clean(html, whitelist)
+        XCTAssertTrue(cleaned?.contains("background-color:#E9EAEB") == true,
+                      "Expected # to be preserved in style attribute, got: \(cleaned ?? "nil")")
+    }
+
+    func testDoesNotApplyURLResolutionToClassAttribute() throws {
+        let html = #"<div class="foo#bar">content</div>"#
+        let whitelist = try Whitelist()
+            .addTags("div")
+            .addAttributes("div", "class")
+        let cleaned = try SwiftSoup.clean(html, whitelist)
+        XCTAssertTrue(cleaned?.contains(#"class="foo#bar""#) == true,
+                      "Expected # to be preserved in class attribute, got: \(cleaned ?? "nil")")
+    }
+
+    func testStillResolvesURLAttributes() throws {
+        // URL attributes with protocols defined should still be resolved,
+        // while non-URL attributes on the same element are left alone.
+        let html = #"<a href="http://example.com" style="color:#333;">link</a>"#
+        let whitelist = try Whitelist()
+            .addTags("a")
+            .addAttributes("a", "href", "style")
+            .addProtocols("a", "href", "http", "https")
+        let cleaned = try SwiftSoup.clean(html, whitelist)
+        XCTAssertTrue(cleaned?.contains("http://example.com") == true,
+                      "Expected href to be preserved, got: \(cleaned ?? "nil")")
+        XCTAssertTrue(cleaned?.contains("color:#333") == true,
+                      "Expected # to be preserved in style attribute, got: \(cleaned ?? "nil")")
+    }
+
 }


### PR DESCRIPTION
## Problem

`safeAttribute` (introduced in #369) applies URL resolution to **all** attribute values, not just URL attributes. Foundation's URL resolver treats `#` in non-URL values as a fragment identifier and percent-encodes it — for example, `background-color:#E9EAEB` in a `style` attribute becomes `background-color:%23E9EAEB`, corrupting CSS color values throughout sanitized HTML.

This affects any attribute value containing `#` that isn't a URL attribute, such as:
- `style="background-color:#E9EAEB;"`
- `style="color:#333;"`

## Root cause

In `safeAttribute`, URL resolution via `resolveWithTrimmedURL` runs unconditionally on all safe attributes. In jsoup (which SwiftSoup is based on), URL resolution only happens inside `testValidProtocol` when protocols are defined for the attribute, and the `Cleaner` copies the original attribute directly otherwise. There is no equivalent of `safeAttribute` that modifies values post-validation.

## Fix

Add an `isURLAttribute` check that gates URL resolution and whitespace mode handling to only run on attributes that have protocols defined in the whitelist. Attributes without protocol definitions (like `style`, `class`, etc.) are returned with their original values unmodified.

This aligns SwiftSoup's behavior with jsoup's implicit convention: calling `addProtocols` for an attribute signals that it's a URL attribute; all other attributes pass through unchanged.

## Tests

Three new tests in `CleanerTest`:
- `testDoesNotApplyURLResolutionToNonURLAttributes` — verifies `#` in `style` attribute is preserved
- `testDoesNotApplyURLResolutionToClassAttribute` — verifies `#` in `class` attribute is preserved
- `testStillResolvesURLAttributes` — verifies URL attributes with protocols are still resolved while non-URL attributes on the same element are left alone