### PR TITLE
Fix CharacterReader bounds safety for truncated HTML

### DIFF
--- a/Sources/CharacterReader.swift
+++ b/Sources/CharacterReader.swift
@@ -361,12 +361,12 @@ public final class CharacterReader {
                 return slice(start, pos)
             }
 
-            pos += charLen
+            pos = min(pos + charLen, end)
         }
-        
+
         return slice(start, pos)
     }
-    
+
     private func unicodeScalar(at index: String.UTF8View.Index, in utf8View: String.UTF8View) -> UnicodeScalar? {
         var iterator = utf8View[index...].makeIterator()
         var utf8Decoder = UTF8()
@@ -696,7 +696,7 @@ public final class CharacterReader {
     }
 
     public func matchesAny(_ seq: ParsingStrings) -> Bool {
-        guard input.count > pos
+        guard pos < end
         else { return false }
 
         if let byte = currentByte(), byte < Self.asciiUpperLimitByte {
@@ -728,8 +728,7 @@ public final class CharacterReader {
     }
 
     public func matchesAny(_ seq: [[UInt8]]) -> Bool {
-        guard pos < end,
-              input.count > pos
+        guard pos < end
         else { return false }
 
         if let byte = currentByte() {
@@ -779,8 +778,7 @@ public final class CharacterReader {
     }
     
     public func matchesDigit() -> Bool {
-        guard pos < end,
-              input.count > pos
+        guard pos < end
         else { return false }
 
         let firstByte = input[pos]
@@ -873,8 +871,8 @@ public final class CharacterReader {
         if seq.count == 1 {
             return input[pos...].firstIndex(of: transformedFirst) != nil
         }
+        guard seq.count <= end - pos else { return false }
         let lastStart = end - seq.count
-        if pos > lastStart { return false }
         var i = pos
         while i <= lastStart {
             if input[i] == transformedFirst {
@@ -911,8 +909,8 @@ public final class CharacterReader {
         if totalCount == 1 {
             return input[pos...].firstIndex(of: transformedFirst) != nil
         }
+        guard totalCount <= end - pos else { return false }
         let lastStart = end - totalCount
-        if pos > lastStart { return false }
         var i = pos
         let prefixCount = prefix.count
         while i <= lastStart {
@@ -984,8 +982,8 @@ public final class CharacterReader {
         if targetCount == 1 {
             return input[pos...].firstIndex(of: targetUtf8[0])
         }
+        guard targetCount <= end - pos else { return nil }
         let lastStart = end - targetCount
-        if pos > lastStart { return nil }
 
         let first = targetUtf8[0]
         if targetCount == 2 {

--- a/Tests/SwiftSoupTests/HtmlParserTest.swift
+++ b/Tests/SwiftSoupTests/HtmlParserTest.swift
@@ -692,4 +692,62 @@ class HtmlParserTest: XCTestCase {
         let doc = try SwiftSoup.parse(html)
         XCTAssertEqual(try doc.body()?.text(), "")
     }
+
+    // https://github.com/scinfu/SwiftSoup/issues/344
+    // https://github.com/scinfu/SwiftSoup/issues/189
+    func testParse_DoesNotCrashOnTruncatedHtml() throws {
+        let html = """
+        <figure class="img-border featured-image"><img width="1600" height="800" src="https://9to5mac.com/wp-content/uploads/sites/6/2025/08/crash-detection.jpg?quality=82&amp
+        """
+        let doc = try SwiftSoup.parse(html)
+        XCTAssertNotNil(doc.body())
+    }
+
+    func testParse_DoesNotCrashOnTruncatedHtmlVariants() throws {
+        // Truncated at various points in attribute values, entities, tags
+        let truncatedHtmls = [
+            "<a href=\"",
+            "<a href=\"&",
+            "<a href=\"&amp",
+            "<a href=\"&amp;",
+            "<a href='test&amp",
+            "<div class=",
+            "<div class=\"test",
+            "<!DOCTYPE",
+            "<!DOCTYPE html",
+            "<!-- comment",
+            "<script>var x = ",
+            "<style>.foo {",
+            "<img src=\"data:image/png;base64,",
+            "<a href=\"https://example.com?a=1&",
+            "<a href=\"https://example.com?a=1&amp",
+            "<a href=\"https://example.com?a=1&amp;b=2&",
+            "<p>Hello \u{C3}",  // truncated 2-byte UTF-8 (first byte of ã)
+            "<p>Hello \u{E2}\u{80}",  // truncated 3-byte UTF-8 (first 2 bytes of —)
+            "<p>test</p><img src=\"foo&",
+            "<table><tr><td>cell&amp",
+            "<",
+            "< ",
+            "</",
+            "<a",
+            "<a ",
+            "<a h",
+            "<a hr",
+            "<a hre",
+            "<a href",
+            "<a href=",
+            "<a href='",
+            "&",
+            "&amp",
+            "&#",
+            "&#x",
+            "&#x4",
+            "&#65",
+        ]
+
+        for (i, html) in truncatedHtmls.enumerated() {
+            let doc = try SwiftSoup.parse(html)
+            XCTAssertNotNil(doc.body(), "Failed on variant \(i): \(html)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #189, #344 — `Fatal error: Index out of range` crashes when parsing truncated or malformed HTML.

- **Consistent bounds guard**: Use `pos < end` in `matchesAny`/`matchesDigit` guards instead of `input.count > pos`. While currently equivalent, `pos < end` is the correct semantic bound used everywhere else in the file and is future-proof if `end` ever diverges from `input.count`.
- **Integer underflow prevention**: Guard `nextIndexOf` and `containsAsciiTransformed` against integer underflow when the target sequence is longer than remaining input (`end - targetCount` would wrap negative).
- **Pos overshoot fix**: Clamp `pos` advancement in `consumeToAnySlice` multi-byte path to prevent `pos` from overshooting `end` by up to 3 bytes.

## Test plan

- Added test for the exact HTML from #344 (`<figure>` with truncated `&amp` entity in `src` attribute)
- Added 35 additional truncated HTML variants covering: partial entities, partial attributes, partial tags, truncated UTF-8 sequences, partial doctypes, partial comments
- All 597 tests pass