### PR TITLE
Normalize &nbsp; output for Whitelist.none()

### DIFF
--- a/Sources/SwiftSoup.swift
+++ b/Sources/SwiftSoup.swift
@@ -248,7 +248,8 @@ import Foundation
 		let dirty: Document = try parseBodyFragment(bodyHtml, baseUri)
 		let cleaner: Cleaner = Cleaner(whitelist)
 		let clean: Document = try cleaner.clean(dirty)
-		return try clean.body()?.html()
+        let html = try clean.body()?.html()
+        return normalizeTextOnlyNbsp(html, whitelist: whitelist)
 	}
 
 	/**
@@ -282,8 +283,23 @@ import Foundation
 		let cleaner: Cleaner = Cleaner(whitelist)
 		let clean: Document = try cleaner.clean(dirty)
 		clean.outputSettings(outputSettings)
-		return try clean.body()?.html()
+        let html = try clean.body()?.html()
+        return normalizeTextOnlyNbsp(html, whitelist: whitelist)
 	}
+
+    private func normalizeTextOnlyNbsp(_ html: String?, whitelist: Whitelist) -> String? {
+        guard whitelist.isTextOnly(), let html else {
+            return html
+        }
+
+        var normalized = html.replacingOccurrences(of: "&nbsp;", with: " ")
+        normalized = normalized.replacingOccurrences(
+            of: "&#(?:160|x[aA]0);",
+            with: " ",
+            options: .regularExpression
+        )
+        return normalized
+    }
 
 	/**
 	 Test if the input HTML has only tags and attributes allowed by the Whitelist. Useful for form validation. The input HTML should

--- a/Sources/Whitelist.swift
+++ b/Sources/Whitelist.swift
@@ -663,6 +663,10 @@ import Foundation
         return attrs
     }
 
+    func isTextOnly() -> Bool {
+        tagNames.isEmpty
+    }
+
 }
 
 // named types for config. All just hold strings, but here for my sanity.

--- a/Tests/SwiftSoupTests/CleanerTest.swift
+++ b/Tests/SwiftSoupTests/CleanerTest.swift
@@ -251,6 +251,25 @@ class CleanerTest: XCTestCase {
         XCTAssertEqual("привет", try SwiftSoup.clean("привет", Whitelist.none()))
     }
 
+    func testWhitelistNoneNormalizesNbspEntityToSpace() throws {
+        XCTAssertEqual(" ", try SwiftSoup.clean("&nbsp;", Whitelist.none()))
+    }
+
+    func testWhitelistNoneNormalizesNumericNbspEntitiesToSpaces() throws {
+        let html = "Hello&nbsp;there&#160;friend"
+        XCTAssertEqual("Hello there friend", try SwiftSoup.clean(html, Whitelist.none()))
+    }
+
+    func testWhitelistNoneStillEscapesOtherEntities() throws {
+        let html = "&amp;&lt;&gt;"
+        XCTAssertEqual("&amp;&lt;&gt;", try SwiftSoup.clean(html, Whitelist.none()))
+    }
+
+    func testNonEmptyWhitelistStillPreservesNbspEntity() throws {
+        let html = "&nbsp;<b>Bold</b>"
+        XCTAssertEqual("&nbsp;<b>Bold</b>", TextUtil.stripNewlines(try SwiftSoup.clean(html, Whitelist.simpleText())!))
+    }
+
     func testScriptTagInWhiteList() throws {
         let whitelist: Whitelist = try Whitelist.relaxed()
         try whitelist.addTags( "script" )


### PR DESCRIPTION
Closes #227

## Summary
- reproduce the current `Whitelist.none()` behavior where `SwiftSoup.clean("&nbsp;", Whitelist.none())` returns `&nbsp;`
- normalize serialized non-breaking-space entities back to regular spaces only for text-only cleaning (`Whitelist.none()`)
- keep existing entity escaping behavior unchanged for other entities and for non-empty whitelists

## Tests
- add regression coverage for `&nbsp;` and `&#160;` with `Whitelist.none()`
- verify other entities like `&amp;`, `&lt;`, and `&gt;` still remain escaped
- verify non-empty whitelists still preserve `&nbsp;` serialization
- `swift test --filter CleanerTest`
- `swift test`

## Notes
- this change is intentionally narrow: it only post-processes the final cleaned fragment when the whitelist allows text nodes only, so broader serializer/entity behavior is unchanged