### PR TITLE
Escape cssSelector output for class and id selectors

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -1056,14 +1056,14 @@ open class Element: Node {
     public func cssSelector() throws -> String {
         let elementId = id()
         if !elementId.isEmpty {
-            return "#" + elementId
+            return "#" + Element.cssEscapeIdentifier(elementId)
         }
         
         // Translate HTML namespace ns:tag to CSS namespace syntax ns|tag
         let tagName: String = self.tagName().replacingOccurrences(of: ":", with: "|")
         var selector: String = tagName
         let cl = try classNames()
-        let classes: String = cl.joined(separator: ".")
+        let classes: String = cl.map(Element.cssEscapeIdentifier).joined(separator: ".")
         if !classes.isEmpty {
             selector.append(".")
             selector.append(classes)
@@ -1080,6 +1080,22 @@ open class Element: Node {
         }
         
         return try parent()!.cssSelector() + (selector)
+    }
+
+    private static func cssEscapeIdentifier(_ identifier: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(identifier.count)
+
+        for character in identifier {
+            if Character.isLetterOrDigit(character) || character == "-" || character == "_" {
+                escaped.append(character)
+            } else {
+                escaped.append("\\")
+                escaped.append(character)
+            }
+        }
+
+        return escaped
     }
     
     /**

--- a/Sources/QueryParser.swift
+++ b/Sources/QueryParser.swift
@@ -163,7 +163,12 @@ public class QueryParser {
     private func consumeSubQuery() -> String {
         var sq = ""
         while (!tq.isEmpty()) {
-            if (tq.matches("(")) {
+            if tq.matchesCS("\\") {
+                sq.append(tq.consume())
+                if !tq.isEmpty() {
+                    sq.append(tq.consume())
+                }
+            } else if (tq.matches("(")) {
                 sq.append("(")
                 sq.append(tq.chompBalanced("(", ")"))
                 sq.append(")")

--- a/Sources/TokenQueue.swift
+++ b/Sources/TokenQueue.swift
@@ -415,12 +415,24 @@ open class TokenQueue {
      - returns: identifier
      */
     open func consumeCssIdentifier() -> String {
-        let start = pos
-        while (!isEmpty() && (matchesWord() || matchesAny("-", "_"))) {
-            pos+=1
+        let accum = StringBuilder()
+        while !isEmpty() {
+            let c = queue.charAt(pos)
+            if c == TokenQueue.ESC {
+                pos += 1
+                if !isEmpty() {
+                    accum.append(queue.charAt(pos))
+                    pos += 1
+                }
+            } else if Character.isLetterOrDigit(c) || c == "-" || c == "_" {
+                accum.append(c)
+                pos += 1
+            } else {
+                break
+            }
         }
 
-        return queue.substring(start, pos - start)
+        return accum.toString()
     }
 
     /**

--- a/Tests/SwiftSoupTests/ElementTest.swift
+++ b/Tests/SwiftSoupTests/ElementTest.swift
@@ -1184,6 +1184,25 @@ class ElementTest: XCTestCase {
 		XCTAssertTrue(try divC == doc.select(divC.cssSelector()).first())
 	}
 
+    func testCssPathEscapesSpecialCharactersInClassNames() throws {
+        let html = #"<div class="Fz(xs) Fw(b)"><div>149.64</div></div>"#
+        let doc = try SwiftSoup.parse(html)
+        let element = try doc.getElementsContainingOwnText("149.64").first()
+
+        XCTAssertNotNil(element)
+        XCTAssertEqual(#"html > body > div.Fz\(xs\).Fw\(b\) > div"#, try element?.cssSelector())
+        XCTAssertTrue(try element == doc.select(element?.cssSelector() ?? "").first())
+        XCTAssertEqual("149.64", try doc.select(#".Fw\(b\) > div"#).text())
+    }
+
+    func testCssPathEscapesSpecialCharactersInId() throws {
+        let doc = try SwiftSoup.parse(#"<div id="quote:body/main">A</div>"#)
+        let element = try doc.select("div").first()
+
+        XCTAssertEqual(#"#quote\:body\/main"#, try element?.cssSelector())
+        XCTAssertTrue(try element == doc.select(element?.cssSelector() ?? "").first())
+    }
+
 	func testClassNames() throws {
 		let doc: Document = try SwiftSoup.parse("<div class=\"c1 c2\">C</div>")
 		let div: Element = try doc.select("div").get(0)


### PR DESCRIPTION
Closes #222

## Summary
- reproduce the `cssSelector()` failure for class names containing reserved CSS characters such as parentheses
- escape generated CSS identifiers for class names and ids in `Element.cssSelector()`
- teach selector parsing to consume backslash-escaped CSS identifiers so generated selectors round-trip through `select(...)`
- preserve escaped delimiter characters while splitting subqueries in `QueryParser`

## Tests
- add regression coverage for `cssSelector()` on class names like `Fz(xs)` and `Fw(b)`
- verify escaped selectors can be fed back into `select(...)` and still resolve the original element
- add id escaping coverage for selectors containing characters like `:` and `/`
- `swift test --filter ElementTest`
- `swift test`

## Notes
- this is intentionally separate from the sanitizer PRs because it changes selector generation/parsing behavior, not cleaning behavior