### PR TITLE
Add explicit XML parse convenience APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,31 @@ print(try document.title()) // Output: Example
 ```
 
 ---
+### Parse an XML Document
+
+Use the XML parser when working with feeds, OPML, or other non-HTML documents. The default `SwiftSoup.parse(...)`
+entry points apply HTML5 parsing rules, so tags like `<link>` and `<img>` will be treated as HTML tags instead of
+generic XML elements.
+
+```swift
+import SwiftSoup
+
+let xml = """
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <link>I'm link</link>
+    <img>I'm img</img>
+  </body>
+</opml>
+"""
+
+let document = try SwiftSoup.parseXML(xml)
+print(try document.select("link").first()?.text()) // Output: I'm link
+print(try document.select("body > img").first()?.text()) // Output: I'm img
+```
+
+---
 ## Profiling
 
 SwiftSoup includes a lightweight profiler (gated by a compile-time flag) and a small CLI harness for parsing benchmarks.

--- a/Sources/SwiftSoup.swift
+++ b/Sources/SwiftSoup.swift
@@ -9,6 +9,7 @@ import Foundation
 
 	/**
 	 Parse HTML into a Document. The parser will make a sensible, balanced document tree out of any HTML.
+     For XML input, use ``parseXML(_:_:)`` or ``parse(_:_:_:)`` with ``Parser/xmlParser()``.
 	 
 	 - parameter html:    HTML to parse
 	 - parameter baseUri: The URL where the HTML was retrieved from. Used to resolve relative URLs to absolute URLs, that occur
@@ -21,6 +22,7 @@ import Foundation
 
 	/**
 	 Parse Data into a Document. The parser will make a sensible, balanced document tree out of any HTML.
+     For XML input, use ``parseXML(_:_:)`` or ``parse(_:_:_:)`` with ``Parser/xmlParser()``.
 	 
 	 - parameter data: Data to parse
 	 - parameter baseUri: The URL where the HTML was retrieved from. Used to resolve relative URLs to absolute URLs, that occur
@@ -84,6 +86,7 @@ import Foundation
 	/**
 	 Parse HTML into a Document. As no base URI is specified, absolute URL detection relies on the HTML including a
 	 `<base href>` tag.
+     For XML input, use ``parseXML(_:)``.
 	 
 	 - parameter html: HTML to parse
 	 - returns: sane HTML
@@ -96,6 +99,7 @@ import Foundation
     /**
 	 Parse Data into a Document. As no base URI is specified, absolute URL detection relies on the HTML including a
 	 `<base href>` tag.
+     For XML input, use ``parseXML(_:)``.
 	 
 	 - parameter data: Data to parse
 	 - returns: sane HTML
@@ -104,6 +108,51 @@ import Foundation
 	public func parse(_ data: Data) throws -> Document {
 		return try Parser.parse(data, "")
 	}
+
+    /**
+     Parse XML into a Document using the XML parser. Unlike ``parse(_:_:)``, this does not apply HTML5 tree-building
+     rules or normalize known HTML tags like `<link>` or `<img>`.
+
+     - parameter xml: XML to parse
+     - parameter baseUri: The URL where the XML was retrieved from. Used to resolve relative URLs to absolute URLs.
+     - returns: parsed XML document
+     */
+    public func parseXML(_ xml: String, _ baseUri: String) throws -> Document {
+        return try parse(xml, baseUri, Parser.xmlParser())
+    }
+
+    /**
+     Parse XML into a Document using the XML parser. As no base URI is specified, absolute URL detection relies on the
+     XML including a suitable base URI in its own data.
+
+     - parameter xml: XML to parse
+     - returns: parsed XML document
+     */
+    public func parseXML(_ xml: String) throws -> Document {
+        return try parseXML(xml, "")
+    }
+
+    /**
+     Parse XML data into a Document using the XML parser.
+
+     - parameter data: XML data to parse
+     - parameter baseUri: The URL where the XML was retrieved from. Used to resolve relative URLs to absolute URLs.
+     - returns: parsed XML document
+     */
+    public func parseXML(_ data: Data, _ baseUri: String) throws -> Document {
+        return try Parser.xmlParser().parseInput([UInt8](data), baseUri)
+    }
+
+    /**
+     Parse XML data into a Document using the XML parser. As no base URI is specified, absolute URL detection relies on
+     the XML including a suitable base URI in its own data.
+
+     - parameter data: XML data to parse
+     - returns: parsed XML document
+     */
+    public func parseXML(_ data: Data) throws -> Document {
+        return try parseXML(data, "")
+    }
 
 
 

--- a/Tests/SwiftSoupTests/XmlTreeBuilderTest.swift
+++ b/Tests/SwiftSoupTests/XmlTreeBuilderTest.swift
@@ -9,6 +9,29 @@ import XCTest
 import SwiftSoup
 
 class XmlTreeBuilderTest: XCTestCase {
+    private let issue309Xml = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <opml version="1.0">
+      <head>
+        <title>Default</title>
+      </head>
+      <body>
+        <link>I'm link</link>
+        <a>I'm a</a>
+        <image>I'm image</image>
+        <img>I'm img</img>
+        <outline text="News" title="News">
+          <outline type="rss" text="BBC NEWS" title="BBC NEWS" xmlUrl="https://feeds.bbci.co.uk/news/world/rss.xml" htmlUrl="https://feeds.bbci.co.uk"/>
+          <outline type="rss" text="CBS NEWS" title="CBS NEWS" xmlUrl="https://www.cbsnews.com/latest/rss/main" htmlUrl="https://www.cbsnews.com/"/>
+          <outline type="rss" text="ESPN" title="ESPN" xmlUrl="https://www.espn.com/espn/rss/news" htmlUrl="https://www.espn.com/"/>
+        </outline>
+        <outline text="Designer" title="Technology">
+          <outline type="rss" text="Daring Fireball" title="Daring Fireball" xmlUrl="https://daringfireball.net/feeds/json" htmlUrl="https://daringfireball.net"/>
+          <outline type="rss" text="Colossal" title="Colossal" xmlUrl="https://www.thisiscolossal.com/feed" htmlUrl="https://www.thisiscolossal.com/"/>
+        </outline>
+      </body>
+    </opml>
+    """
 
 	func testSimpleXmlParse() throws {
 		let xml = "<doc id=2 href='/bar'>Foo <br /><link>One</link><link>Two</link></doc>"
@@ -39,6 +62,26 @@ class XmlTreeBuilderTest: XCTestCase {
 		let doc = try SwiftSoup.parse(xml, "http://foo.com/", Parser.xmlParser())
 		try XCTAssertEqual("<doc><val>One<val>Two</val>Three</val></doc>", TextUtil.stripNewlines(doc.html()))
 	}
+
+    func testIssue309ParseXmlConvenienceParsesXmlSpecificTags() throws {
+        let doc = try SwiftSoup.parseXML(issue309Xml)
+
+        XCTAssertEqual("Default", try doc.select("title").first()?.text())
+        XCTAssertEqual("I'm link", try doc.select("link").first()?.text())
+        XCTAssertEqual("I'm a", try doc.select("a").first()?.text())
+        XCTAssertEqual("I'm image", try doc.select("image").first()?.text())
+        XCTAssertEqual("I'm img", try doc.select("img").first()?.text())
+        XCTAssertEqual(7, try doc.select("body outline").count)
+        XCTAssertEqual(2, try doc.select("body > outline").count)
+        XCTAssertEqual(OutputSettings.Syntax.xml, doc.outputSettings().syntax())
+    }
+
+    func testIssue309ParseXmlConvenienceMatchesExplicitXmlParser() throws {
+        let convenienceDoc = try SwiftSoup.parseXML(issue309Xml)
+        let explicitDoc = try SwiftSoup.parse(issue309Xml, "", Parser.xmlParser())
+
+        XCTAssertEqual(try explicitDoc.outerHtml(), try convenienceDoc.outerHtml())
+    }
 
 	//TODO: nabil
 	//	public void testSupplyParserToConnection() throws IOException {


### PR DESCRIPTION
Fixes #309.

## Summary
- reproduce the issue sample from the comments and screenshots
- add `SwiftSoup.parseXML(...)` convenience entry points for `String` and `Data`
- document that `SwiftSoup.parse(...)` uses the HTML parser and that XML documents should use the XML parser path
- add regression tests covering the reported OPML/XML case

## Why this approach
The reproduced behavior comes from calling the default HTML parser on XML input. That parser intentionally applies HTML5 tag semantics, so tags like `<link>` and `<img>` are normalized as HTML tags and selectors like `body > outline` stop matching the XML structure the reporter expected.

The underlying XML parser already handles the sample correctly when called with `Parser.xmlParser()`. This PR keeps the default HTML parsing behavior unchanged and instead makes the XML path easier to discover and use through explicit `parseXML(...)` helpers and README guidance.

## Reproduction covered by tests
Using the OPML sample from #309, the new regression test verifies that XML parsing returns:
- `link.text() == "I'm link"`
- `img.text() == "I'm img"`
- `image.text() == "I'm image"`
- `select("body outline").count == 7`
- `select("body > outline").count == 2`

## Verification
- `swift test --filter XmlTreeBuilderTest`
- `swift test`