### PR TITLE
Add crossorigin to boolean attributes list

### DIFF
--- a/Sources/Attribute.swift
+++ b/Sources/Attribute.swift
@@ -11,7 +11,7 @@ open class Attribute {
     /// The element type of a dictionary: a tuple containing an individual
     /// key-value pair.
     static let booleanAttributes = ParsingStrings([
-        "allowfullscreen", "async", "autofocus", "checked", "compact", "controls", "declare", "default", "defer",
+        "allowfullscreen", "async", "autofocus", "checked", "compact", "controls", "crossorigin", "declare", "default", "defer",
         "disabled", "formnovalidate", "hidden", "inert", "ismap", "itemscope", "multiple", "muted", "nohref",
         "noresize", "noshade", "novalidate", "nowrap", "open", "readonly", "required", "reversed", "seamless",
         "selected", "sortable", "truespeed", "typemustmatch"

--- a/Tests/SwiftSoupTests/AttributeTest.swift
+++ b/Tests/SwiftSoupTests/AttributeTest.swift
@@ -59,4 +59,46 @@ class AttributeTest: XCTestCase {
         attr.html(accum: sb, out: out)
         XCTAssertEqual("disabled", sb.toString())
     }
+
+    func testCrossoriginWithoutValueCollapsesInOutput() throws {
+        // <script crossorigin> is parsed as a BooleanAttribute and should round-trip without =""
+        let html = "<script crossorigin src=\"app.js\"></script>"
+        let doc = try SwiftSoup.parse(html)
+        let script = try doc.select("script").first()!
+
+        XCTAssertTrue(try script.hasAttr("crossorigin"))
+        let output = try script.outerHtml()
+        XCTAssertTrue(output.contains("crossorigin"))
+        XCTAssertFalse(output.contains("crossorigin=\"\""))
+    }
+
+    func testCrossoriginEmptyValueCollapsesInOutput() throws {
+        // <script crossorigin=""> should also collapse to <script crossorigin> because
+        // crossorigin is in the boolean attributes list
+        let html = "<script crossorigin=\"\" src=\"app.js\"></script>"
+        let doc = try SwiftSoup.parse(html)
+        let script = try doc.select("script").first()!
+
+        let output = try script.outerHtml()
+        XCTAssertTrue(output.contains("crossorigin"))
+        XCTAssertFalse(output.contains("crossorigin=\"\""))
+    }
+
+    func testCrossoriginWithValuePreservesValue() throws {
+        let html = "<script crossorigin=\"use-credentials\" src=\"app.js\"></script>"
+        let doc = try SwiftSoup.parse(html)
+        let script = try doc.select("script").first()!
+
+        XCTAssertEqual("use-credentials", try script.attr("crossorigin"))
+    }
+
+    func testCrossoriginSetProgrammaticallyCollapsesWhenEmpty() throws {
+        let doc = try SwiftSoup.parse("<script src=\"app.js\"></script>")
+        let script = try doc.select("script").first()!
+        try script.attr("crossorigin", "")
+
+        let output = try script.outerHtml()
+        XCTAssertTrue(output.contains("crossorigin"))
+        XCTAssertFalse(output.contains("crossorigin=\"\""))
+    }
 }


### PR DESCRIPTION
Fixes #280.

## Summary
Adds `crossorigin` to the boolean attributes list in `Attribute.swift`.

Per the [HTML spec on CORS settings attributes](https://html.spec.whatwg.org/#cors-settings-attributes), `crossorigin` allows the empty string to be treated as `anonymous`. This means `<script crossorigin>` is equivalent to `<script crossorigin="">`, making it behave like a boolean attribute for output purposes.

**Note:** jsoup does not currently include `crossorigin` in its boolean list, but the HTML spec semantics support it — the empty value and the valueless form are equivalent.

## What the fix actually changes
- Parsing `<script crossorigin>` (no value) already worked — the parser creates a `BooleanAttribute` which always collapses in output
- Parsing `<script crossorigin="">` (empty value) creates a regular `Attribute` — this is where the `booleanAttributes` list matters for collapsing the empty value
- Setting the attribute programmatically via `attr("crossorigin", "")` also benefits from this fix

## Changes
- **`Attribute.swift`** — add `"crossorigin"` to `booleanAttributes` (alphabetically between `"controls"` and `"declare"`)
- **`AttributeTest.swift`** — add 4 tests covering all scenarios

## Test plan
- [x] `<script crossorigin>` round-trips without `=""` (already worked, covered for regression)
- [x] `<script crossorigin="">` collapses to `crossorigin` in output (**this is the fix**)
- [x] `<script crossorigin="use-credentials">` preserves the explicit value
- [x] Programmatic `attr("crossorigin", "")` collapses in output (**this is the fix**)
- [x] 2 of 4 tests fail without the fix, confirming the change is necessary
- [x] Full test suite passes (618 tests, 0 failures)