### PR TITLE
Fix compound attribute selector regression

### DIFF
--- a/Sources/CssSelector.swift
+++ b/Sources/CssSelector.swift
@@ -899,7 +899,24 @@ open class CssSelector {
         }
         
         if let open = trimmed.firstIndex(of: "[") {
-            guard let close = trimmed.lastIndex(of: "]"), close == trimmed.index(before: trimmed.endIndex) else {
+            // Find the matching close bracket for the first '[', skipping quoted content.
+            // This correctly bails out for compound selectors like tag[a='x'][b='y'].
+            var scanIdx = trimmed.index(after: open)
+            var inQuote: Character? = nil
+            var close: String.Index? = nil
+            while scanIdx < trimmed.endIndex {
+                let ch = trimmed[scanIdx]
+                if let q = inQuote {
+                    if ch == q { inQuote = nil }
+                } else if ch == "'" || ch == "\"" {
+                    inQuote = ch
+                } else if ch == "]" {
+                    close = scanIdx
+                    break
+                }
+                scanIdx = trimmed.index(after: scanIdx)
+            }
+            guard let close, close == trimmed.index(before: trimmed.endIndex) else {
                 return .none
             }
             let tagPart = trimmed[..<open]

--- a/Tests/SwiftSoupTests/SelectorTest.swift
+++ b/Tests/SwiftSoupTests/SelectorTest.swift
@@ -1055,4 +1055,50 @@ class SelectorTest: XCTestCase {
 		XCTAssertEqual("One", try doc.select("div[data=\"End]\"").first()?.text())
 		XCTAssertEqual("Two", try doc.select("div[data=\"[Another)]]\"").first()?.text())
 	}
+
+	// Verify compound attribute selectors work on simple HTML
+	func testCompoundAttributeSelectorSimple() throws {
+		let html = "<div id='info-id' data-type='info-data'><p>Hello</p></div>"
+		let doc = try SwiftSoup.parse(html)
+		let result = try doc.select("div[id='info-id'][data-type='info-data']")
+		XCTAssertEqual(1, result.size(), "Compound selector on simple HTML should work")
+	}
+
+	// https://github.com/scinfu/SwiftSoup/issues/390
+	func testCompoundAttributeSelectorWithSpecialBodyTags() throws {
+		let html = """
+		<!doctype html>
+		<html>
+		    <head>
+		        <title></title>
+		        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+		        </meta>
+		        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=3, minimum-scale=1, user-scalable=yes">
+		        </meta>
+		    </head>
+		    <body>
+		        <link>I'm link</link>
+		        <a>I'm a</a>
+		        <image>I'm image</image>
+
+		        <div id="info-id" data-type="info-data">
+		            <img src="cid:f269cce5-0cff-4041-81f4-d78865425c3c"/>
+		        </div>
+		    </body>
+		</html>
+		"""
+
+		let document = try SwiftSoup.parse(html)
+
+		// Single attribute selectors should work
+		let byId = try document.select("div[id='info-id']")
+		XCTAssertEqual(1, byId.size(), "Single [id] selector should match")
+
+		let byData = try document.select("div[data-type='info-data']")
+		XCTAssertEqual(1, byData.size(), "Single [data-type] selector should match")
+
+		// Compound attribute selector should also work
+		let compound = try document.select("div[id='info-id'][data-type='info-data']")
+		XCTAssertEqual(1, compound.size(), "Compound attribute selector should match one element")
+	}
 }


### PR DESCRIPTION
Fixes #390.

## Summary

Fixes a regression introduced in [144d910](https://github.com/scinfu/SwiftSoup/commit/144d910) ("various optimizations", first released in v2.12) where compound CSS attribute selectors like `div[id='info-id'][data-type='info-data']` return empty results.

**Root cause:** The `fastSimpleQueryPlan` fast path in `CssSelector.swift` uses `firstIndex(of: "[")` and `lastIndex(of: "]")` to extract the attribute portion of a selector. For compound selectors with multiple `[...]` groups (e.g. `tag[a='x'][b='y']`), this incorrectly treats everything between the first `[` and the last `]` as a single attribute expression, producing a malformed key/value pair that never matches.

For example, `div[id='info-id'][data-type='info-data']` was parsed as a single attribute with key `id` and value `info-id'][data-type='info-data` - which obviously never matches any element.

**Fix:** Replace the naive `lastIndex(of: "]")` with a quote-aware forward scan that finds the matching `]` for the first `[`. If the matched `]` is not the last character of the selector, the fast path correctly returns `.none` and the query falls through to the full `QueryParser` which handles compound selectors properly. The quote-aware scan also correctly handles edge cases like `div[data='value[with]brackets']`.

## Changes
- **`CssSelector.swift`** - replace `lastIndex(of: "]")` bracket matching in `fastSimpleQueryPlan` with a quote-aware forward scan that finds the true matching `]` for the first `[`
- **`SelectorTest.swift`** - add 2 regression tests:
  - `testCompoundAttributeSelectorSimple` - compound selector on simple HTML
  - `testCompoundAttributeSelectorWithSpecialBodyTags` - reproduces the exact issue from #390

## Test plan
- [x] `testCompoundAttributeSelectorSimple` - verifies `div[id='x'][data-type='y']` matches on simple HTML
- [x] `testCompoundAttributeSelectorWithSpecialBodyTags` - reproduces the exact HTML from #390, verifies both individual and compound selectors match
- [x] Existing `testAttributeWithBrackets` still passes (brackets inside quoted values)
- [x] All 78 selector tests pass
- [x] Full test suite passes (657 tests, 0 failures)