### PR TITLE
Make selectorResultCacheRoot weak to break Document retain cycle (#394)

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -362,7 +362,7 @@ open class Element: Node {
     @usableFromInline
     internal var selectorQueryStats: SelectorQueryStats? = nil
     @usableFromInline
-    internal var selectorResultCacheRoot: Node? = nil
+    internal weak var selectorResultCacheRoot: Node? = nil
     
     /// Cached normalized text (UTF‑8) for trim+normalize path.
     /// NOTE: Removed text cache; keep no per-node cache state here.


### PR DESCRIPTION
Fixes #394.

From my testing it appeared to be specifically the strong back-edge from each Element to the root Document.

`Element.selectorResultCacheRoot: Node?` at line 365 is set on first selector call via `getSelectorResultCacheRoot() → textMutationRoot()`, which walks up to the root Document. That reference is `internal var` (strong). Document already strongly owns the same Element via `childNodes`, so once any selector runs:

```
Document → childNodes → child Element → selectorResultCacheRoot → Document
```

The entire tree — Document, Elements, Attributes, TextNodes, and any per-Element `SelectorResultCache` / `SelectorQueryStats` — becomes unreachable from external roots but ARC can't free it. `leaks(1)` doesn't surface it; Xcode's Memory Graph flags it as a leaked allocation and labels the edge as `selectorResultCacheRoot` directly.

Marking the property `weak` worked for me and is much less invasive than swapping out the cache implementation:

```diff
 @usableFromInline
-internal var selectorResultCacheRoot: Node? = nil
+internal weak var selectorResultCacheRoot: Node? = nil
```

It's semantically correct — the cache is invalidated and rebuilt on next access via `getSelectorResultCacheRoot()` whenever the root is gone — and matches what #394 expected from pinning back to 2.11.x (cache absent → no cycle).

On an iOS browser workload (36 back/forward navigations across 5 content-rich sites — Wikipedia, arstechnica, news.ycombinator) final `phys_footprint` drops from 3.5 GB to 70 MB, and live `SwiftSoup.Element` from 1.4 M to 2.6 K. Same magnitude as #394's 4 MB/s growth report on long-running parse workloads.