### PR TITLE
Tear down child nodes iteratively to avoid deep-tree stack overflow

### DIFF
--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -158,7 +158,38 @@ open class Node: Equatable, Hashable {
         self.attributes = nil
         self.baseUri = nil
     }
-    
+
+    deinit {
+        // `childNodes` holds strong references, so the default release chain
+        // (Node.deinit -> release childNodes -> child Node.deinit -> ...) recurses
+        // once per nesting level. Deeply nested HTML overflows small thread stacks,
+        // so unwind the subtree iteratively instead.
+        tearDownChildNodesIteratively()
+    }
+
+    /// Releases the descendant subtree without recursing through `deinit`.
+    ///
+    /// Children are drained onto a work stack; a popped node held only by the
+    /// stack (`isKnownUniquelyReferenced`) is about to deinit, so its own
+    /// children are hoisted onto the stack and its `childNodes` cleared before
+    /// it is dropped - it then deinits with an empty `childNodes` and the chain
+    /// never nests. Nodes still referenced elsewhere are left fully intact, so
+    /// this is behaviourally identical to the default recursive release.
+    private func tearDownChildNodesIteratively() {
+        if childNodes.isEmpty { return }
+        var stack = childNodes
+        childNodes.removeAll(keepingCapacity: false)
+        while !stack.isEmpty {
+            var node = stack.removeLast()
+            if isKnownUniquelyReferenced(&node) && !node.childNodes.isEmpty {
+                stack.append(contentsOf: node.childNodes)
+                node.childNodes.removeAll(keepingCapacity: false)
+            }
+            // `node` leaves scope here: if it was uniquely held it deinits now,
+            // with an already-empty `childNodes`, so no recursion occurs.
+        }
+    }
+
     /**
      Get the node name of this node. Use for debugging purposes and not logic switching (for that, use instanceof).
      - returns: node name

--- a/Tests/SwiftSoupTests/StackOverflow393Test.swift
+++ b/Tests/SwiftSoupTests/StackOverflow393Test.swift
@@ -1,0 +1,70 @@
+import XCTest
+import Foundation
+@testable import SwiftSoup
+
+final class StackOverflow393Test: XCTestCase {
+
+    private func makeDeepHTML(depth: Int) -> String {
+        var s = "<html><body>"
+        for _ in 0..<depth { s += "<div>" }
+        s += "x"
+        for _ in 0..<depth { s += "</div>" }
+        s += "</body></html>"
+        return s
+    }
+
+    /// Runs `body` on a Thread with an explicitly small stack and waits for it.
+    /// Returns true if the thread finished cleanly. Before the iterative
+    /// teardown fix a stack overflow crashed the whole process (EXC_BAD_ACCESS).
+    private func runOnSmallStack(stackSize: Int, _ body: @escaping @Sendable () -> Void) -> Bool {
+        let done = DispatchSemaphore(value: 0)
+        let thread = Thread {
+            body()
+            done.signal()
+        }
+        thread.stackSize = stackSize // bytes, multiple of 4 KiB
+        thread.start()
+        return done.wait(timeout: .now() + 30) == .success
+    }
+
+    // CONTROL A: shallow tree on a small stack — must survive.
+    func testShallowOnSmallStackSurvives() {
+        let html = makeDeepHTML(depth: 50)
+        let ok = runOnSmallStack(stackSize: 512 * 1024) {
+            var doc: Document? = try? SwiftSoup.parse(html)
+            doc = nil
+            _ = doc
+        }
+        XCTAssertTrue(ok, "shallow teardown should never overflow")
+    }
+
+    // CONTROL B: deep tree on the main thread's big stack — must survive.
+    func testDeepOnMainThreadSurvives() throws {
+        let html = makeDeepHTML(depth: 12_000)
+        var doc: Document? = try SwiftSoup.parse(html)
+        doc = nil
+        _ = doc
+    }
+
+    // REGRESSION (#393): deep tree released on a small-stack thread.
+    // Before the fix this overflowed the recursive Node.deinit chain.
+    func testDeepTeardownOnSmallStackSurvives() {
+        let html = makeDeepHTML(depth: 12_000)
+        let ok = runOnSmallStack(stackSize: 512 * 1024) {
+            var doc: Document? = try? SwiftSoup.parse(html)
+            doc = nil // subtree torn down here
+            _ = doc
+        }
+        XCTAssertTrue(ok, "deep teardown overflowed the small-stack thread")
+    }
+
+    // REGRESSION (#393): same shape via Element.empty() on a uniquely-held deep subtree.
+    func testDeepEmptyOnSmallStackSurvives() {
+        let html = makeDeepHTML(depth: 12_000)
+        let ok = runOnSmallStack(stackSize: 512 * 1024) {
+            guard let doc = try? SwiftSoup.parse(html), let body = doc.body() else { return }
+            _ = body.empty()
+        }
+        XCTAssertTrue(ok, "deep Element.empty() overflowed the small-stack thread")
+    }
+}


### PR DESCRIPTION
Closes #393.

## Problem

`Node.childNodes` is a strong-reference `Array<Node>`. When a node's refcount reaches zero, the default ARC release chain is:

```
Node.deinit -> release childNodes -> child Node.deinit -> release childNodes -> ...
```

That recurses once per HTML nesting level. Real-world pages routinely exceed 10k levels of nesting, which overflows the smaller stacks of non-main threads (Swift cooperative-pool workers, GCD workers, explicit `Thread`s). The result is an `EXC_BAD_ACCESS` crash on `Document` teardown or `Element.empty()` when the work happens off the main thread. `Element.empty()` hits the same recursive release through its `childNodes.removeAll()`.

## Fix

Add a `Node.deinit` that unwinds the subtree iteratively instead of recursively:

- Children are drained onto a work stack.
- A popped node held only by the stack (`isKnownUniquelyReferenced`) is about to deinit anyway, so its own children are hoisted onto the stack and its `childNodes` cleared before it is dropped. It then deinits with an already-empty `childNodes`, so the chain never nests.
- Nodes still referenced elsewhere (e.g. handed out via `Elements`, selector caches, or held by the caller) are left fully intact.

This keeps stack depth bounded regardless of nesting depth, and is behaviourally identical to the default recursive release - it only changes the order of unwinding, not which nodes get freed. `Element.empty()` needs no change of its own: once the `deinit` hook is in place, the children it releases tear down iteratively too.

## Testing

- New `StackOverflow393Test` runs teardown on a `Thread` with a deliberately small 512 KB stack:
  - `testShallowOnSmallStackSurvives` - control: shallow tree on a small stack.
  - `testDeepOnMainThreadSurvives` - control: deep tree (12k levels) on the main thread's large stack.
  - `testDeepTeardownOnSmallStackSurvives` - regression: deep tree released on a small-stack thread. Crashed with `EXC_BAD_ACCESS` / SIGBUS before the fix.
  - `testDeepEmptyOnSmallStackSurvives` - regression: same shape via `Element.empty()` on a uniquely-held deep subtree.
- All four pass with the fix; the two regression tests hard-crashed the test process (SIGBUS) without it.
- Full existing suite: 650/650 pass, no regressions.