### PR TITLE
Drop malformed attributes instead of trapping on them (fixes #392)

### DIFF
--- a/Sources/Attributes.swift
+++ b/Sources/Attributes.swift
@@ -104,6 +104,33 @@ open class Attributes: NSCopying {
         attributes.reserveCapacity(16)
     }
 
+    /// Materializes a deferred attribute, throwing if the key fails validation (e.g. an
+    /// empty-after-trim key). Callers invoke this via `try?` and drop anything that fails,
+    /// matching jsoup — never trapping. See #392.
+    @usableFromInline
+    @inline(__always)
+    internal func makeMaterializedAttribute(keySlice: ByteSlice, value: PendingAttrValue) throws -> Attribute {
+        switch value {
+        case .none:
+            return try BooleanAttribute(keySlice: keySlice)
+        case .empty:
+            return try Attribute(keySlice: keySlice, valueSlice: ByteSlice.empty)
+        case .slice(let slice):
+            return try Attribute(keySlice: keySlice, valueSlice: slice)
+        case .slices(let slices, _):
+            guard let first = slices.first else {
+                return try Attribute(keySlice: keySlice, valueSlice: ByteSlice.empty)
+            }
+            let attribute = try Attribute(keySlice: keySlice, valueSlice: first)
+            for slice in slices.dropFirst() {
+                attribute.appendValueSlice(slice)
+            }
+            return attribute
+        case .bytes(let bytes):
+            return try Attribute(keySlice: keySlice, valueSlice: ByteSlice.fromArray(bytes))
+        }
+    }
+
     @usableFromInline
     @inline(__always)
     internal func appendPending(_ pending: PendingAttribute) {
@@ -117,29 +144,9 @@ open class Attributes: NSCopying {
             } else {
                 return
             }
-            let attribute: Attribute
-            switch pending.value {
-            case .none:
-                attribute = try! BooleanAttribute(keySlice: keySlice)
-            case .empty:
-                attribute = try! Attribute(keySlice: keySlice, valueSlice: ByteSlice.empty)
-            case .slice(let slice):
-                attribute = try! Attribute(keySlice: keySlice, valueSlice: slice)
-            case .slices(let slices, _):
-                if let first = slices.first {
-                    let attr = try! Attribute(keySlice: keySlice, valueSlice: first)
-                    if slices.count > 1 {
-                        for slice in slices.dropFirst() {
-                            attr.appendValueSlice(slice)
-                        }
-                    }
-                    attribute = attr
-                } else {
-                    attribute = try! Attribute(keySlice: keySlice, valueSlice: ByteSlice.empty)
-                }
-            case .bytes(let bytes):
-                attribute = try! Attribute(keySlice: keySlice, valueSlice: ByteSlice.fromArray(bytes))
-            }
+            // Drop malformed attributes (e.g. an empty-after-trim key) rather than
+            // trapping; jsoup does the same. See #392.
+            guard let attribute = try? makeMaterializedAttribute(keySlice: keySlice, value: pending.value) else { return }
             putMaterialized(attribute)
             return
         }
@@ -195,7 +202,6 @@ open class Attributes: NSCopying {
             } else {
                 DebugTrace.log("Attributes.ensureMaterialized: missing name")
             }
-            let attribute: Attribute
             let keySlice: ByteSlice
             if let nameBytes = pendingAttr.nameBytes {
                 keySlice = ByteSlice.fromArray(nameBytes).trim()
@@ -204,28 +210,10 @@ open class Attributes: NSCopying {
             } else {
                 continue
             }
-            switch pendingAttr.value {
-            case .none:
-                attribute = try! BooleanAttribute(keySlice: keySlice)
-            case .empty:
-                attribute = try! Attribute(keySlice: keySlice, valueSlice: ByteSlice.empty)
-            case .slice(let slice):
-                attribute = try! Attribute(keySlice: keySlice, valueSlice: slice)
-            case .slices(let slices, _):
-                if let first = slices.first {
-                    let attr = try! Attribute(keySlice: keySlice, valueSlice: first)
-                    if slices.count > 1 {
-                        for slice in slices.dropFirst() {
-                            attr.appendValueSlice(slice)
-                        }
-                    }
-                    attribute = attr
-                } else {
-                    attribute = try! Attribute(keySlice: keySlice, valueSlice: ByteSlice.empty)
-                }
-            case .bytes(let bytes):
-                attribute = try! Attribute(keySlice: keySlice, valueSlice: ByteSlice.fromArray(bytes))
-            }
+            // Drop malformed attributes (e.g. an empty-after-trim key) rather than
+            // trapping; jsoup does the same. This is the path #392 hits via
+            // getIgnoreCase during select()'s query-index rebuild.
+            guard let attribute = try? makeMaterializedAttribute(keySlice: keySlice, value: pendingAttr.value) else { continue }
             let keyForIndex = attribute.keySlice
             if Attributes.containsAsciiUppercase(keyForIndex) {
                 hasUppercaseKeys = true
@@ -751,7 +739,8 @@ open class Attributes: NSCopying {
             return
         }
         let keySlice = ByteSlice.fromArray(key).trim()
-        let attribute = try! Attribute(keySlice: keySlice, valueSlice: slice)
+        // Drop a malformed key rather than trapping; jsoup does the same. See #392.
+        guard let attribute = try? Attribute(keySlice: keySlice, valueSlice: slice) else { return }
         putMaterialized(attribute)
         ownerElement?.markSourceDirty()
     }

--- a/Tests/SwiftSoupTests/PublicEmptyAttributeKeyTest.swift
+++ b/Tests/SwiftSoupTests/PublicEmptyAttributeKeyTest.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import SwiftSoup
+
+/// Public-API regression tests for #392: a vertical tab (`0x0B`) after a quoted attribute value
+/// produces an attribute key that trims to empty during materialization. Parsing then `select`ing
+/// must drop the malformed attribute rather than trap.
+final class PublicEmptyAttributeKeyTest: XCTestCase {
+
+    /// Boolean attribute (`.none` value).
+    func testBooleanVerticalTabKeyDoesNotCrashSelect() throws {
+        let doc = try SwiftSoup.parse("<div a=\"b\"\u{0B}>hi</div>")
+        let matches = try doc.select("[name=x]")
+        XCTAssertEqual(matches.size(), 0, "Malformed empty-key attribute must be dropped, not crash")
+    }
+
+    /// Valued attribute (`.slice` value).
+    func testValuedVerticalTabKeyDoesNotCrashSelect() throws {
+        let doc = try SwiftSoup.parse("<div a=\"b\"\u{0B}=x>hi</div>")
+        let matches = try doc.select("[name=x]")
+        XCTAssertEqual(matches.size(), 0)
+    }
+
+    /// `<meta>` + the attribute-value selector from the original report.
+    func testMetaVerticalTabKeyDoesNotCrashSelect() throws {
+        let doc = try SwiftSoup.parse("<meta a=\"b\"\u{0B}=og:title>")
+        let matches = try doc.select("meta[property=og:title]")
+        XCTAssertEqual(matches.size(), 0)
+    }
+}


### PR DESCRIPTION
Fixes #392. That issue reported a `try!` crash in attribute materialization but was closed pending a reproducer — here is a minimal **public-API** one, plus a fix that removes the `try!` traps entirely.

### Reproducer (stock 2.13.x)

```swift
let doc = try SwiftSoup.parse("<div a=\"b\"\u{0B}>hi</div>")
_ = try doc.select("[name=x]")
// Attributes.swift: Fatal error: 'try!' expression unexpectedly raised an error:
//   IllegalArgumentException, Message: "String must not be empty"
```

A vertical tab (`0x0B`) immediately after a **quoted** attribute value is the trigger.

### Root cause

Attributes are parsed lazily into a deferred store and only *materialized* on first access (`size()`, `getIgnoreCase()`, the hot-attribute query-index rebuild during `select()`, …). A key can be **non-empty as raw bytes** (passing every parse-time `!isEmpty` guard) yet become **empty after `ByteSlice.trim()`**: `ByteSlice.trim()` strips `0x09…0x0D` + `0x20` — this range **includes `0x0B`** — but the HTML5 tokeniser's attribute-name delimiter set (`CharacterReader.attributeNameDelims`) is `{\t \n \r \f space / = > NUL " ' <}`, which **does not include `0x0B`**, so `0x0B` is read as a normal attribute-name character.

A `0x0B`-only name therefore survives parsing, then trims to empty when materialized. `appendPending`/`ensureMaterialized` feed that empty key to the throwing `Attribute`/`BooleanAttribute` initialisers via `try!`, turning a recoverable validation error into a fatal, uncatchable trap.

> Why only *after a quoted value*? Every other whitespace skip uses `advanceAsciiWhitespace()`, whose `UInt8.isWhitespace` predicate **does** include `0x0B`, so a stray `0x0B` is swallowed. Only `AfterAttributeValue_quoted` errors and transitions to `BeforeAttributeName` *without advancing*, leaving `0x0B` to be consumed as a name by the explicit five-byte whitespace check that excludes it.

### Fix

Rather than guarding the one known-bad input, this removes the `try!` traps from attribute materialization altogether. A throwing helper (`makeMaterializedAttribute`) builds the attribute, and the three call sites (`appendPending`, `ensureMaterialized`, and the single-attribute fallback) invoke it via `try?`, **dropping** any attribute that fails validation. This matches jsoup (which silently drops malformed empty-key attributes) and makes materialization resilient to *any* validation failure, not just the empty-key case — a third-party parser should never `try!` on uncontrolled input.

### Tests / verification

- Adds `Tests/SwiftSoupTests/PublicEmptyAttributeKeyTest.swift` — boolean, valued, and `<meta>` selector cases, public API only. Traps before the fix; after, `select` returns 0 matches (attribute dropped).
- Full suite: **662 tests, 0 failures**.
- Benchmark (`BenchmarkProfileTest`, release, `SET=base,large`, 500 iterations, same machine): baseline `f474b11` **32586.93 ms** vs fixed `d33de7b` **32324.84 ms** (**−0.80%**) — within run-to-run noise; the helper is `@inline(__always)`, so codegen at the call sites is unchanged.
