### PR TITLE
Restore Carthage project support

### DIFF
--- a/SwiftSoup.xcodeproj/project.pbxproj
+++ b/SwiftSoup.xcodeproj/project.pbxproj
@@ -407,7 +407,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/SwiftSoup-Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
+				"INFOPLIST_FILE[sdk=appletv*]" = "$(SRCROOT)/Resources/InfotvOS.plist";
+				"INFOPLIST_FILE[sdk=macosx*]" = "$(SRCROOT)/Resources/InfoMac.plist";
+				"INFOPLIST_FILE[sdk=watch*]" = "$(SRCROOT)/Resources/InfoWatchOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -427,16 +430,18 @@
 				PRODUCT_NAME = SwiftSoup;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -448,7 +453,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/SwiftSoup-Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
+				"INFOPLIST_FILE[sdk=appletv*]" = "$(SRCROOT)/Resources/InfotvOS.plist";
+				"INFOPLIST_FILE[sdk=macosx*]" = "$(SRCROOT)/Resources/InfoMac.plist";
+				"INFOPLIST_FILE[sdk=watch*]" = "$(SRCROOT)/Resources/InfoWatchOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -468,7 +476,7 @@
 				PRODUCT_NAME = SwiftSoup;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -479,9 +487,11 @@
 				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};

--- a/SwiftSoup.xcodeproj/xcshareddata/xcschemes/SwiftSoup.xcscheme
+++ b/SwiftSoup.xcodeproj/xcshareddata/xcschemes/SwiftSoup.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4851416F94D82A4E0A5A346"
+               BuildableName = "SwiftSoup.framework"
+               BlueprintName = "SwiftSoup"
+               ReferencedContainer = "container:SwiftSoup.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4851416F94D82A4E0A5A346"
+            BuildableName = "SwiftSoup.framework"
+            BlueprintName = "SwiftSoup"
+            ReferencedContainer = "container:SwiftSoup.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4851416F94D82A4E0A5A346"
+            BuildableName = "SwiftSoup.framework"
+            BlueprintName = "SwiftSoup"
+            ReferencedContainer = "container:SwiftSoup.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Cause

The current Xcode project no longer works well with Carthage because the shared framework scheme is missing and the framework target points to a generated Info.plist path that is not checked in.

As a result, Carthage cannot reliably discover and archive the `SwiftSoup` framework target from the project.

## Changes

This PR restores the project settings needed for Carthage builds:

- Adds a shared `SwiftSoup` scheme for Carthage discovery.
- Updates the framework target to use the checked-in platform Info.plist files:
  - `Resources/Info.plist`
  - `Resources/InfoMac.plist`
  - `Resources/InfotvOS.plist`
  - `Resources/InfoWatchOS.plist`
- Restores tvOS and watchOS platform settings on the framework target.

## Validation

- `carthage build --no-skip-current --use-xcframeworks --verbose`: succeeded
- Confirmed `SwiftSoup.xcframework` is generated for iOS, tvOS, and watchOS