### PR TITLE
Fix repeated source-backed mutations

### DIFF
--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -35,10 +35,7 @@ open class Document: Element {
     internal var parsedAsXml: Bool = false
     
     @usableFromInline
-    internal var dirtySourceRootIDs: Set<ObjectIdentifier> = []
-    
-    @usableFromInline
-    internal var dirtySourceRoots: [Weak<Node>] = []
+    internal var dirtySourceRoots: [ObjectIdentifier: Weak<Node>] = [:]
 
 
 
@@ -491,63 +488,55 @@ open class Document: Element {
 
     @usableFromInline
     internal func registerDirtySourceRoot(_ node: Node) {
-        cleanupDirtySourceRoots()
+        let identifier = ObjectIdentifier(node)
+        if let registered = dirtySourceRoots[identifier]?.value,
+           registered === node,
+           registered.sourceRangeDirty {
+            return
+        }
 
         if node === self {
-            dirtySourceRootIDs = [ObjectIdentifier(self)]
-            dirtySourceRoots = [Weak(self)]
+            dirtySourceRoots = [identifier: Weak(self)]
             return
         }
 
         var ancestor = node.parentNode
         while let current = ancestor {
-            if dirtySourceRootIDs.contains(ObjectIdentifier(current)) {
+            let ancestorIdentifier = ObjectIdentifier(current)
+            if let registered = dirtySourceRoots[ancestorIdentifier]?.value,
+               registered === current,
+               registered.sourceRangeDirty {
                 return
             }
             ancestor = current.parentNode
         }
 
-        dirtySourceRoots.removeAll { weakNode in
-            guard let existing = weakNode.value else { return true }
-            if node.isAncestor(of: existing) {
-                dirtySourceRootIDs.remove(ObjectIdentifier(existing))
-                return true
+        cleanupDirtySourceRoots()
+        let descendantIdentifiers = dirtySourceRoots.compactMap { entry -> ObjectIdentifier? in
+            let (identifier, weakNode) = entry
+            guard let existing = weakNode.value,
+                  node.isAncestor(of: existing) else {
+                return nil
             }
-            return false
+            return identifier
         }
-
-        let identifier = ObjectIdentifier(node)
-        if dirtySourceRootIDs.insert(identifier).inserted {
-            dirtySourceRoots.append(Weak(node))
+        for descendantIdentifier in descendantIdentifiers {
+            dirtySourceRoots.removeValue(forKey: descendantIdentifier)
         }
+        dirtySourceRoots[identifier] = Weak(node)
     }
 
     @usableFromInline
     internal func currentDirtySourceRoots() -> [Node] {
         cleanupDirtySourceRoots()
-        return dirtySourceRoots.compactMap { weakNode in
-            guard let node = weakNode.value, node.sourceRangeDirty else { return nil }
-            return node
-        }
+        return dirtySourceRoots.values.compactMap(\.value)
     }
 
     @usableFromInline
     internal func cleanupDirtySourceRoots() {
-        dirtySourceRoots.removeAll { weakNode in
-            guard let node = weakNode.value else { return true }
-            let identifier = ObjectIdentifier(node)
-            guard dirtySourceRootIDs.contains(identifier) else { return true }
-            return false
+        dirtySourceRoots = dirtySourceRoots.filter { _, weakNode in
+            weakNode.value?.sourceRangeDirty == true
         }
-
-        if dirtySourceRoots.isEmpty {
-            dirtySourceRootIDs.removeAll(keepingCapacity: true)
-            return
-        }
-
-        dirtySourceRootIDs = Set(dirtySourceRoots.compactMap { weakNode in
-            weakNode.value.map(ObjectIdentifier.init)
-        })
     }
 
     @usableFromInline
@@ -624,7 +613,6 @@ open class Document: Element {
         clone.updateMetaCharset = updateMetaCharset
         clone.sourceBuffer = nil
         clone.parsedAsXml = parsedAsXml
-        clone.dirtySourceRootIDs.removeAll(keepingCapacity: false)
         clone.dirtySourceRoots.removeAll(keepingCapacity: false)
         return copy(clone: clone, parent: parent, copyChildren: false, rebuildIndexes: false)
     }
@@ -637,7 +625,6 @@ open class Document: Element {
         clone.updateMetaCharset = updateMetaCharset
         clone.sourceBuffer = nil
         clone.parsedAsXml = parsedAsXml
-        clone.dirtySourceRootIDs.removeAll(keepingCapacity: false)
         clone.dirtySourceRoots.removeAll(keepingCapacity: false)
         return super.copy(clone: clone, parent: parent)
     }

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -529,6 +529,7 @@ open class Node: Equatable, Hashable {
     @usableFromInline
     internal func markSourceDirty(force: Bool = false) {
         if sourceRangeDirty {
+            ownerDocument()?.registerDirtySourceRoot(self)
             return
         }
         if !force, treeBuilder?.isBulkBuilding == true {
@@ -543,6 +544,9 @@ open class Node: Equatable, Hashable {
     @usableFromInline
     internal func markSourceDirty(force: Bool = false, registerDirtyRoot: Bool) {
         if sourceRangeDirty {
+            if registerDirtyRoot {
+                ownerDocument()?.registerDirtySourceRoot(self)
+            }
             return
         }
         if !force, treeBuilder?.isBulkBuilding == true {

--- a/Tests/SwiftSoupTests/DocumentTest.swift
+++ b/Tests/SwiftSoupTests/DocumentTest.swift
@@ -484,6 +484,50 @@ class DocumentTest: XCTestCase {
 		XCTAssertTrue(try doc.outerHtml().contains("bye"))
 	}
 
+	func testRawSourceSerializationRegistersAlreadyDirtyParentMutation() throws {
+		let input = "<html><head></head><body><div><span>hello</span></div></body></html>"
+		let doc = try SwiftSoup.parse(input)
+		doc.outputSettings().prettyPrint(pretty: false)
+
+		let span = try XCTUnwrap(doc.select("span").first())
+		try span.text("bye")
+
+		let div = try XCTUnwrap(doc.select("div").first())
+		try div.attr("id", "a")
+
+		XCTAssertEqual("<html><head></head><body><div id=\"a\"><span>bye</span></div></body></html>", try doc.outerHtml())
+	}
+
+	func testRawSourceSerializationRegistersAlreadyDirtyElementMutation() throws {
+		let input = "<html><head></head><body><div><span>hello</span></div></body></html>"
+		let doc = try SwiftSoup.parse(input)
+		doc.outputSettings().prettyPrint(pretty: false)
+
+		let span = try XCTUnwrap(doc.select("span").first())
+		let text = try XCTUnwrap(span.childNode(0) as? TextNode)
+		text.text("bye")
+		try span.attr("id", "a")
+
+		XCTAssertEqual("<html><head></head><body><div><span id=\"a\">bye</span></div></body></html>", try doc.outerHtml())
+	}
+
+	func testRawSourceSerializationRegistersAlreadyDirtyAncestorAfterSerialization() throws {
+		let input = "<html><head></head><body><div><span>hello</span></div></body></html>"
+		let doc = try SwiftSoup.parse(input)
+		doc.outputSettings().prettyPrint(pretty: false)
+
+		let div = try XCTUnwrap(doc.select("div").first())
+		let span = try XCTUnwrap(doc.select("span").first())
+		let text = try XCTUnwrap(span.childNode(0) as? TextNode)
+		text.text("bye")
+
+		XCTAssertEqual("<html><head></head><body><div><span>bye</span></div></body></html>", try doc.outerHtml())
+
+		try div.attr("id", "a")
+
+		XCTAssertEqual("<html><head></head><body><div id=\"a\"><span>bye</span></div></body></html>", try doc.outerHtml())
+	}
+
 	func testRawSourceXmlParsedDocument() throws {
 		let input = "<root><br/></root>"
 		let doc = try SwiftSoup.parse(input, "", Parser.xmlParser())


### PR DESCRIPTION
Source-backed serialization tracked only the first dirty descendant. If a later mutation touched an ancestor that was already marked dirty, markSourceDirty returned before promoting that ancestor to a patch root, so outerHtml could silently omit the later change.

This change:
- re-registers an already-dirty node when it is mutated directly;
- replaces the parallel weak-array and identifier-set registry with a single weak dictionary;
- keeps repeated mutations on an existing root O(1);
- preserves ancestor/descendant root coalescing;
- adds regression coverage for parent, element, and post-serialization mutations.

Verification:
- focused regression tests: 3 passed
- complete SwiftSoup suite: 665 passed, 0 failed