### PR TITLE
Reduce source-backed serialization overhead

### DIFF
--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -450,6 +450,10 @@ open class Document: Element {
     @usableFromInline
     internal func sourcePatches() throws -> [SourcePatch] {
         guard sourceBuffer != nil else { return [] }
+        let roots = currentDirtySourceRoots()
+        guard !roots.isEmpty || sourceRangeDirty else {
+            return []
+        }
         let out = (_outputSettings.copy() as! OutputSettings).prettyPrint(pretty: false)
         var patches: [SourcePatch] = []
 
@@ -475,7 +479,6 @@ open class Document: Element {
             }
         }
 
-        let roots = currentDirtySourceRoots()
         if roots.isEmpty {
             collect(self, false)
         } else {

--- a/Sources/StringBuilder.swift
+++ b/Sources/StringBuilder.swift
@@ -440,7 +440,9 @@ open class StringBuilder {
             if count == 0 { return true }
             let newSize = size + count
             if size == internalBuffer.count {
-                internalBuffer.append(contentsOf: buffer)
+                if let base = buffer.baseAddress {
+                    internalBuffer.append(contentsOf: UnsafeBufferPointer(start: base, count: count))
+                }
                 size = newSize
                 return true
             }
@@ -483,7 +485,10 @@ open class StringBuilder {
             if count == 0 { return }
             let newSize = size + count
             if size == internalBuffer.count {
-                internalBuffer.append(contentsOf: bytes)
+                bytes.withUnsafeBufferPointer { src in
+                    guard let base = src.baseAddress else { return }
+                    internalBuffer.append(contentsOf: UnsafeBufferPointer(start: base, count: count))
+                }
                 size = newSize
                 return
             }
@@ -522,7 +527,10 @@ open class StringBuilder {
             if count == 0 { return }
             let newSize = size + count
             if size == internalBuffer.count {
-                internalBuffer.append(contentsOf: bytes)
+                bytes.withUnsafeBufferPointer { src in
+                    guard let base = src.baseAddress else { return }
+                    internalBuffer.append(contentsOf: UnsafeBufferPointer(start: base, count: count))
+                }
                 size = newSize
                 return
             }

--- a/Sources/StringBuilder.swift
+++ b/Sources/StringBuilder.swift
@@ -502,7 +502,15 @@ open class StringBuilder {
                     }
                 }
                 if count > available {
-                    internalBuffer.append(contentsOf: bytes[bytes.index(bytes.startIndex, offsetBy: available)...])
+                    bytes.withUnsafeBufferPointer { src in
+                        guard let srcBase = src.baseAddress else { return }
+                        internalBuffer.append(
+                            contentsOf: UnsafeBufferPointer(
+                                start: srcBase.advanced(by: available),
+                                count: count - available
+                            )
+                        )
+                    }
                 }
                 size = newSize
                 return
@@ -544,7 +552,15 @@ open class StringBuilder {
                     }
                 }
                 if count > available {
-                    internalBuffer.append(contentsOf: bytes[bytes.index(bytes.startIndex, offsetBy: available)...])
+                    bytes.withUnsafeBufferPointer { src in
+                        guard let srcBase = src.baseAddress else { return }
+                        internalBuffer.append(
+                            contentsOf: UnsafeBufferPointer(
+                                start: srcBase.advanced(by: available),
+                                count: count - available
+                            )
+                        )
+                    }
                 }
                 size = newSize
                 return


### PR DESCRIPTION
Follow-up optimizations for the source-backed serializer merged in #397.

This change:
- appends contiguous byte buffers directly instead of materializing suffix collections;
- handles partially filled pooled buffers without slice allocation;
- returns immediately when a source-backed document has no dirty roots, avoiding output-settings copies and patch traversal.

The behavior and fallback policy are unchanged.

Verification:
- complete SwiftSoup suite: 662 passed, 0 failed