### PR TITLE
Ignore generated Derived artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Swift Package Manager
 .build
+/Derived/
 Package.resolved
 
 # Xcode user settings


### PR DESCRIPTION
Ignores the repository-local Derived directory used by generated Xcode metadata and benchmark/project tooling. These files are reproducible build artifacts and should not appear as source changes.