### PR TITLE
Preserve mutations on source-backed body and HTML elements

### DIFF
--- a/Sources/HtmlTreeBuilder.swift
+++ b/Sources/HtmlTreeBuilder.swift
@@ -753,6 +753,22 @@ class HtmlTreeBuilder: TreeBuilder {
         return stack[index]
     }
 
+    /// Records the explicit closing tag for an element that remains on the HTML
+    /// parser stack. `body` and `html` transition the insertion mode without
+    /// being popped, so the normal pop bookkeeping cannot complete their ranges.
+    @inline(__always)
+    func completeSourceRangeForOpenElement(
+        _ elementName: [UInt8],
+        endingAt endTag: Token.EndTag
+    ) {
+        guard tracksSourceRanges,
+              let endRange = endTag.sourceRange,
+              let element = getFromStack(elementName) else {
+            return
+        }
+        element.setSourceRangeEnd(endRange.end)
+    }
+
     
     @inlinable
     func getFromStack(_ elName: String) -> Element? {

--- a/Sources/HtmlTreeBuilderState.swift
+++ b/Sources/HtmlTreeBuilderState.swift
@@ -1193,6 +1193,10 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
                             return false
                         } else {
                             // todo: error if stack contains something not dd, dt, li, optgroup, option, p, rp, rt, tbody, td, tfoot, th, thead, tr, body, html
+                            tb.completeSourceRangeForOpenElement(
+                                UTF8Arrays.body,
+                                endingAt: endTag
+                            )
                             tb.transition(.AfterBody)
                         }
                         return true
@@ -1322,6 +1326,10 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
                                 return false
                             } else {
                                 // todo: error if stack contains something not dd, dt, li, optgroup, option, p, rp, rt, tbody, td, tfoot, th, thead, tr, body, html
+                                tb.completeSourceRangeForOpenElement(
+                                    UTF8Arrays.body,
+                                    endingAt: endTag
+                                )
                                 tb.transition(.AfterBody)
                             }
                         } else if name == UTF8Arrays.html {
@@ -2333,6 +2341,10 @@ enum HtmlTreeBuilderState: String, HtmlTreeBuilderStateProtocol {
                     tb.error(self)
                     return false
                 } else {
+                    tb.completeSourceRangeForOpenElement(
+                        UTF8Arrays.html,
+                        endingAt: t.asEndTag()
+                    )
                     tb.transition(.AfterAfterBody)
                 }
             } else if (t.isEOF()) {

--- a/Tests/SwiftSoupTests/SourceReuseSerializationTest.swift
+++ b/Tests/SwiftSoupTests/SourceReuseSerializationTest.swift
@@ -35,6 +35,21 @@ final class SourceReuseSerializationTest: XCTestCase {
         XCTAssertEqual(try reparsed.getElementById("reader")?.text(), "Before")
     }
 
+    func testNormalSerializationPreservesBodyAndHTMLAttributeMutations() throws {
+        let document = try parseHTML(
+            "<html lang='ja'><head><title>Test</title></head>" +
+            "<body class='reader'><main id='reader'>Before</main></body></html>"
+        )
+        let html = try XCTUnwrap(document.getElementsByTag("html").first())
+        let body = try XCTUnwrap(document.body())
+        try html.attr("data-document-state", "processed")
+        try body.attr("data-processing-state", "complete")
+
+        let reparsed = try SwiftSoup.parse(string(try document.outerHtmlUTF8()))
+        XCTAssertEqual(try reparsed.getElementsByTag("html").first()?.attr("data-document-state"), "processed")
+        XCTAssertEqual(try reparsed.body()?.attr("data-processing-state"), "complete")
+    }
+
     func testReusingSourceOutsideBodyPreservesSourceBackedShell() throws {
         let document = try parseHTML(
             "<!doctype html><html><!--before-head--><head data-shell='source'><title>Title</title></head>" +
@@ -42,6 +57,8 @@ final class SourceReuseSerializationTest: XCTestCase {
             "<!--after-body--></html>"
         )
         let main = try XCTUnwrap(document.getElementById("reader"))
+        let body = try XCTUnwrap(document.body())
+        try body.attr("data-processing-state", "complete")
         try main.text("After")
         try main.attr("data-state", "complete")
 
@@ -52,6 +69,7 @@ final class SourceReuseSerializationTest: XCTestCase {
 
         let reparsed = try SwiftSoup.parse(serialized)
         XCTAssertEqual(try reparsed.head()?.attr("data-shell"), "source")
+        XCTAssertEqual(try reparsed.body()?.attr("data-processing-state"), "complete")
         XCTAssertEqual(try reparsed.getElementById("reader")?.text(), "After")
         XCTAssertEqual(try reparsed.getElementById("reader")?.attr("data-state"), "complete")
     }


### PR DESCRIPTION
## Summary

Complete source ranges for explicit `</body>` and `</html>` tags even though the HTML parser changes insertion mode without popping those elements from its stack.

Without complete ranges, `outerHtmlUTF8()` can miss attribute mutations made directly on a parsed `body` or `html` element: the source-patch collector cannot replace the incomplete dirty element, and unchanged descendants provide no smaller patch to carry the attribute change.

The parser bookkeeping lives in one helper used by both `body` parsing branches and the `html` end-tag branch. The specialized `outerHtmlUTF8ReusingSourceOutsideBody()` path is also covered to keep its current-body contract explicit.

## Verification

- `swift test --filter SourceReuseSerializationTest`: 8 passed
- `swift test`: 673 passed, 0 failed