### PR TITLE
Fix escaped id selectors in the simple-selector fast path

### DIFF
--- a/Sources/CssSelector.swift
+++ b/Sources/CssSelector.swift
@@ -828,7 +828,9 @@ open class CssSelector {
                      TokeniserStateVars.colonByte,
                      TokeniserStateVars.dotByte,
                      TokeniserStateVars.leftBracketByte,
-                     TokeniserStateVars.hashByte:
+                     TokeniserStateVars.hashByte,
+                     // Escapes are decoded by TokenQueue.consumeCssIdentifier, not here.
+                     TokeniserStateVars.backslashByte:
                     return .none
                 default:
                     break

--- a/Sources/TokeniserState.swift
+++ b/Sources/TokeniserState.swift
@@ -42,6 +42,7 @@ public class TokeniserStateVars {
     @usableFromInline static let pipeByte: UInt8 = 0x7C
     @usableFromInline static let dotByte: UInt8 = 0x2E
     @usableFromInline static let leftBracketByte: UInt8 = 0x5B
+    @usableFromInline static let backslashByte: UInt8 = 0x5C
     @usableFromInline static let rightBracketByte: UInt8 = 0x5D
     @usableFromInline static let underscoreByte: UInt8 = 0x5F
     @usableFromInline static let zeroByte: UInt8 = 0x30

--- a/Tests/SwiftSoupTests/ElementTest.swift
+++ b/Tests/SwiftSoupTests/ElementTest.swift
@@ -1203,6 +1203,28 @@ class ElementTest: XCTestCase {
         XCTAssertTrue(try element == doc.select(element?.cssSelector() ?? "").first())
     }
 
+    // Unlike the id above, these contain no character the simple-selector fast path declines.
+    func testCssPathRoundTripsIdWithEscapedCharacters() throws {
+        for id in ["quote$body/main", "a b", "a(b)", "a'b", "a@b", "a%b"] {
+            let doc = try SwiftSoup.parse("<div id=\"\(id)\">A</div><div id=\"other\">B</div>")
+            guard let element = try doc.select("div").first() else {
+                XCTFail("no element for id \(id)")
+                continue
+            }
+            let selector = try element.cssSelector()
+            XCTAssertEqual(1, try doc.select(selector).size(), "selector \(selector)")
+            XCTAssertEqual("A", try doc.select(selector).text(), "selector \(selector)")
+        }
+    }
+
+    func testCssPathRoundTripsIdContainingBackslash() throws {
+        let doc = try SwiftSoup.parse(#"<div id="a\b">A</div><div id="ab">B</div>"#)
+        let element = try doc.select("div").first()
+
+        XCTAssertEqual(#"#a\\b"#, try element?.cssSelector())
+        XCTAssertEqual("A", try doc.select(element?.cssSelector() ?? "").text())
+    }
+
 	func testClassNames() throws {
 		let doc: Document = try SwiftSoup.parse("<div class=\"c1 c2\">C</div>")
 		let div: Element = try doc.select("div").get(0)

--- a/Tests/SwiftSoupTests/SelectorTest.swift
+++ b/Tests/SwiftSoupTests/SelectorTest.swift
@@ -1056,6 +1056,15 @@ class SelectorTest: XCTestCase {
 		XCTAssertEqual("Two", try doc.select("div[data=\"[Another)]]\"").first()?.text())
 	}
 
+	// A combinator is what decides between the two match paths; both must agree.
+	func testEscapedIdSelectorIsIndependentOfCombinators() throws {
+		let doc = try SwiftSoup.parse("<div><p id='x$y'>t</p></div>")
+		XCTAssertEqual(1, try doc.select(#"#x\$y"#).size())
+		XCTAssertEqual(1, try doc.select(#"body #x\$y"#).size())
+		XCTAssertEqual(1, try doc.select(#"div > #x\$y"#).size())
+		XCTAssertEqual(1, try doc.select(#"p#x\$y"#).size())
+	}
+
 	// Verify compound attribute selectors work on simple HTML
 	func testCompoundAttributeSelectorSimple() throws {
 		let html = "<div id='info-id' data-type='info-data'><p>Hello</p></div>"


### PR DESCRIPTION
## Summary

`Element.cssSelector()` backslash-escapes reserved characters in an id (#377); `TokenQueue.consumeCssIdentifier()` decodes it. The simple-selector fast path in `CssSelector` matches id bytes literally and never decodes it, so the library cannot find the element its own selector names:

```swift
let doc = try SwiftSoup.parse(#"<div id="quote$body/main">A</div>"#)
let el = try doc.select("div").first()!
try el.cssSelector()                              // #quote\$body\/main
try doc.select(el.cssSelector()).size()           // 0  <- expected 1
try doc.select("body > " + el.cssSelector()).size() // 1  (full parser)
```

The sibling branches of that function (`tag#id`, `.class`, `tag.class`, bare tag) screen their identifier with `isSimpleIdent`, an allow-list that already rejects a backslash. Only bare `#id` uses a deny-list, and `\` was missing from it. Adding it routes escaped ids to the full parser, as `:` `.` `[` `#` already are. The existing id test passes only because its id also contains `:`.

## Verification

- `swift test`: 676 passed, 0 failed (673 before).
- 22 escaped-id probes against the same build with the fast path force-disabled: stock disagrees on 16, patched on 1 (unescaped `#x$y`, deliberately left lenient).
- 2460 selector×document results byte-identical (sha256) before/after.
- AGENTS.md benchmark (base,large, release, 3 interleaved runs/arm): 28300 vs 28127 ms mean, 4.8%/5.2% spread per arm — noise.

AI-assisted; see the commit trailer.
