### PR TITLE
Keep DOM identity hashes and OrderedSet membership stable across mutation

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -2841,7 +2841,6 @@ open class Element: Node {
     
     override public func hash(into hasher: inout Hasher) {
         super.hash(into: &hasher)
-        hasher.combine(_tag)
     }
 }
 

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -1335,8 +1335,7 @@ open class Node: Equatable, Hashable {
     /// your program. Do not save hash values to use during a future execution.
     @inline(__always)
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(description)
-        hasher.combine(baseUri)
+        hasher.combine(ObjectIdentifier(self))
     }
 }
 

--- a/Sources/OrderedSet.swift
+++ b/Sources/OrderedSet.swift
@@ -64,9 +64,10 @@ public class OrderedSet<T: Hashable> {
 	*/
 	public func append(_ object: T) {
 
-		if let lastIndex = index(of: object) {
-			remove(object)
-			insert(object, at: lastIndex)
+		if let index = contents.removeValue(forKey: object) {
+			// Keep the position, but replace both stored representatives of an equal value.
+			contents[object] = index
+			sequencedContents[index] = object
 		} else {
 			contents[object] = contents.count
 			sequencedContents.append(object)
@@ -92,16 +93,11 @@ public class OrderedSet<T: Hashable> {
 	- parameter    object: The object to be removed.
 	*/
 	public func remove(_ object: T) {
-		if let index = contents[object] {
-			contents[object] = nil
+		if let index = contents.removeValue(forKey: object) {
 			sequencedContents.remove(at: index)
 
-			for (object, i) in contents {
-				if i < index {
-					continue
-				}
-
-				contents[object] = i - 1
+			for i in index..<sequencedContents.count {
+				contents[sequencedContents[i]] = i
 			}
 		}
 	}
@@ -147,11 +143,14 @@ public class OrderedSet<T: Hashable> {
 	public func swapObject(_ first: T, with second: T) {
 		if let firstPosition = contents[first] {
 			if let secondPosition = contents[second] {
-				contents[first] = secondPosition
-				contents[second] = firstPosition
-
-				sequencedContents[firstPosition] = second
-				sequencedContents[secondPosition] = first
+				guard firstPosition != secondPosition else { return }
+				// Arguments identify members; a swap must not replace the stored
+				// representatives with equal-but-distinct lookup values.
+				let storedFirst = sequencedContents[firstPosition]
+				let storedSecond = sequencedContents[secondPosition]
+				contents[storedFirst] = secondPosition
+				contents[storedSecond] = firstPosition
+				sequencedContents.swapAt(firstPosition, secondPosition)
 			}
 		}
 	}
@@ -173,18 +172,32 @@ public class OrderedSet<T: Hashable> {
 	}
 
 	/**
-	Tests if a the ordered set is a subset of another sequence.
+	Tests if the ordered set is a subset of another sequence.
+	Collections retain their membership checks; other sequences are consumed
+	at most once and stop when all members are found. Empty receivers do not
+	consume the input. Temporary storage is bounded by the receiver count.
 	- parameter    sequence:   The sequence to check.
 	- returns:                 true if the sequence contains all objects contained in the receiver, otherwise false.
 	*/
 	public func isSubset<S: Sequence>(of sequence: S) -> Bool where S.Iterator.Element == T {
-		for (object, _) in contents {
-			if !sequence.contains(object) {
-				return false
+		guard !contents.isEmpty else { return true }
+		// Collections are restartable and may answer contains without scanning
+		// (notably Set and Range). A singleton needs only one membership query,
+		// even for a single-pass Sequence, and needs no temporary membership set.
+		if contents.count == 1 || sequence is any Collection {
+			for object in contents.keys {
+				if !sequence.contains(object) { return false }
 			}
+			return true
 		}
-
-		return true
+		// Sequence need not be restartable. Track required members while
+		// consuming a single iterator, without retaining the input's tail.
+		var remaining = Set(contents.keys)
+		for object in sequence {
+			remaining.remove(object)
+			if remaining.isEmpty { return true }
+		}
+		return false
 	}
 
 	/**
@@ -206,23 +219,32 @@ public class OrderedSet<T: Hashable> {
 				return
 			}
 
-			let adjustment = position > index ? -1 : 1
-
-			var currentIndex = position
-			while currentIndex != index {
-				let nextIndex = currentIndex + adjustment
-
-				let firstObject = sequencedContents[currentIndex]
-				let secondObject = sequencedContents[nextIndex]
-
-				sequencedContents[currentIndex] = secondObject
-				sequencedContents[nextIndex] = firstObject
-
-				contents[firstObject] = nextIndex
-				contents[secondObject] = currentIndex
-
-				currentIndex += adjustment
+			// Keep the stored representative, not a possibly equal incoming object.
+			let moved = sequencedContents[position]
+			// A one-step move needs only the original direct swap, not a shift loop.
+			if position == index - 1 || position == index + 1 {
+				let displaced = sequencedContents[index]
+				sequencedContents[position] = displaced
+				sequencedContents[index] = moved
+				contents[moved] = index
+				contents[displaced] = position
+				return
 			}
+			if position < index {
+				for i in position..<index {
+					let shifted = sequencedContents[i + 1]
+					sequencedContents[i] = shifted
+					contents[shifted] = i
+				}
+			} else {
+				for i in stride(from: position, to: index, by: -1) {
+					let shifted = sequencedContents[i - 1]
+					sequencedContents[i] = shifted
+					contents[shifted] = i
+				}
+			}
+			sequencedContents[index] = moved
+			contents[moved] = index
 		}
 	}
 
@@ -258,11 +280,15 @@ public class OrderedSet<T: Hashable> {
 			return
 		}
 
-		// Append our object, then swap them until its at the end.
-		append(object)
+		if index == count {
+			append(object)
+			return
+		}
 
-		for i in (index..<count-1).reversed() {
-			swapObject(self[i], with: self[i+1])
+		// Shift array storage once, then update each affected index once.
+		sequencedContents.insert(object, at: index)
+		for i in index..<sequencedContents.count {
+			contents[sequencedContents[i]] = i
 		}
 	}
 
@@ -387,7 +413,7 @@ public struct OrderedSetGenerator<T: Hashable>: IteratorProtocol {
 extension OrderedSetGenerator where T: Comparable {}
 
 public func +<T, S: Sequence> (lhs: OrderedSet<T>, rhs: S) -> OrderedSet<T> where S.Iterator.Element == T {
-	let joinedSet = lhs
+	let joinedSet = OrderedSet(sequence: lhs)
 	joinedSet.append(contentsOf: rhs)
 
 	return joinedSet
@@ -398,7 +424,7 @@ public func +=<T, S: Sequence> (lhs: inout OrderedSet<T>, rhs: S) where S.Iterat
 }
 
 public func -<T, S: Sequence> (lhs: OrderedSet<T>, rhs: S) -> OrderedSet<T> where S.Iterator.Element == T {
-	let purgedSet = lhs
+	let purgedSet = OrderedSet(sequence: lhs)
 	purgedSet.remove(rhs)
 
 	return purgedSet

--- a/Tests/SwiftSoupTests/ElementIdentityHashTest.swift
+++ b/Tests/SwiftSoupTests/ElementIdentityHashTest.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import SwiftSoup
+
+final class ElementIdentityHashTest: XCTestCase {
+    func testHashRemainsStableWhenTagChanges() throws {
+        let element = try Element(Tag.valueOf("p"), "")
+        let node: Node = element
+        let initialElementHash = element.hashValue
+        let initialNodeHash = node.hashValue
+        for tag in ["div", "SPAN", "custom-element", "日本語", "p"] {
+            try element.tagName(tag)
+            XCTAssertEqual(element.hashValue, initialElementHash)
+            XCTAssertEqual(node.hashValue, initialNodeHash)
+        }
+    }
+
+    func testElementAndNodeCollectionsKeepRenamedKeys() throws {
+        let document = try SwiftSoup.parse("<main><p>one</p><p>two</p></main>")
+        let elements = try document.getElementsByTag("p").array()
+        let elementSet = Set(elements)
+        let nodeSet = Set(elements.map { $0 as Node })
+        let elementMap = Dictionary(uniqueKeysWithValues: elements.enumerated().map { ($0.element, $0.offset) })
+        let nodeMap = Dictionary(uniqueKeysWithValues: elements.enumerated().map { ($0.element as Node, $0.offset) })
+        for (index, element) in elements.enumerated() {
+            try element.tagName("section")
+            XCTAssertTrue(elementSet.contains(element))
+            XCTAssertTrue(nodeSet.contains(element))
+            XCTAssertEqual(elementMap[element], index)
+            XCTAssertEqual(nodeMap[element], index)
+        }
+        XCTAssertEqual(elementSet.count, 2)
+        XCTAssertNotEqual(elements[0], elements[1])
+    }
+
+    func testHashDoesNotSerializeOrDependOnAttributeAndTextChanges() throws {
+        let element = try Element(Tag.valueOf("p"), "")
+        let original = element.hashValue
+        try element.attr("class", "one")
+        try element.text("日本語 < &")
+        try element.appendElement("em").text("two")
+        try element.tagName("article")
+        XCTAssertEqual(element.hashValue, original)
+        XCTAssertEqual(Set([element, element]).count, 1)
+    }
+}

--- a/Tests/SwiftSoupTests/NodeIdentityHashTest.swift
+++ b/Tests/SwiftSoupTests/NodeIdentityHashTest.swift
@@ -1,0 +1,68 @@
+import XCTest
+import SwiftSoup
+
+final class NodeIdentityHashTest: XCTestCase {
+    func testHashAndDictionaryMembershipSurviveDOMMutation() throws {
+        let document = try SwiftSoup.parse("<p>Before</p>")
+        let node = try XCTUnwrap(document.select("p").first())
+        let originalHash = node.hashValue
+        let nodes: Set<Node> = [node]
+        var values: [Node: String] = [node: "retained"]
+
+        try node.attr("class", "updated")
+        try node.text("After")
+        try node.setBaseUri("https://example.com/changed/")
+
+        XCTAssertEqual(node.hashValue, originalHash)
+        XCTAssertTrue(nodes.contains(node))
+        XCTAssertEqual(values[node], "retained")
+        XCTAssertEqual(values.removeValue(forKey: node), "retained")
+        XCTAssertTrue(values.isEmpty)
+    }
+
+    func testDistinctNodesWithIdenticalMarkupRemainDistinct() throws {
+        let document = try SwiftSoup.parse("<p>Same</p><p>Same</p>")
+        let paragraphs = try document.select("p").array()
+        XCTAssertEqual(paragraphs.count, 2)
+        let first: Node = paragraphs[0]
+        let second: Node = paragraphs[1]
+        XCTAssertNotEqual(first, second)
+        XCTAssertEqual(Set<Node>([first, second, first]).count, 2)
+        let values: [Node: Int] = [first: 1, second: 2]
+        XCTAssertEqual(values[first], 1)
+        XCTAssertEqual(values[second], 2)
+    }
+
+    func testHashSurvivesReparentingAndOutputSettingsChanges() throws {
+        let original = try SwiftSoup.parse("<div><p>Value</p></div>")
+        let destination = try SwiftSoup.parse("<main></main>")
+        let node = try XCTUnwrap(original.select("p").first())
+        let parent = try XCTUnwrap(destination.select("main").first())
+        let hash = node.hashValue
+        let values: [Node: Int] = [node: 42]
+
+        try parent.appendChild(node)
+        destination.outputSettings().prettyPrint(pretty: false)
+        destination.outputSettings().syntax(syntax: .xml)
+
+        XCTAssertEqual(node.hashValue, hash)
+        XCTAssertEqual(values[node], 42)
+    }
+
+    func testHashDoesNotInvokeSerialization() {
+        let document = CountingDocument([])
+        var hasher = Hasher()
+        document.hash(into: &hasher)
+        _ = hasher.finalize()
+        XCTAssertEqual(document.serializationCount, 0)
+    }
+
+    private final class CountingDocument: Document {
+        var serializationCount = 0
+
+        override func outerHtml() throws -> String {
+            serializationCount += 1
+            return try super.outerHtml()
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetCollectionMembershipTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetCollectionMembershipTest.swift
@@ -1,0 +1,168 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetCollectionMembershipTest: XCTestCase {
+    private final class OneShot<T>: Sequence {
+        let values: [T]
+        var iteratorRequests = 0
+        var nextCalls = 0
+        init(_ values: [T]) { self.values = values }
+        func makeIterator() -> AnyIterator<T> {
+            iteratorRequests += 1
+            guard iteratorRequests == 1 else { return AnyIterator { nil } }
+            var position = 0
+            return AnyIterator {
+                self.nextCalls += 1
+                guard position < self.values.count else { return nil }
+                defer { position += 1 }
+                return self.values[position]
+            }
+        }
+    }
+
+    // All iterators deliberately share their traversal state, as a stream does.
+    private final class SharedStream: Sequence {
+        var position = 0
+        var iteratorRequests = 0
+        let values: [Int]
+        init(_ values: [Int]) { self.values = values }
+        func makeIterator() -> AnyIterator<Int> {
+            iteratorRequests += 1
+            return AnyIterator {
+                guard self.position < self.values.count else { return nil }
+                defer { self.position += 1 }
+                return self.values[self.position]
+            }
+        }
+    }
+
+    private final class MembershipCollection: Collection {
+        typealias Index = Int
+        var membershipCalls = 0
+        var elementReads = 0
+        let values = [1, 2, 3]
+        var startIndex: Int { 0 }
+        var endIndex: Int { values.count }
+        func index(after i: Int) -> Int { i + 1 }
+        subscript(i: Int) -> Int { elementReads += 1; return values[i] }
+        func _customContainsEquatableElement(_ element: Int) -> Bool? {
+            membershipCalls += 1
+            return values.contains(element)
+        }
+    }
+
+    func testOneShotSequenceIsNotRestarted() {
+        let receiver = OrderedSet<Int>(sequence: [1, 2])
+        for values in [[1, 2], [2, 1], [7, 1, 1, 2, 8]] {
+            let input = OneShot(values)
+            XCTAssertTrue(receiver.isSubset(of: input))
+            XCTAssertEqual(input.iteratorRequests, 1)
+            XCTAssertEqual(Array(receiver), [1, 2])
+        }
+    }
+
+    func testSharedStateAndTypeErasedSequences() {
+        for values in [[1, 2], [2, 1]] {
+            let stream = SharedStream(values)
+            let receiver = OrderedSet<Int>(sequence: [1, 2])
+            XCTAssertTrue(receiver.isSubset(of: AnySequence(stream)))
+            XCTAssertEqual(stream.iteratorRequests, 1)
+            XCTAssertEqual(stream.position, 2)
+        }
+        let receiver = OrderedSet<Int>(sequence: [1, 2, 3])
+        XCTAssertTrue(receiver.isSubset(of: receiver))
+    }
+
+    func testEmptyAndSingletonKeepTheirConsumptionBehavior() {
+        let unused = OneShot([1, 2])
+        XCTAssertTrue(OrderedSet<Int>().isSubset(of: unused))
+        XCTAssertEqual(unused.iteratorRequests, 0)
+        XCTAssertEqual(unused.nextCalls, 0)
+        let singleton = OneShot([1, 2, 3])
+        XCTAssertTrue(OrderedSet<Int>(sequence: [2]).isSubset(of: singleton))
+        XCTAssertEqual(singleton.iteratorRequests, 1)
+        XCTAssertEqual(singleton.nextCalls, 2)
+    }
+
+    func testStopsWhenSatisfiedAndExhaustsOnlyMissingCases() {
+        let receiver = OrderedSet<Int>(sequence: [1, 2])
+        let prefix = OneShot([7, 1, 1, 2, 8, 9])
+        XCTAssertTrue(receiver.isSubset(of: prefix))
+        XCTAssertEqual(prefix.nextCalls, 4)
+        let missing = OneShot([1, 1, 8])
+        XCTAssertFalse(receiver.isSubset(of: missing))
+        XCTAssertEqual(missing.iteratorRequests, 1)
+        XCTAssertEqual(missing.nextCalls, 4) // Includes the nil terminator.
+    }
+
+    func testCollectionsKeepMembershipCustomization() {
+        let receiver = OrderedSet<Int>(sequence: [1, 2])
+        let specialized = MembershipCollection()
+        XCTAssertTrue(receiver.isSubset(of: specialized))
+        XCTAssertEqual(specialized.membershipCalls, 2)
+        XCTAssertEqual(specialized.elementReads, 0)
+        XCTAssertTrue(receiver.isSubset(of: Set([1, 2, 3])))
+        XCTAssertTrue(receiver.isSubset(of: 0..<Int.max))
+        XCTAssertFalse(receiver.isSubset(of: [0, 1]))
+        XCTAssertTrue(receiver.isSubset(of: [9, 1, 2, 8][1...2]))
+    }
+
+    func testCollisionsEqualRepresentativesAndSnapshots() {
+        final class Key: Hashable {
+            let value: Int
+            init(_ value: Int) { self.value = value }
+            static func == (lhs: Key, rhs: Key) -> Bool { lhs.value == rhs.value }
+            func hash(into hasher: inout Hasher) { hasher.combine(0) }
+        }
+        let first = Key(1), second = Key(2)
+        let receiver = OrderedSet<Key>(sequence: [first, second])
+        var saved = receiver.makeIterator()
+        XCTAssertTrue(receiver.isSubset(of: OneShot([Key(2), Key(2), Key(1)])))
+        XCTAssertTrue(receiver[0] === first)
+        XCTAssertTrue(receiver[1] === second)
+        XCTAssertTrue(saved.next() === first)
+        XCTAssertTrue(saved.next() === second)
+        XCTAssertNil(saved.next())
+        XCTAssertEqual(receiver.index(of: first), 0)
+        XCTAssertEqual(receiver.index(of: second), 1)
+    }
+
+    func testGeneratedFiniteSequencesAgainstSetOracle() {
+        var seed: UInt64 = 0x535542534554
+        func draw(_ limit: Int) -> Int {
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            return Int((seed >> 32) % UInt64(limit))
+        }
+        for _ in 0..<512 {
+            let wanted = (0..<draw(16)).map { _ in draw(16) }
+            let offered = (0..<draw(32)).map { _ in draw(16) }
+            let receiver = OrderedSet<Int>(sequence: wanted)
+            let expected = Set(wanted).isSubset(of: Set(offered))
+            let input = OneShot(offered)
+            XCTAssertEqual(receiver.isSubset(of: input), expected)
+            XCTAssertLessThanOrEqual(input.iteratorRequests, 1)
+            XCTAssertEqual(receiver.isSubset(of: offered), expected)
+            XCTAssertEqual(Set(receiver), Set(wanted))
+        }
+    }
+
+    func testHugeRangeMembershipIncludesRemoteEndpointsAndMisses() {
+        let positive = OrderedSet(sequence: [1, Int.max - 1])
+        XCTAssertTrue(positive.isSubset(of: 0..<Int.max))
+        XCTAssertFalse(OrderedSet(sequence: [-1, Int.max - 1]).isSubset(of: 0..<Int.max))
+        XCTAssertTrue(OrderedSet(sequence: [Int.max]).isSubset(of: 0...Int.max))
+        XCTAssertFalse(OrderedSet(sequence: [Int.max]).isSubset(of: 0..<Int.max))
+        XCTAssertTrue(OrderedSet(sequence: [Int.min, Int.max]).isSubset(of: Int.min...Int.max))
+    }
+
+    func testSingletonAndEmptyKeepCollectionMembershipDispatch() {
+        let specialized = MembershipCollection()
+        XCTAssertTrue(OrderedSet<Int>().isSubset(of: specialized))
+        XCTAssertEqual(specialized.membershipCalls, 0)
+        XCTAssertEqual(specialized.elementReads, 0)
+        XCTAssertTrue(OrderedSet(sequence: [2]).isSubset(of: specialized))
+        XCTAssertFalse(OrderedSet(sequence: [4]).isSubset(of: specialized))
+        XCTAssertEqual(specialized.membershipCalls, 2)
+        XCTAssertEqual(specialized.elementReads, 0)
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetGenericBoundaryTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetGenericBoundaryTest.swift
@@ -1,0 +1,97 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetGenericBoundaryTest: XCTestCase {
+    private final class Stream<Value>: Sequence, IteratorProtocol {
+        let values: [Value]
+        var offset = 0
+        private(set) var iteratorCount = 0
+        init(_ values: [Value]) { self.values = values }
+        func makeIterator() -> Stream<Value> { iteratorCount += 1; return self }
+        func next() -> Value? {
+            guard offset < values.count else { return nil }
+            defer { offset += 1 }
+            return .some(values[offset]) // A nil member is not end-of-stream.
+        }
+    }
+
+    private final class Key: Hashable {
+        let id: Int
+        init(_ id: Int) { self.id = id }
+        static func == (lhs: Key, rhs: Key) -> Bool { lhs.id == rhs.id }
+        func hash(into hasher: inout Hasher) { hasher.combine(0) }
+    }
+
+    func testNestedOptionalSinglePassSubsetsMatchFiniteArrayOracle() {
+        let alphabet: [Int??] = [nil, .some(nil), .some(.some(1)), .some(.some(2))]
+        var comparisons = 0
+        for length in 0...5 {
+            let possibilities = 1 << (2 * length)
+            for code in 0..<possibilities {
+                var bits = code
+                let values: [Int??] = (0..<length).map { _ in
+                    defer { bits >>= 2 }
+                    return alphabet[bits & 3]
+                }
+                for mask in 0..<16 {
+                    let required = alphabet.enumerated().compactMap { index, value -> Int??? in
+                        mask & (1 << index) == 0 ? nil : .some(value)
+                    }
+                    let expected = required.allSatisfy { values.contains($0) }
+                    for order in [required, Array(required.reversed())] {
+                        let subject = OrderedSet(sequence: order)
+                        let stream = Stream(values)
+                        XCTAssertEqual(subject.isSubset(of: stream), expected)
+                        XCTAssertLessThanOrEqual(stream.iteratorCount, 1)
+                        XCTAssertEqual(Array(subject), order)
+                        comparisons += 1
+                    }
+                }
+            }
+        }
+        XCTAssertEqual(comparisons, 43_680)
+    }
+
+    func testNilMembersRemainDistinctFromMissingIndicesAndIteratorExhaustion() {
+        let values: [Int??] = [nil, .some(nil), .some(.some(1))]
+        let subject = OrderedSet(sequence: values)
+        var saved = subject.makeIterator()
+        subject.swapObject(values[0], with: values[1])
+        XCTAssertEqual(Array(subject), [values[1], values[0], values[2]])
+        for index in 0..<subject.count {
+            XCTAssertEqual(subject.index(of: subject[index]), index)
+        }
+        subject.moveObject(values[0], toIndex: 2)
+        XCTAssertEqual(Array(subject), [values[1], values[2], values[0]])
+        for value in values {
+            let next: Int??? = saved.next()
+            XCTAssertNotNil(next as Any?)
+            XCTAssertEqual(next, .some(value))
+        }
+        XCTAssertNil(saved.next() as Any?)
+        subject.remove(values[1])
+        XCTAssertNil(subject.index(of: values[1]))
+        XCTAssertEqual(subject.index(of: values[0]), 1)
+        XCTAssertTrue(subject.isSubset(of: Stream([values[0], values[2]])))
+    }
+
+    func testTypeErasedCollisionKeysKeepRepresentativesAndReleaseLookups() {
+        let first = Key(1), second = Key(2)
+        let subject = OrderedSet(sequence: [AnyHashable(first), AnyHashable(second)])
+        weak var lookup: Key?
+        do {
+            let temporary = Key(1)
+            lookup = temporary
+            subject.swapObject(AnyHashable(temporary), with: AnyHashable(Key(2)))
+            XCTAssertTrue(subject.isSubset(of: Stream([AnyHashable(temporary), AnyHashable(Key(2))])))
+        }
+        XCTAssertNil(lookup)
+        XCTAssertTrue(subject[0].base as? Key === second)
+        XCTAssertTrue(subject[1].base as? Key === first)
+        XCTAssertEqual(subject.index(of: AnyHashable(Key(1))), 1)
+        XCTAssertEqual(subject.index(of: AnyHashable(Key(2))), 0)
+        let replacement = Key(1)
+        subject.append(AnyHashable(replacement))
+        XCTAssertTrue(subject[1].base as? Key === replacement, "Append still explicitly replaces equal members")
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetInsertionTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetInsertionTest.swift
@@ -1,0 +1,129 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetInsertionTest: XCTestCase {
+    private final class Item: Hashable {
+        let key: Int
+        let payload: String
+        init(_ key: Int, _ payload: String = "original") { self.key = key; self.payload = payload }
+        static func == (lhs: Item, rhs: Item) -> Bool { lhs.key == rhs.key }
+        func hash(into hasher: inout Hasher) { hasher.combine(0) }
+    }
+
+    private func check(_ set: OrderedSet<Int>, _ expected: [Int],
+                       file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(Array(set), expected, file: file, line: line)
+        XCTAssertEqual(set.count, expected.count, file: file, line: line)
+        for (i, value) in expected.enumerated() {
+            XCTAssertEqual(set.index(of: value), i, file: file, line: line)
+        }
+    }
+
+    func testEveryGapAndExistingValueAtSmallWidths() {
+        for width in 0...48 {
+            for gap in 0...width {
+                for value in -1..<width {
+                    let set = OrderedSet(sequence: Array(0..<width))
+                    var expected = Array(0..<width)
+                    if value == -1 { expected.insert(value, at: gap) }
+                    set.insert(value, at: gap)
+                    check(set, expected)
+                }
+            }
+        }
+    }
+
+    func testEqualIncomingReferenceDoesNotReplaceExistingRepresentative() {
+        let original = Item(7)
+        let set = OrderedSet(sequence: [Item(0), original, Item(9)])
+        weak var incoming: Item?
+        do {
+            let duplicate = Item(7, "duplicate")
+            incoming = duplicate
+            for gap in 0...set.count { set.insert(duplicate, at: gap) }
+        }
+        XCTAssertNil(incoming)
+        XCTAssertTrue(set[1] === original)
+        XCTAssertEqual(set.map(\.key), [0, 7, 9])
+        set.remove(original)
+        XCTAssertNil(set.index(of: original))
+    }
+
+    func testCollisionsAndSavedIteratorsPreserveReferences() {
+        let original = (0..<64).map { Item($0) }
+        let set = OrderedSet(sequence: original)
+        var iterator = set.makeIterator()
+        var expected = original
+        for i in 64..<160 {
+            let item = Item(i)
+            let gap = (i * 13) % (expected.count + 1)
+            set.insert(item, at: gap)
+            expected.insert(item, at: gap)
+            XCTAssertEqual(set.map(ObjectIdentifier.init), expected.map(ObjectIdentifier.init))
+            for (index, value) in expected.enumerated() { XCTAssertEqual(set.index(of: value), index) }
+        }
+        for item in original { XCTAssertTrue(iterator.next() === item) }
+        XCTAssertNil(iterator.next())
+    }
+
+    func testSeededInsertRemoveMoveAndReplaceAgainstArrayModel() {
+        let set = OrderedSet<Int>()
+        var expected: [Int] = []
+        var seed: UInt64 = 0x778_2026
+        func next(_ n: Int) -> Int {
+            seed = seed &* 6364136223846793005 &+ 1
+            return Int((seed >> 32) % UInt64(n))
+        }
+        for _ in 0..<2048 {
+            let value = next(96)
+            switch next(4) {
+            case 0, 1:
+                let gap = next(expected.count + 1)
+                set.insert(value, at: gap)
+                if !expected.contains(value) { expected.insert(value, at: gap) }
+            case 2:
+                set.remove(value)
+                expected.removeAll { $0 == value }
+            default:
+                if !expected.isEmpty {
+                    let gap = next(expected.count)
+                    set.moveObject(value, toIndex: gap)
+                    if let old = expected.firstIndex(of: value) {
+                        let stored = expected.remove(at: old)
+                        expected.insert(stored, at: gap)
+                    }
+                }
+            }
+            check(set, expected)
+        }
+    }
+
+    func testSequenceInsertionAndSubscriptUpdatesAfterSingleInsertion() {
+        let set = OrderedSet(sequence: [1, 2, 3])
+        set.insert(4, at: 1)
+        set.insert([5, 4, 6, 5], at: 2)
+        check(set, [1, 4, 5, 6, 2, 3])
+        set[2] = 3
+        check(set, [1, 4, 6, 2, 3])
+        set[1] = 8
+        check(set, [1, 8, 6, 2, 3])
+        set.moveObject(at: 0, to: 4)
+        check(set, [8, 6, 2, 3, 1])
+        set.remove(set)
+        set.insert(10, at: 0)
+        check(set, [10])
+    }
+
+    func testDOMIdentitySurvivesInsertionAndTagMutation() throws {
+        let nodes = try (0..<80).map { _ in try Element(Tag.valueOf("p"), "") }
+        let set = OrderedSet<Element>()
+        for element in nodes { set.insert(element, at: set.count / 2) }
+        XCTAssertEqual(set.count, 80)
+        for (i, element) in set.enumerated() {
+            try element.tagName(i % 2 == 0 ? "span" : "div")
+            XCTAssertEqual(set.index(of: element), i)
+        }
+        for element in nodes { set.remove(element) }
+        XCTAssertTrue(set.isEmpty)
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetMoveShiftTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetMoveShiftTest.swift
@@ -1,0 +1,129 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetMoveShiftTest: XCTestCase {
+    private final class Item: Hashable {
+        let key: Int
+        let payload: String
+        init(_ key: Int, _ payload: String = "original") { self.key = key; self.payload = payload }
+        static func == (lhs: Item, rhs: Item) -> Bool { lhs.key == rhs.key }
+        func hash(into hasher: inout Hasher) { hasher.combine(0) }
+    }
+    private func check(_ set: OrderedSet<Int>, _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(Array(set), expected, file: file, line: line)
+        XCTAssertEqual(set.count, expected.count, file: file, line: line)
+        for (index, value) in expected.enumerated() { XCTAssertEqual(set.index(of: value), index, file: file, line: line) }
+    }
+
+    func testEverySourceDestinationAndBothPublicOverloads() {
+        for width in 1...48 {
+            for source in 0..<width {
+                for destination in 0..<width {
+                    var expected = Array(0..<width)
+                    let stored = expected.remove(at: source)
+                    expected.insert(stored, at: destination)
+                    let first = OrderedSet(sequence: 0..<width)
+                    first.moveObject(source, toIndex: destination)
+                    check(first, expected)
+                    let second = OrderedSet(sequence: 0..<width)
+                    second.moveObject(at: source, to: destination)
+                    check(second, expected)
+                }
+            }
+        }
+    }
+
+    func testEqualArgumentDoesNotReplaceStoredRepresentativeOrStayRetained() {
+        let values = (0..<24).map { Item($0) }
+        let set = OrderedSet(sequence: values)
+        weak var supplied: Item?
+        do {
+            let duplicate = Item(7, "must not replace")
+            supplied = duplicate
+            set.moveObject(duplicate, toIndex: 0)
+            XCTAssertTrue(set[0] === values[7])
+            set.moveObject(duplicate, toIndex: 23)
+            XCTAssertTrue(set[23] === values[7])
+        }
+        XCTAssertNil(supplied)
+        XCTAssertEqual(set.map(\.payload), Array(repeating: "original", count: 24))
+        set.remove(values[7])
+        XCTAssertNil(set.index(of: values[7]))
+        XCTAssertEqual(set.map(\.key), (0..<24).filter { $0 != 7 })
+    }
+
+    func testSnapshotIteratorsAndHashCollisionsSurviveMoves() {
+        let values = (0..<64).map { Item($0) }
+        let set = OrderedSet(sequence: values)
+        var snapshot = set.makeIterator()
+        var expected = values
+        for i in 0..<256 {
+            let from = (i * 13) % 64, to = (i * 29 + 3) % 64
+            let item = expected.remove(at: from)
+            expected.insert(item, at: to)
+            set.moveObject(item, toIndex: to)
+            XCTAssertEqual(set.map(ObjectIdentifier.init), expected.map(ObjectIdentifier.init))
+            for (index, value) in expected.enumerated() { XCTAssertEqual(set.index(of: value), index) }
+        }
+        for value in values { XCTAssertTrue(snapshot.next() === value) }
+        XCTAssertNil(snapshot.next())
+    }
+
+    func testAbsentAndSamePositionMovesAreNoOps() {
+        for width in [1, 2, 16, 512] {
+            let set = OrderedSet(sequence: 0..<width)
+            for index in 0..<width {
+                set.moveObject(-1, toIndex: index)
+                set.moveObject(index, toIndex: index)
+                set.moveObject(at: index, to: index)
+            }
+            check(set, Array(0..<width))
+        }
+    }
+
+    func testSeededInterleavedMovesAndCollectionEdits() {
+        let set = OrderedSet(sequence: 0..<40)
+        var expected = Array(0..<40)
+        var seed: UInt64 = 0xE975_20260909
+        func next(_ n: Int) -> Int { seed = seed &* 6364136223846793005 &+ 1; return Int((seed >> 32) % UInt64(n)) }
+        for _ in 0..<2048 {
+            let value = next(96)
+            switch next(5) {
+            case 0:
+                set.append(value)
+                if !expected.contains(value) { expected.append(value) }
+            case 1:
+                set.remove(value)
+                expected.removeAll { $0 == value }
+            case 2:
+                let gap = next(expected.count + 1)
+                set.insert(value, at: gap)
+                if !expected.contains(value) { expected.insert(value, at: gap) }
+            default:
+                if !expected.isEmpty {
+                    let to = next(expected.count)
+                    set.moveObject(value, toIndex: to)
+                    if let from = expected.firstIndex(of: value) {
+                        expected.insert(expected.remove(at: from), at: to)
+                    }
+                }
+            }
+            check(set, expected)
+        }
+    }
+
+    func testElementIdentityAndDOMAreIndependentOfCollectionMoves() throws {
+        let doc = try SwiftSoup.parse("<main><i id=a>A</i><b id=b>B</b><em id=c>C</em></main>")
+        let elements = try doc.select("main > *").array()
+        let set = OrderedSet(sequence: elements)
+        let before = try doc.outerHtml()
+        set.moveObject(elements[2], toIndex: 0)
+        XCTAssertEqual(set.map { $0.id() }, ["c", "a", "b"])
+        try elements[2].tagName("section")
+        set.moveObject(elements[2], toIndex: 2)
+        XCTAssertEqual(set.map(ObjectIdentifier.init), elements.map(ObjectIdentifier.init))
+        try elements[2].tagName("em")
+        XCTAssertEqual(try doc.outerHtml(), before)
+        for (index, element) in elements.enumerated() { XCTAssertEqual(set.index(of: element), index) }
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetOperatorIsolationTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetOperatorIsolationTest.swift
@@ -1,0 +1,62 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetOperatorIsolationTest: XCTestCase {
+    private final class Item: Hashable {
+        let key: Int
+        let payload: String
+        init(_ key: Int, _ payload: String) { self.key = key; self.payload = payload }
+        static func == (lhs: Item, rhs: Item) -> Bool { lhs.key == rhs.key }
+        func hash(into hasher: inout Hasher) { hasher.combine(key) }
+    }
+
+    func testPlusReturnsIndependentSetWithoutMutatingLeftOperand() {
+        let lhs = OrderedSet(sequence: [1, 2, 3])
+        let result = lhs + [3, 4]
+        XCTAssertEqual(Array(lhs), [1, 2, 3])
+        XCTAssertEqual(Array(result), [1, 2, 3, 4])
+        XCTAssertFalse(lhs === result)
+    }
+
+    func testMinusReturnsIndependentSetWithoutMutatingLeftOperand() {
+        let lhs = OrderedSet(sequence: [1, 2, 3])
+        let result = lhs - [2, 9]
+        XCTAssertEqual(Array(lhs), [1, 2, 3])
+        XCTAssertEqual(Array(result), [1, 3])
+        XCTAssertFalse(lhs === result)
+    }
+
+    func testResultsDoNotShareSubsequentMutation() {
+        let lhs = OrderedSet(sequence: [1, 2, 3])
+        let plus = lhs + [4]
+        let minus = lhs - [2]
+        plus.append(5)
+        minus.remove(1)
+        XCTAssertEqual(Array(lhs), [1, 2, 3])
+        XCTAssertEqual(Array(plus), [1, 2, 3, 4, 5])
+        XCTAssertEqual(Array(minus), [3])
+    }
+
+    func testPlusRetainsAppendReplacementSemanticsOnlyInResult() {
+        let original = Item(1, "original")
+        let other = Item(2, "other")
+        let replacement = Item(1, "replacement")
+        let lhs = OrderedSet(sequence: [original, other])
+        let result = lhs + [replacement]
+        XCTAssertTrue(lhs[0] === original)
+        XCTAssertTrue(lhs[1] === other)
+        XCTAssertTrue(result[0] === replacement)
+        XCTAssertTrue(result[1] === other)
+    }
+
+    func testMutatingOperatorsStillMutateInPlace() {
+        var value = OrderedSet(sequence: [1, 2, 3])
+        let identity = value
+        value += [4]
+        XCTAssertTrue(value === identity)
+        XCTAssertEqual(Array(value), [1, 2, 3, 4])
+        value -= [2]
+        XCTAssertTrue(value === identity)
+        XCTAssertEqual(Array(value), [1, 3, 4])
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetSinglePassSubsetTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetSinglePassSubsetTest.swift
@@ -1,0 +1,138 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetSinglePassSubsetTest: XCTestCase {
+    /// A valid single-pass Sequence: every iterator shares one input cursor.
+    private final class Stream<Value>: Sequence, IteratorProtocol {
+        private let values: [Value]
+        private(set) var position = 0
+        private(set) var iteratorCount = 0
+        private(set) var nextCount = 0
+        init(_ values: [Value]) { self.values = values }
+        func makeIterator() -> Stream<Value> { iteratorCount += 1; return self }
+        func next() -> Value? {
+            nextCount += 1
+            guard position < values.count else { return nil }
+            defer { position += 1 }
+            return values[position]
+        }
+    }
+    private final class Item: Hashable {
+        let key: Int
+        let payload: String
+        init(_ key: Int, _ payload: String) { self.key = key; self.payload = payload }
+        static func == (lhs: Item, rhs: Item) -> Bool { lhs.key == rhs.key }
+        func hash(into hasher: inout Hasher) { hasher.combine(0) }
+    }
+    func testSinglePassPermutationsContainTheSameMembers() {
+        let set = OrderedSet(sequence: [1, 2, 3])
+        for values in [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]] {
+            XCTAssertTrue(set.isSubset(of: Stream(values)), "stream: \(values)")
+            XCTAssertEqual(Array(set), [1, 2, 3])
+        }
+    }
+    func testCreatesOneIteratorAndStopsAfterTheLastRequiredMember() {
+        let stream = Stream([99, 3, 99, 1, 99, 2, 100, 101])
+        let set = OrderedSet(sequence: [1, 2, 3])
+        XCTAssertTrue(set.isSubset(of: stream))
+        XCTAssertEqual(stream.iteratorCount, 1)
+        XCTAssertEqual(stream.position, 6)
+        XCTAssertEqual(stream.nextCount, 6)
+        XCTAssertEqual(stream.next(), 100, "must not materialize the unused tail")
+    }
+    func testStandardAnyIteratorCanBeConsumedOnlyOnce() {
+        let permutations = [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
+        for values in permutations {
+            var position = 0
+            let iterator = AnyIterator<Int> {
+                guard position < values.count else { return nil }
+                defer { position += 1 }
+                return values[position]
+            }
+            XCTAssertTrue(OrderedSet(sequence: [1, 2, 3]).isSubset(of: iterator))
+        }
+    }
+    func testEmptyReceiverDoesNotConsumeOrCreateAnIterator() {
+        let stream = Stream([1, 2, 3])
+        XCTAssertTrue(OrderedSet<Int>().isSubset(of: stream))
+        XCTAssertEqual(stream.iteratorCount, 0)
+        XCTAssertEqual(stream.nextCount, 0)
+    }
+    func testMissingMembersAndDuplicateValues() {
+        for values in [[], [0], [1, 1, 1], [3, 2, 2, 9], [9, 9, 9]] {
+            let required = [1, 2, 3]
+            let expected = required.allSatisfy { values.contains($0) }
+            XCTAssertEqual(OrderedSet(sequence: required).isSubset(of: Stream(values)), expected)
+        }
+        for values in [[3, 3, 1, 1, 2, 2], [2, 2, 1, 1, 3, 3], [1, 1, 2, 2, 3, 3]] {
+            XCTAssertTrue(OrderedSet(sequence: [1, 2, 3]).isSubset(of: Stream(values)))
+        }
+    }
+    func testReferenceRepresentativesRemainStoredAndLookupsAreReleased() {
+        let a = Item(1, "original-a"), b = Item(2, "original-b")
+        let set = OrderedSet(sequence: [a, b])
+        var iterator = set.makeIterator()
+        weak var lookup: Item?
+        do {
+            let temporary = Item(1, "lookup")
+            lookup = temporary
+            XCTAssertTrue(set.isSubset(of: [Item(2, "lookup"), temporary]))
+        }
+        XCTAssertNil(lookup)
+        XCTAssertTrue(set[0] === a)
+        XCTAssertTrue(set[1] === b)
+        XCTAssertTrue(iterator.next() === a)
+        XCTAssertTrue(iterator.next() === b)
+        XCTAssertEqual(set.index(of: Item(1, "probe")), 0)
+        XCTAssertEqual(set.index(of: Item(2, "probe")), 1)
+    }
+    func testCanonicalStringEqualityDoesNotRewriteStoredBytes() {
+        let composed = "caf\u{E9}", decomposed = "cafe\u{301}"
+        let set = OrderedSet(sequence: [composed, "日本"])
+        XCTAssertTrue(set.isSubset(of: ["日本", decomposed]))
+        XCTAssertEqual(set.map { Array($0.utf8) }, [Array(composed.utf8), Array("日本".utf8)])
+    }
+    func testGeneratedStreamsMatchAnIndependentArrayMembershipOracle() {
+        // 364 streams, eight subsets, both receiver orders: 5,824 comparisons.
+        for length in 0...5 {
+            var count = 1
+            for _ in 0..<length { count *= 3 }
+            for code in 0..<count {
+                var remaining = code
+                var values: [Int] = []
+                for _ in 0..<length { values.append(remaining % 3); remaining /= 3 }
+                for mask in 0..<8 {
+                    let required = (0..<3).filter { mask & (1 << $0) != 0 }
+                    let expected = required.allSatisfy { values.contains($0) }
+                    for order in [required, Array(required.reversed())] {
+                        let set = OrderedSet(sequence: order)
+                        let stream = Stream(values)
+                        XCTAssertEqual(set.isSubset(of: stream), expected,
+                                       "receiver=\(order), input=\(values)")
+                        XCTAssertEqual(Array(set), order)
+                        XCTAssertLessThanOrEqual(stream.iteratorCount, 1)
+                    }
+                }
+            }
+        }
+    }
+    func testSelfAndRestartableCollectionsRemainSupported() {
+        for width in 0...24 {
+            let values = Array(0..<width)
+            let set = OrderedSet(sequence: values)
+            XCTAssertTrue(set.isSubset(of: set))
+            XCTAssertTrue(set.isSubset(of: values.reversed()))
+            XCTAssertTrue(set.isSubset(of: Set(values)))
+            XCTAssertEqual(set.isSubset(of: values.dropLast()), values.isEmpty)
+            XCTAssertEqual(Array(set), values)
+        }
+    }
+    func testLazyUnboundedInputStopsWhenTheSubsetIsProved() {
+        var requested = 0
+        let input = AnySequence<Int> {
+            AnyIterator { requested += 1; return 42 }
+        }
+        XCTAssertTrue(OrderedSet(sequence: [42]).isSubset(of: input))
+        XCTAssertEqual(requested, 1)
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetSwapIdentityTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetSwapIdentityTest.swift
@@ -1,0 +1,155 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetSwapIdentityTest: XCTestCase {
+    private final class Item: Hashable {
+        let key: Int
+        let payload: String
+        init(_ key: Int, _ payload: String = "stored") { self.key = key; self.payload = payload }
+        static func == (lhs: Item, rhs: Item) -> Bool { lhs.key == rhs.key }
+        func hash(into hasher: inout Hasher) { hasher.combine(0) }
+    }
+
+    private func check(_ set: OrderedSet<Int>, _ expected: [Int],
+                       file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(Array(set), expected, file: file, line: line)
+        XCTAssertEqual(set.count, expected.count, file: file, line: line)
+        for (index, value) in expected.enumerated() {
+            XCTAssertEqual(set.index(of: value), index, file: file, line: line)
+        }
+    }
+
+    func testEqualLookupArgumentsDoNotReplaceStoredRepresentatives() {
+        let a = Item(1), b = Item(2), c = Item(3)
+        let set = OrderedSet(sequence: [a, b, c])
+        set.swapObject(Item(1, "lookup-a"), with: Item(3, "lookup-c"))
+        XCTAssertEqual(set.map(ObjectIdentifier.init), [c, b, a].map(ObjectIdentifier.init))
+        XCTAssertTrue(set[0] === c)
+        XCTAssertTrue(set[2] === a)
+        for (index, item) in [c, b, a].enumerated() {
+            XCTAssertEqual(set.index(of: Item(item.key)), index)
+        }
+    }
+
+    func testEqualKeySelfSwapIsAnIdentityPreservingNoOp() {
+        let stored = Item(1)
+        let set = OrderedSet(sequence: [stored])
+        set.swapObject(Item(1, "left lookup"), with: Item(1, "right lookup"))
+        XCTAssertTrue(set.first === stored)
+        XCTAssertEqual(set.count, 1)
+        XCTAssertEqual(set.index(of: stored), 0)
+    }
+
+    func testTemporaryLookupArgumentsAreNotRetainedBySwapping() {
+        let set = OrderedSet(sequence: [Item(1), Item(2)])
+        weak var firstLookup: Item?
+        weak var secondLookup: Item?
+        do {
+            let a = Item(1, "temporary-a"), b = Item(2, "temporary-b")
+            firstLookup = a; secondLookup = b
+            set.swapObject(a, with: b)
+        }
+        XCTAssertNil(firstLookup)
+        XCTAssertNil(secondLookup)
+        XCTAssertEqual(set.map(\.payload), ["stored", "stored"])
+    }
+
+    func testCanonicalEquivalentLookupPreservesStoredStringBytes() {
+        let stored = "caf\u{E9}", lookup = "cafe\u{301}"
+        XCTAssertEqual(stored, lookup)
+        XCTAssertNotEqual(Array(stored.utf8), Array(lookup.utf8))
+        let set = OrderedSet(sequence: [stored, "日本"])
+        set.swapObject(lookup, with: "日本")
+        XCTAssertEqual(set.map { Array($0.utf8) }, [Array("日本".utf8), Array(stored.utf8)])
+        set.swapObject(lookup, with: stored)
+        XCTAssertEqual(set.map { Array($0.utf8) }, [Array("日本".utf8), Array(stored.utf8)])
+    }
+
+    func testEveryPairIncludingSelfAndMissingKeysPreservesIndices() {
+        for width in 0...32 {
+            for a in -1...width {
+                for b in -1...width {
+                    let set = OrderedSet(sequence: 0..<width)
+                    var expected = Array(0..<width)
+                    if a >= 0, a < width, b >= 0, b < width { expected.swapAt(a, b) }
+                    set.swapObject(a, with: b)
+                    check(set, expected)
+                    set.swapObject(a, with: b)
+                    check(set, Array(0..<width))
+                }
+            }
+        }
+    }
+
+    func testSnapshotIteratorAndDeliberateHashCollisions() {
+        let values = (0..<48).map { Item($0) }
+        let set = OrderedSet(sequence: values)
+        var snapshot = set.makeIterator()
+        var expected = values
+        for i in 0..<192 {
+            let a = (i * 7) % 48, b = (i * 11 + 3) % 48
+            set.swapObject(expected[a], with: expected[b])
+            expected.swapAt(a, b)
+            XCTAssertEqual(set.map(ObjectIdentifier.init), expected.map(ObjectIdentifier.init))
+            for (index, item) in expected.enumerated() { XCTAssertEqual(set.index(of: item), index) }
+        }
+        for item in values { XCTAssertTrue(snapshot.next() === item) }
+        XCTAssertNil(snapshot.next())
+    }
+
+    func testMissingObjectDoesNotReplaceAnEqualPresentRepresentative() {
+        let stored = Item(1)
+        let set = OrderedSet(sequence: [stored])
+        set.swapObject(Item(1, "lookup"), with: Item(2))
+        set.swapObject(Item(2), with: Item(1, "lookup"))
+        XCTAssertTrue(set.first === stored)
+        XCTAssertEqual(set.count, 1)
+        XCTAssertNil(set.index(of: Item(2)))
+    }
+
+    func testSwapsComposeWithAppendReplacementRemovalInsertionAndMoves() {
+        let set = OrderedSet<Int>()
+        var expected: [Int] = []
+        var state: UInt64 = 0x9B05_20260909
+        func next(_ limit: Int) -> Int {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Int((state >> 32) % UInt64(limit))
+        }
+        for _ in 0..<2048 {
+            let a = next(64), b = next(64)
+            switch next(5) {
+            case 0:
+                set.append(a)
+                if !expected.contains(a) { expected.append(a) }
+            case 1:
+                set.remove(a); expected.removeAll { $0 == a }
+            case 2:
+                let gap = next(expected.count + 1)
+                set.insert(a, at: gap)
+                if !expected.contains(a) { expected.insert(a, at: gap) }
+            case 3:
+                if !expected.isEmpty {
+                    let destination = next(expected.count)
+                    set.moveObject(a, toIndex: destination)
+                    if let index = expected.firstIndex(of: a) {
+                        expected.insert(expected.remove(at: index), at: destination)
+                    }
+                }
+            default:
+                set.swapObject(a, with: b)
+                if let first = expected.firstIndex(of: a), let second = expected.firstIndex(of: b) {
+                    expected.swapAt(first, second)
+                }
+            }
+            check(set, expected)
+        }
+        let original = Item(1), replacement = Item(1, "replacement"), other = Item(2)
+        let objects = OrderedSet(sequence: [original, other])
+        objects.append(replacement) // Append intentionally replaces equal representatives.
+        objects.swapObject(replacement, with: other)
+        XCTAssertTrue(objects[1] === replacement)
+        objects.remove(Item(1))
+        XCTAssertEqual(objects.count, 1)
+        XCTAssertTrue(objects[0] === other)
+    }
+}

--- a/Tests/SwiftSoupTests/OrderedSetUpdateTest.swift
+++ b/Tests/SwiftSoupTests/OrderedSetUpdateTest.swift
@@ -1,0 +1,132 @@
+import XCTest
+import SwiftSoup
+
+final class OrderedSetUpdateTest: XCTestCase {
+    private final class Item: Hashable {
+        let key: Int
+        let value: String
+        init(_ key: Int, _ value: String) { self.key = key; self.value = value }
+        static func == (lhs: Item, rhs: Item) -> Bool { lhs.key == rhs.key }
+        func hash(into hasher: inout Hasher) { hasher.combine(0) } // Deliberate collisions.
+    }
+
+    private func assertContents(_ set: OrderedSet<Int>, _ expected: [Int],
+                                file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(Array(set), expected, file: file, line: line)
+        XCTAssertEqual(set.count, expected.count, file: file, line: line)
+        for (index, value) in expected.enumerated() {
+            XCTAssertEqual(set.index(of: value), index, file: file, line: line)
+        }
+    }
+
+    func testDuplicateAppendKeepsPositions() {
+        let set = OrderedSet(sequence: [1, 2, 3, 4])
+        set.append(contentsOf: [4, 2, 1, 3, 2, 4])
+        assertContents(set, [1, 2, 3, 4])
+        set.append(5)
+        assertContents(set, [1, 2, 3, 4, 5])
+    }
+
+    func testEqualIncomingInstanceReplacesBothStoredRepresentatives() {
+        let set = OrderedSet<Item>()
+        weak var old: Item?
+        do {
+            let original = Item(1, "old")
+            old = original
+            set.append(original)
+        }
+        let incoming = Item(1, "new")
+        set.append(incoming)
+        XCTAssertNil(old)
+        XCTAssertEqual(set.count, 1)
+        XCTAssertTrue(set[0] === incoming)
+        XCTAssertEqual(set.index(of: Item(1, "lookup")), 0)
+        set.remove(Item(1, "remove"))
+        XCTAssertTrue(set.isEmpty)
+    }
+
+    func testCollidingKeysKeepOrderAndLatestValue() {
+        let set = OrderedSet<Item>()
+        for i in 0..<32 { set.append(Item(i, "old")) }
+        for i in (0..<32).reversed() { set.append(Item(i, "new")) }
+        XCTAssertEqual(set.map(\.key), Array(0..<32))
+        XCTAssertTrue(set.allSatisfy { $0.value == "new" })
+        for i in stride(from: 0, to: 32, by: 2) { set.remove(Item(i, "remove")) }
+        XCTAssertEqual(set.map(\.key), Array(stride(from: 1, to: 32, by: 2)))
+        for (index, item) in set.enumerated() { XCTAssertEqual(set.index(of: item), index) }
+    }
+
+    func testRemovalOnlyShiftsFollowingPositions() {
+        let set = OrderedSet(sequence: [0, 1, 2, 3, 4, 5])
+        set.remove(0)
+        assertContents(set, [1, 2, 3, 4, 5])
+        set.remove(3)
+        assertContents(set, [1, 2, 4, 5])
+        set.remove(5)
+        set.remove(99)
+        assertContents(set, [1, 2, 4])
+        set.remove(set)
+        assertContents(set, [])
+        set.append(7)
+        assertContents(set, [7])
+    }
+
+    func testIteratorSnapshotSurvivesUpdates() {
+        let old = Item(1, "old")
+        let set = OrderedSet(sequence: [old, Item(2, "second")])
+        var iterator = set.makeIterator()
+        let replacement = Item(1, "replacement")
+        set.append(replacement)
+        set.remove(Item(2, "lookup"))
+        XCTAssertTrue(iterator.next() === old)
+        XCTAssertEqual(iterator.next()?.key, 2)
+        XCTAssertNil(iterator.next())
+        XCTAssertTrue(set.first === replacement)
+    }
+
+    func testMixedUpdatesMatchArrayReference() {
+        let set = OrderedSet<Int>()
+        var expected: [Int] = []
+        var state: UInt64 = 90207
+        func next(_ upperBound: Int) -> Int {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Int((state >> 32) % UInt64(upperBound))
+        }
+        for _ in 0..<1000 {
+            let value = next(40)
+            switch next(6) {
+            case 0:
+                set.append(value)
+                if !expected.contains(value) { expected.append(value) }
+            case 1:
+                set.remove(value)
+                expected.removeAll { $0 == value }
+            case 2:
+                let index = next(expected.count + 1)
+                set.insert(value, at: index)
+                if !expected.contains(value) { expected.insert(value, at: index) }
+            case 3 where !expected.isEmpty:
+                let index = next(expected.count)
+                set[index] = value
+                if expected[index] != value {
+                    if expected.contains(value) { expected.remove(at: index) }
+                    else { expected[index] = value }
+                }
+            case 4 where !expected.isEmpty:
+                let index = next(expected.count)
+                set.moveObject(value, toIndex: index)
+                if let oldIndex = expected.firstIndex(of: value) {
+                    expected.remove(at: oldIndex)
+                    expected.insert(value, at: index)
+                }
+            default:
+                let other = next(40)
+                set.swapObject(value, with: other)
+                if let first = expected.firstIndex(of: value), let second = expected.firstIndex(of: other) {
+                    expected.swapAt(first, second)
+                }
+            }
+            assertContents(set, expected)
+        }
+    }
+}


### PR DESCRIPTION
Part 2/8 of the SwiftSoup correctness/runtime reconciliation from lake-of-fire/SwiftSoup. Depends on #412. This PR targets that topic branch so its diff is incremental; review/merge the stack in order and retarget to master as prerequisites land.

First makes Node/Element hashes stable under content/tag mutation, as required by dictionary-backed membership. Fixes OrderedSet container aliasing in +/-, preserves stored representatives during moves/swaps, honors single-pass sequences and specialized Collection membership, and shifts affected storage once for insertion/moves. Existing explicit mutating operators retain their behavior. Regression tests cover identity, optional values, sequence consumption, insertion, and moves.

Validation: `swift test -c release --jobs 2` on Apple Swift 6.3.3 / arm64 macOS: Executed 736 tests, with 0 failures (0 unexpected) in 12.209 (12.285) seconds.

Built on current upstream `35f7e1b0049236edcc351c0f10e7beddd0d4e76c`; upstream PR #411 and its escaped-ID regression coverage are retained. Source is extracted from the reviewed fork tree `a197bd5620a062f210686541dd38499c1913d342` without importing its merge/publication-workflow history. Exact head: `d52ca7576b8c87ef5f90412a1c70a5b9191bb56c`.

No new performance measurements are claimed for this integration under host load. Historical evidence is kept separate in part 8. This submission does not update upstream master or a release branch.

Stack order: #412 → #413 → #414 → #415 → #416 → #417 → #418 → #419.
