### PR TITLE
Fix Unicode matcher captures and reuse compiled patterns

### DIFF
--- a/Sources/Pattern.swift
+++ b/Sources/Pattern.swift
@@ -10,9 +10,11 @@ import Foundation
 public struct Pattern: Sendable {
     public static let CASE_INSENSITIVE: Int = 0x02
     let pattern: String
+    private let compiled: Result<NSRegularExpression, Error>
 
     init(_ pattern: String) {
         self.pattern = pattern
+        compiled = Result { try NSRegularExpression(pattern: pattern, options: []) }
     }
 
     static public func compile(_ s: String) -> Pattern {
@@ -23,12 +25,12 @@ public struct Pattern: Sendable {
     }
 
     public func validate() throws {
-         _ = try NSRegularExpression(pattern: self.pattern, options: [])
+        _ = try compiled.get()
     }
 
     public func matcher(in text: String) -> Matcher {
         do {
-            let regex = try NSRegularExpression(pattern: self.pattern, options: [])
+            let regex = try compiled.get()
             let nsString = NSString(string: text)
             let results = regex.matches(in: text, options: [], range: NSRange(location: 0, length: nsString.length))
 
@@ -58,15 +60,20 @@ public class  Matcher {
 
     @discardableResult
     public func find() -> Bool {
+        // Stay exhausted after the last match instead of advancing indefinitely.
+        guard index < matches.count else { return false }
         index += 1
-        if(index < matches.count) {
-            return true
-        }
-        return false
+        return index < matches.count
     }
 
+    /// Returns capture `i` from the current match (zero is the entire match).
+    /// Returns nil before a successful `find()`, after exhaustion, for an invalid
+    /// group index, or for an optional group that did not participate. A present
+    /// zero-length capture returns an empty string.
     public func group(_ i: Int) -> String? {
+        guard matches.indices.contains(index) else { return nil }
         let b = matches[index]
+        guard i >= 0 && i < b.numberOfRanges else { return nil }
         #if !os(Linux) && !swift(>=4)
             let c = b.rangeAt(i)
         #else
@@ -74,8 +81,9 @@ public class  Matcher {
         #endif
 
         if(c.location == NSNotFound) {return nil}
-        let result = string.substring(c.location, c.length)
-        return result
+        // Foundation ranges are UTF-16 offsets, not Swift Character offsets.
+        // NSString also preserves scalar captures inside a composed grapheme.
+        return (string as NSString).substring(with: c)
     }
     public func group() -> String? {
         return group(0)

--- a/Tests/SwiftSoupTests/MatcherCaptureRegressionTest.swift
+++ b/Tests/SwiftSoupTests/MatcherCaptureRegressionTest.swift
@@ -1,0 +1,215 @@
+import XCTest
+import Foundation
+import Dispatch
+@testable import SwiftSoup
+
+final class MatcherCaptureRegressionTest: XCTestCase {
+    private func assertCapture(
+        _ matcher: Matcher, _ group: Int, _ expected: String?,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        // String equality hides canonical-equivalence differences. Check bytes.
+        XCTAssertEqual(matcher.group(group).map { Array($0.utf8) },
+                       expected.map { Array($0.utf8) }, file: file, line: line)
+    }
+
+    func testASCIICapturesAtNonzeroOffsets() {
+        let matcher = Pattern.compile("(a)(b+)").matcher(in: "--abb--ab")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "abb")
+        assertCapture(matcher, 1, "a")
+        assertCapture(matcher, 2, "bb")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "ab")
+        assertCapture(matcher, 2, "b")
+    }
+
+    func testJapaneseBMPCaptures() {
+        let matcher = Pattern.compile("(日本)(語)").matcher(in: "前 日本語 後")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "日本語")
+        assertCapture(matcher, 1, "日本")
+        assertCapture(matcher, 2, "語")
+    }
+
+    func testCaptureAfterEmojiPrefixDoesNotTrap() {
+        let matcher = Pattern.compile("(x)").matcher(in: "👩🏽‍💻x")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "x")
+        assertCapture(matcher, 1, "x")
+    }
+
+    func testSupplementaryScalarCaptureUsesUTF16Length() {
+        let matcher = Pattern.compile("(😀)").matcher(in: "😀z")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "😀")
+        assertCapture(matcher, 1, "😀")
+    }
+
+    func testZWJSequenceCanBeCapturedAsSeparateScalars() {
+        let matcher = Pattern.compile("(👩)(🏽)(\u{200D})(💻)").matcher(in: "👩🏽‍💻!")
+        XCTAssertTrue(matcher.find())
+        for (index, expected) in ["👩🏽‍💻", "👩", "🏽", "\u{200D}", "💻"].enumerated() {
+            assertCapture(matcher, index, expected)
+        }
+    }
+
+    func testCombiningMarkCapturesDoNotExpandToWholeGrapheme() {
+        let matcher = Pattern.compile("(e)(\\p{M})").matcher(in: "e\u{301}x")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "e\u{301}")
+        assertCapture(matcher, 1, "e")
+        assertCapture(matcher, 2, "\u{301}")
+    }
+
+    func testFlagCanBeCapturedAsSeparateRegionalIndicators() {
+        let matcher = Pattern.compile("(🇯)(🇵)").matcher(in: "🇯🇵x")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "🇯🇵")
+        assertCapture(matcher, 1, "🇯")
+        assertCapture(matcher, 2, "🇵")
+    }
+
+    func testCRLFCapturesKeepExactCodeUnits() {
+        let matcher = Pattern.compile("(\r)(\n)").matcher(in: "\r\nx")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "\r\n")
+        assertCapture(matcher, 1, "\r")
+        assertCapture(matcher, 2, "\n")
+    }
+
+    func testZeroWidthMatchInsideGraphemeRemainsPresent() {
+        let matcher = Pattern.compile("(?=(\u{301}))").matcher(in: "e\u{301}x")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "")
+        assertCapture(matcher, 1, "\u{301}")
+    }
+
+    func testZeroWidthMatchAtUnicodeEnd() {
+        let matcher = Pattern.compile("$").matcher(in: "👩🏽‍💻")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "")
+        XCTAssertFalse(matcher.find())
+    }
+
+    func testEmbeddedNULAndUnicodeBytesArePreserved() {
+        let matcher = Pattern.compile("(日\0😀)").matcher(in: "前日\0😀後")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "日\0😀")
+        assertCapture(matcher, 1, "日\0😀")
+    }
+
+    func testUnmatchedOptionalAndPresentEmptyGroupsStayDistinct() {
+        let matcher = Pattern.compile("(a)?()").matcher(in: "")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 0, "")
+        assertCapture(matcher, 1, nil)
+        assertCapture(matcher, 2, "")
+        assertCapture(matcher, 1, nil)
+        assertCapture(matcher, 2, "")
+    }
+
+    func testGroupBeforeFindReturnsNilWithoutAdvancing() {
+        let matcher = Pattern.compile("(x)").matcher(in: "x")
+        XCTAssertNil(matcher.group())
+        assertCapture(matcher, 1, nil)
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 1, "x")
+    }
+
+    func testNoMatchAndRepeatedFailedFindRemainSafe() {
+        let matcher = Pattern.compile("x").matcher(in: "日本")
+        XCTAssertEqual(matcher.count, 0)
+        XCTAssertNil(matcher.group())
+        for _ in 0..<128 {
+            XCTAssertFalse(matcher.find())
+            assertCapture(matcher, 0, nil)
+        }
+    }
+
+    func testExhaustionDoesNotExposePreviousCapture() {
+        let matcher = Pattern.compile("(x)").matcher(in: "x")
+        XCTAssertTrue(matcher.find())
+        assertCapture(matcher, 1, "x")
+        for _ in 0..<128 {
+            XCTAssertFalse(matcher.find())
+            XCTAssertNil(matcher.group())
+            assertCapture(matcher, 1, nil)
+        }
+        XCTAssertEqual(matcher.count, 1)
+    }
+
+    func testInvalidGroupIndicesDoNotTrapOrMoveCursor() {
+        let matcher = Pattern.compile("(x)").matcher(in: "x")
+        XCTAssertTrue(matcher.find())
+        for group in [Int.min, -1, 2, 3, Int.max] {
+            assertCapture(matcher, group, nil)
+            assertCapture(matcher, 1, "x")
+        }
+        XCTAssertFalse(matcher.find())
+    }
+
+    func testSourceSnapshotAndCopiedPatternMatchersAreIndependent() {
+        var source = "😀x"
+        let pattern = Pattern.compile("(x|日)")
+        let copy = pattern
+        let first = pattern.matcher(in: source)
+        let second = copy.matcher(in: "e\u{301}日")
+        source = "replacement"
+        XCTAssertTrue(first.find())
+        assertCapture(first, 1, "x")
+        XCTAssertTrue(second.find())
+        assertCapture(second, 1, "日")
+        XCTAssertFalse(first.find())
+        assertCapture(second, 1, "日")
+        XCTAssertEqual(source, "replacement")
+    }
+
+    func testConcurrentPatternReuseWithIndependentUnicodeCaptures() {
+        final class Failures: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+            func record() { lock.lock(); value += 1; lock.unlock() }
+            var count: Int { lock.lock(); defer { lock.unlock() }; return value }
+        }
+        let failures = Failures()
+        let pattern = Pattern.compile("(日|x)")
+        DispatchQueue.concurrentPerform(iterations: 128) { index in
+            let expected = index.isMultiple(of: 2) ? "日" : "x"
+            let matcher = pattern.matcher(in: "👩🏽‍💻" + expected)
+            if !matcher.find() || matcher.group(1).map({ Array($0.utf8) }) != Array(expected.utf8)
+                || matcher.find() || matcher.group() != nil {
+                failures.record()
+            }
+        }
+        XCTAssertEqual(failures.count, 0)
+    }
+
+    func testGeneratedCapturesMatchIndependentUTF16SliceOracle() throws {
+        let fragments = ["", "日本", "😀", "👩🏽‍💻", "e\u{301}", "é", "🇯🇵", "\r\n", "a\0b", "\u{600}x", "क्‍ष", "\u{10FFFF}"]
+        let patterns = ["(.)", "(\\X)", "(\\p{L}+)(\\p{M}*)", "(a)?(b|日|😀)",
+                        "(?=(.))", "^|$", "(e)(\u{301})", "(\r)(\n)"]
+        for source in patterns {
+            let pattern = Pattern.compile(source)
+            let reference = try NSRegularExpression(pattern: source)
+            for seed in 0..<128 {
+                let input = fragments[seed % fragments.count]
+                    + fragments[(seed * 7 + 3) % fragments.count] + "ab" + String(seed)
+                let units = Array(input.utf16)
+                let expected = reference.matches(in: input, range: NSRange(location: 0, length: units.count))
+                let matcher = pattern.matcher(in: input)
+                XCTAssertEqual(matcher.count, expected.count)
+                for match in expected {
+                    XCTAssertTrue(matcher.find())
+                    for group in 0..<match.numberOfRanges {
+                        let range = match.range(at: group)
+                        let text: String? = range.location == NSNotFound ? nil
+                            : String(decoding: units[range.location..<(range.location + range.length)], as: UTF16.self)
+                        assertCapture(matcher, group, text)
+                    }
+                }
+                XCTAssertFalse(matcher.find())
+            }
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/PatternReuseTest.swift
+++ b/Tests/SwiftSoupTests/PatternReuseTest.swift
@@ -1,0 +1,139 @@
+import XCTest
+import Foundation
+import Dispatch
+@testable import SwiftSoup
+
+final class PatternReuseTest: XCTestCase {
+    func testRepeatedMatchesAgreeWithFoundationRanges() throws {
+        let patterns = ["[a-z]+", "(?i)(ab)+", "(?m)^.+$", "(?=a)", "(a)?b", "日本語|😀|é", "\\p{L}+", "^$", "a*", "(.)\\1"]
+        let inputs = ["", "a ab abab", "abc\ndef\n", "bbb", "😀 日本語 e\u{301} é", "aa cc 123"]
+        for source in patterns {
+            let pattern = Pattern.compile(source)
+            let reference = try NSRegularExpression(pattern: source)
+            for _ in 0..<3 {
+                try pattern.validate()
+                XCTAssertEqual(pattern.toString(), source)
+                for input in inputs {
+                    let expected = reference.matches(in: input, range: NSRange(location: 0, length: (input as NSString).length))
+                    let actual = pattern.matcher(in: input)
+                    XCTAssertEqual(actual.count, expected.count)
+                    for (lhs, rhs) in zip(actual.matches, expected) {
+                        XCTAssertEqual(lhs.numberOfRanges, rhs.numberOfRanges)
+                        for group in 0..<rhs.numberOfRanges {
+                            XCTAssertEqual(lhs.range(at: group), rhs.range(at: group))
+                        }
+                    }
+                    var found = 0
+                    while actual.find() { found += 1 }
+                    XCTAssertEqual(found, expected.count)
+                    XCTAssertFalse(actual.find())
+                    XCTAssertEqual(actual.count, expected.count)
+                }
+            }
+        }
+    }
+
+    func testCopiesAndMatchersHaveIndependentCursors() throws {
+        let original = Pattern.compile("(a)?b")
+        let copy = original
+        let first = original.matcher(in: "ab b")
+        let second = copy.matcher(in: "b ab")
+        XCTAssertTrue(first.find())
+        XCTAssertEqual(first.group(), "ab")
+        XCTAssertEqual(first.group(1), "a")
+        XCTAssertTrue(second.find())
+        XCTAssertEqual(second.group(), "b")
+        XCTAssertNil(second.group(1))
+        try copy.validate()
+        XCTAssertTrue(first.find())
+        XCTAssertEqual(first.group(), "b")
+        XCTAssertNil(first.group(1))
+        XCTAssertFalse(first.find())
+        XCTAssertTrue(second.find())
+        XCTAssertEqual(second.group(1), "a")
+        XCTAssertFalse(second.find())
+    }
+
+    func testInvalidPatternRemainsNonthrowingUntilValidation() {
+        for source in ["[", "(", "*", "\\"] {
+            let pattern = Pattern.compile(source)
+            XCTAssertEqual(pattern.toString(), source)
+            let nativeError: NSError
+            do {
+                _ = try NSRegularExpression(pattern: source)
+                XCTFail("Fixture must be invalid")
+                continue
+            } catch { nativeError = error as NSError }
+            for _ in 0..<3 {
+                XCTAssertThrowsError(try pattern.validate()) { error in
+                    XCTAssertEqual((error as NSError).domain, nativeError.domain)
+                    XCTAssertEqual((error as NSError).code, nativeError.code)
+                }
+                let matcher = pattern.matcher(in: "input")
+                XCTAssertEqual(matcher.count, 0)
+                XCTAssertFalse(matcher.find())
+            }
+        }
+    }
+
+    func testPreservesExistingOptionOverloadAndEmbeddedFlags() {
+        // The legacy Int overload currently ignores its option. This optimization
+        // must not silently turn a performance change into an API behavior change.
+        XCTAssertFalse(Pattern.compile("abc", Pattern.CASE_INSENSITIVE).matcher(in: "ABC").find())
+        XCTAssertTrue(Pattern.compile("(?i)abc").matcher(in: "ABC").find())
+    }
+
+    func testZeroWidthMatchesRemainEagerAndComplete() {
+        let pattern = Pattern.compile("(?=a)")
+        let matcher = pattern.matcher(in: "aaa")
+        XCTAssertEqual(matcher.count, 3)
+        for _ in 0..<3 {
+            XCTAssertTrue(matcher.find())
+            XCTAssertEqual(matcher.group(), "")
+        }
+        XCTAssertFalse(matcher.find())
+        XCTAssertFalse(pattern.matcher(in: "bbb").find())
+    }
+
+    func testSharedPatternAcrossConcurrentInputs() {
+        final class Results: @unchecked Sendable {
+            let lock = NSLock()
+            var failures = 0
+            func fail() { lock.lock(); failures += 1; lock.unlock() }
+        }
+        let results = Results()
+        let pattern = Pattern.compile("^(日本語|word)-[0-9]+$")
+        DispatchQueue.concurrentPerform(iterations: 128) { index in
+            for offset in 0..<16 {
+                let input = index.isMultiple(of: 2) ? "日本語-\(offset)" : "word-\(offset)"
+                if !pattern.matcher(in: input).find() || pattern.matcher(in: "no match").find() {
+                    results.fail()
+                }
+            }
+        }
+        XCTAssertEqual(results.failures, 0)
+    }
+
+    func testRegexSelectorsObserveNewInputsAfterMutation() throws {
+        let document = try SwiftSoup.parse("<main><p id='a' data-probe='word-2'>word-2</p><p id='b' data-probe='word-3'>word-3</p></main>")
+        let pattern = Pattern.compile("^word-(2|4)$")
+        let b = try XCTUnwrap(document.getElementById("b"))
+        for pass in 0..<8 {
+            let value = pass.isMultiple(of: 2) ? "word-3" : "word-4"
+            try b.attr("data-probe", value)
+            try b.text(value)
+            let expected = pass.isMultiple(of: 2) ? ["a"] : ["a", "b"]
+            XCTAssertEqual(try document.getElementsByAttributeValueMatching("data-probe", pattern).array().map { $0.id() }, expected)
+            XCTAssertEqual(try document.getElementsByAttributeValueMatching("data-probe", pattern.toString()).array().map { $0.id() }, expected)
+            XCTAssertEqual(try document.getElementsMatchingOwnText(pattern).array().map { $0.id() }, expected)
+            XCTAssertEqual(try document.select("p[data-probe~=^word-(2|4)$]").array().map { $0.id() }, expected)
+        }
+    }
+
+    func testPublicRegexOverloadsStillRejectInvalidExpressions() throws {
+        let document = try SwiftSoup.parse("<p data-probe='value'>text</p>")
+        XCTAssertThrowsError(try document.getElementsByAttributeValueMatching("data-probe", "["))
+        XCTAssertThrowsError(try document.getElementsMatchingText("["))
+        XCTAssertThrowsError(try document.getElementsMatchingOwnText("["))
+    }
+}


### PR DESCRIPTION
Part 3/8 of the SwiftSoup correctness/runtime reconciliation from lake-of-fire/SwiftSoup. Depends on #413. This PR targets that topic branch so its diff is incremental; review/merge the stack in order and retarget to master as prerequisites land.

Uses Foundation UTF-16 capture ranges to avoid Unicode crashes, returns nil for invalid/exhausted matcher access, and reuses immutable regex compilation between Pattern matchers. Invalid patterns retain deferred error handling. Tests cover grapheme boundaries, empty captures, invalid access, compilation reuse and concurrency.

Validation: `swift test -c release --jobs 2` on Apple Swift 6.3.3 / arm64 macOS: Executed 763 tests, with 0 failures (0 unexpected) in 15.483 (15.606) seconds.

Built on current upstream `35f7e1b0049236edcc351c0f10e7beddd0d4e76c`; upstream PR #411 and its escaped-ID regression coverage are retained. Source is extracted from the reviewed fork tree `a197bd5620a062f210686541dd38499c1913d342` without importing its merge/publication-workflow history. Exact head: `142836a896b23c35b92c91a489402831956ce769`.

No new performance measurements are claimed for this integration under host load. Historical evidence is kept separate in part 8. This submission does not update upstream master or a release branch.

Stack order: #412 → #413 → #414 → #415 → #416 → #417 → #418 → #419.
