### PR TITLE
Batch entity serialization and skip unnecessary CSS comment scanning

### DIFF
--- a/Sources/Entities.swift
+++ b/Sources/Entities.swift
@@ -71,12 +71,7 @@ public final class Entities: Sendable {
 
     @inline(__always)
     private static func multipointsForName(_ name: ByteSlice) -> [UnicodeScalar]? {
-        for (key, value) in EscapeMode.staticData.multipoints {
-            if compareName(key, name) == 0 {
-                return value
-            }
-        }
-        return nil
+        return EscapeMode.staticData.multipoints[name.toArraySlice()]
     }
     private static let escapeTableAttrHtml: [UInt8] = {
         var table = [UInt8](repeating: 0, count: 256)
@@ -550,7 +545,22 @@ public final class Entities: Sendable {
             if end &- i == 2 && base[i] == StringUtil.utf8NBSPLead && base[i &+ 1] == StringUtil.utf8NBSPTrail {
                 accum.append(escapeMode == .xhtml ? xa0EntityUTF8 : nbspEntityUTF8)
             } else {
-                accum.write(contentsOf: base.advanced(by: i), count: end &- i)
+                // Copy adjacent non-ASCII sequences together. Keep the existing
+                // lead-byte stepping, including for malformed/truncated UTF-8.
+                var runEnd = end
+                while runEnd < count {
+                    let next = base[runEnd]
+                    if next < asciiUpperLimitByte { break }
+                    let nextEnd = min(runEnd &+ utf8CharLength(for: next), count)
+                    if nextEnd &- runEnd == 2 && next == StringUtil.utf8NBSPLead
+                        && base[runEnd &+ 1] == StringUtil.utf8NBSPTrail {
+                        break
+                    }
+                    runEnd = nextEnd
+                }
+                accum.write(contentsOf: base.advanced(by: i), count: runEnd &- i)
+                i = runEnd
+                continue
             }
             i = end
         }

--- a/Sources/Whitelist.swift
+++ b/Sources/Whitelist.swift
@@ -830,6 +830,9 @@ import Foundation
     }
 
     private func stripCSSComments(_ style: String) -> String {
+        // A comment cannot start without an ASCII slash. Leave the existing
+        // quote/escape-aware scanner authoritative whenever one is present.
+        guard style.utf8.contains(0x2F) else { return style }
         var result = ""
         var quote: Character?
         var isEscaped = false

--- a/Tests/SwiftSoupTests/CSSCommentFastPathTest.swift
+++ b/Tests/SwiftSoupTests/CSSCommentFastPathTest.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import SwiftSoup
+
+final class CSSCommentFastPathTest: XCTestCase {
+    private func whitelist() throws -> Whitelist {
+        try Whitelist.none().addTags("p", "span")
+            .addAttributes(":all", "style")
+            .addCSSProperties(":all", "color", "font-weight", "font-family", "content", "width", "background-image", "transform", "behavior", "-moz-binding")
+    }
+
+    private func sanitize(_ value: String, using whitelist: Whitelist? = nil) throws -> String? {
+        let rules = try whitelist ?? self.whitelist()
+        let element = try Element(Tag.valueOf("p"), "")
+        return try rules.safeAttribute("p", element, Attribute(key: "style", value: value))?.getValue()
+    }
+
+    func testSlashFreePropertiesStillFilterAndNormalize() throws {
+        XCTAssertEqual(try sanitize(" COLOR: red; position:absolute; font-weight: bold "), "color:red; font-weight:bold")
+        XCTAssertNil(try sanitize(""))
+        XCTAssertNil(try sanitize("position:absolute"))
+        XCTAssertEqual(try sanitize("transform:translate(10px, calc(100% - 1em)); content:'a;b:c'"),
+                       "transform:translate(10px, calc(100% - 1em)); content:'a;b:c'")
+    }
+
+    func testUnicodeBytesAndQuotedEscapesArePreserved() throws {
+        for value in ["日本語", "cafe\u{301}", "👩🏽‍💻", "∕／⁄", "a\u{00A0}b", "x\\\"y", "a\u{200D}b"] {
+            let style = "content:'\(value)'"
+            XCTAssertEqual(Array(try XCTUnwrap(sanitize(style)).utf8), Array(style.utf8))
+        }
+    }
+
+    func testSlashFreeUnsafeValuesRemainRejected() throws {
+        for value in ["expression(alert(1))", "ExPrEsSiOn (alert(1))", "expre\nssion(alert(1))", "@import 'x'", "url(x)", "u\u{00A0}rl(x)"] {
+            XCTAssertNil(try sanitize("width:\(value)"), value)
+        }
+        XCTAssertNil(try sanitize("behavior:test; -moz-binding:test"))
+    }
+
+    func testCommentsAndCommentLikeQuotedContentRetainOldScanner() throws {
+        XCTAssertEqual(try sanitize("co/*x*/lor:red; /* ; : */ font-weight:bold; content:'a/*not-comment*/b'"),
+                       "color:red; font-weight:bold; content:'a/*not-comment*/b'")
+        XCTAssertEqual(try sanitize("color:red/*unterminated"), "color:red")
+        XCTAssertNil(try sanitize("/*unterminated"))
+        XCTAssertEqual(try sanitize("content:'a/b'; color:red"), "content:'a/b'; color:red")
+        XCTAssertEqual(try sanitize("color:red; width:exp/*x*/ression(alert(1)); background-image:u/*x*/rl(x)"), "color:red")
+    }
+
+    func testSeededSlashFreeStylesAgreeWithForcedCommentScanner() throws {
+        let rules = try whitelist()
+        var state: UInt64 = 0x9624
+        let values = ["red", "日本語", "cafe\u{301}", "'x;y:z'", "calc(100% - 1em)", "expression(1)", "'👩🏽‍💻'", "'a\\\"b'", "u\u{00A0}rl(x)"]
+        let keys = ["color", "content", "font-family", "width", "position"]
+        for _ in 0..<512 {
+            state = state &* 6364136223846793005 &+ 1
+            let key = keys[Int(state % UInt64(keys.count))]
+            let value = values[Int((state >> 16) % UInt64(values.count))]
+            let style = "\(key):\(value); color:blue"
+            // The prefix is stripped by the unchanged scanner. All fixtures
+            // begin with ASCII property names, avoiding grapheme-boundary changes.
+            XCTAssertEqual(try sanitize(style, using: rules), try sanitize("/**/" + style, using: rules))
+        }
+    }
+
+    func testCleaningAndRepeatedRuleChangesDoNotMutateInput() throws {
+        let rules = try whitelist()
+        let document = try SwiftSoup.parse("<p style=\"color:red; position:absolute\">日本語</p><span style=\"content:'a/b'\">x</span>")
+        let original = try document.outerHtml()
+        let cleaner = Cleaner(headWhitelist: nil, bodyWhitelist: rules)
+        let first = try cleaner.clean(document)
+        XCTAssertEqual(try first.select("p").attr("style"), "color:red")
+        try rules.removeCSSProperties(":all", "color")
+        let second = try cleaner.clean(document)
+        XCTAssertFalse(try second.select("p").hasAttr("style"))
+        XCTAssertEqual(try document.outerHtml(), original)
+        XCTAssertEqual(try first.select("p").attr("style"), "color:red")
+    }
+}

--- a/Tests/SwiftSoupTests/EntityEscapeRunTest.swift
+++ b/Tests/SwiftSoupTests/EntityEscapeRunTest.swift
@@ -1,0 +1,157 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class EntityEscapeRunTest: XCTestCase {
+    private let modes = [Entities.EscapeMode.base, .extended, .xhtml]
+
+    // Independent byte oracle for the historical non-normalizing UTF path.
+    // Its deliberately permissive lead-byte stepping also covers malformed input.
+    private func reference(_ bytes: [UInt8], attribute: Bool, xhtml: Bool) -> [UInt8] {
+        var result: [UInt8] = []
+        var i = 0
+        while i < bytes.count {
+            let b = bytes[i]
+            if b < 128 {
+                let replacement: String?
+                switch b {
+                case 38: replacement = "&amp;"
+                case 60 where !attribute || xhtml: replacement = "&lt;"
+                case 62 where !attribute: replacement = "&gt;"
+                case 34 where attribute: replacement = "&quot;"
+                default: replacement = nil
+                }
+                if let replacement { result.append(contentsOf: replacement.utf8) }
+                else { result.append(b) }
+                i += 1
+            } else {
+                let width = b < 224 ? 2 : b < 240 ? 3 : 4
+                let end = min(i + width, bytes.count)
+                if end - i == 2 && b == 194 && bytes[i + 1] == 160 {
+                    result.append(contentsOf: (xhtml ? "&#xa0;" : "&nbsp;").utf8)
+                } else { result.append(contentsOf: bytes[i..<end]) }
+                i = end
+            }
+        }
+        return result
+    }
+
+    private func check(_ bytes: [UInt8], mode: Entities.EscapeMode, attribute: Bool,
+                       encoding: String.Encoding = .utf8, file: StaticString = #filePath, line: UInt = #line) {
+        let expected = reference(bytes, attribute: attribute, xhtml: mode == .xhtml)
+        let settings = OutputSettings().charset(encoding).escapeMode(mode)
+        func assertOutput(_ action: (StringBuilder) -> Void) {
+            let builder = StringBuilder(1)
+            action(builder)
+            XCTAssertEqual(Array(builder.buffer), expected, file: file, line: line)
+        }
+        assertOutput { Entities.escape($0, bytes, settings, attribute, false, false) }
+        let padded: [UInt8] = [255, 34, 60] + bytes + [38, 255]
+        assertOutput { Entities.escape($0, padded[3..<(3 + bytes.count)], settings, attribute, false, false) }
+        for storage in [ByteStorage(array: padded), ByteStorage(data: Data(padded)),
+                        ByteStorage(data: Data([99] + padded).dropFirst())] {
+            let slice = ByteSlice(storage: storage, start: 3, end: 3 + bytes.count)
+            assertOutput { Entities.escape($0, slice, settings, attribute, false, false) }
+        }
+        padded.withUnsafeBufferPointer { buffer in
+            let storage = ByteStorage(buffer: buffer.baseAddress!, count: buffer.count, owner: nil)
+            let slice = ByteSlice(storage: storage, start: 3, end: 3 + bytes.count)
+            assertOutput { Entities.escape($0, slice, settings, attribute, false, false) }
+        }
+    }
+
+    func testUnicodeRunsAcrossSettingsAndStorage() {
+        let texts = ["&", "&日本語東京京都", "&é¢£猫😀e\u{301}👩🏽‍💻",
+                     "&日本語\u{A0}\u{A0}猫<犬>\"鳥\"", "&" + String(repeating: "日本語😀", count: 1024)]
+        for text in texts {
+            for mode in modes {
+                for attribute in [false, true] {
+                    for encoding in [String.Encoding.utf8, .utf16] {
+                        check(Array(text.utf8), mode: mode, attribute: attribute, encoding: encoding)
+                    }
+                }
+            }
+        }
+    }
+
+    func testMalformedAndTruncatedRuns() {
+        var seed: UInt64 = 0x6c616b652d666972
+        for n in 0..<2048 {
+            var bytes: [UInt8] = [38] // Forces the escaping path before any malformed bytes.
+            for _ in 0..<(n % 65) {
+                seed = seed &* 6364136223846793005 &+ 1442695040888963407
+                bytes.append(UInt8(truncatingIfNeeded: seed >> 32))
+            }
+            for mode in modes {
+                for attribute in [false, true] { check(bytes, mode: mode, attribute: attribute) }
+            }
+        }
+    }
+
+    func testEveryLeadByteAtBoundaries() {
+        let suffixes: [[UInt8]] = [[], [38], [160], [34, 60], [194, 160], [38, 60, 62], [255, 255, 255]]
+        for value in 0...255 {
+            for suffix in suffixes {
+                for attribute in [false, true] {
+                    check([38, UInt8(value)] + suffix, mode: .xhtml, attribute: attribute)
+                }
+            }
+        }
+    }
+
+    func testASCIIAndUnchangedPaths() {
+        for text in ["", "no escaping", "日本語猫犬", "👩🏽‍💻 café", "&<>'\"", "\u{A0}"] {
+            for mode in modes {
+                let bytes = Array(text.utf8)
+                for attribute in [false, true] { check(bytes, mode: mode, attribute: attribute) }
+            }
+        }
+        let builder = StringBuilder()
+        Entities.escape(builder, Array("  日本語\t & \n猫".utf8), OutputSettings(), false, true, true)
+        XCTAssertEqual(builder.toString(), "日本語 &amp; 猫")
+    }
+
+    func testReplacementCallbacksAndSnapshots() {
+        final class RecordingBuilder: StringBuilder {
+            var replacements: [[UInt8]] = []
+            override func append(_ value: [UInt8]) -> StringBuilder {
+                replacements.append(value)
+                return super.append(value)
+            }
+        }
+        let builder = RecordingBuilder()
+        _ = builder.append("prefix:")
+        let snapshot = builder.buffer
+        let bytes = Array("&猫犬\u{A0}鳥<魚>\"".utf8)
+        Entities.escape(builder, bytes, OutputSettings().escapeMode(.xhtml), true, false, false)
+        XCTAssertEqual(String(decoding: snapshot, as: UTF8.self), "prefix:")
+        XCTAssertEqual(builder.replacements.map { String(decoding: $0, as: UTF8.self) },
+                       ["&amp;", "&#xa0;", "&lt;", "&quot;"])
+        XCTAssertEqual(builder.toString(), "prefix:&amp;猫犬&#xa0;鳥&lt;魚>&quot;")
+
+        for useByteSlice in [false, true] {
+            let alias = StringBuilder(string: "&猫犬😀<鳥>")
+            let source = alias.buffer
+            let before = Array(source)
+            if useByteSlice {
+                Entities.escape(alias, alias.asByteSlice(), OutputSettings(), false, false, false)
+            } else {
+                Entities.escape(alias, source, OutputSettings(), false, false, false)
+            }
+            XCTAssertEqual(Array(alias.buffer), before + reference(before, attribute: false, xhtml: false))
+            XCTAssertEqual(Array(source), before)
+        }
+    }
+
+    func testRegeneratedTextAndAttributes() throws {
+        let text = "猫犬😀\u{A0}<東京>&京都\""
+        let doc = Document("")
+        doc.outputSettings().prettyPrint(pretty: false).escapeMode(.xhtml)
+        let element = try doc.appendElement("p").text(text).attr("title", text)
+        let expectedText = String(decoding: reference(Array(text.utf8), attribute: false, xhtml: true), as: UTF8.self)
+        let expectedAttribute = String(decoding: reference(Array(text.utf8), attribute: true, xhtml: true), as: UTF8.self)
+        let expected = "<p title=\"\(expectedAttribute)\">\(expectedText)</p>"
+        for _ in 0..<4 { XCTAssertEqual(try element.outerHtml(), expected) }
+        XCTAssertEqual(try Entities.unescape(expectedText), text)
+    }
+}

--- a/Tests/SwiftSoupTests/EntityLookupStorageTest.swift
+++ b/Tests/SwiftSoupTests/EntityLookupStorageTest.swift
@@ -1,0 +1,89 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class EntityLookupStorageTest: XCTestCase {
+    // Parse the repository's declarative entity table without any lookup routine.
+    private func table(_ data: [UInt8]) -> [String: [UnicodeScalar]] {
+        var result: [String: [UnicodeScalar]] = [:]
+        for row in String(decoding: data, as: UTF8.self).split(separator: "\n") {
+            let pair = row.split(separator: "=", maxSplits: 1)
+            let codepoints = pair[1].split(separator: ";", maxSplits: 1)[0]
+            result[String(pair[0])] = codepoints.split(separator: ",").map {
+                UnicodeScalar(UInt32($0, radix: 36)!)!
+            }
+        }
+        return result
+    }
+
+    private func check(_ name: String, expected: [UnicodeScalar]?, extended: Bool,
+                       file: StaticString = #filePath, line: UInt = #line) {
+        let bytes = Array(name.utf8)
+        let padded: [UInt8] = [33, 255, 0] + bytes + [0, 59, 255]
+        for storage in [ByteStorage(array: padded), ByteStorage(data: Data(padded)),
+                        ByteStorage(data: Data([99] + padded).dropFirst())] {
+            let slice = ByteSlice(storage: storage, start: 3, end: 3 + bytes.count)
+            XCTAssertEqual(Entities.lookupNamedEntity(slice, allowExtended: extended), expected, name, file: file, line: line)
+        }
+        padded.withUnsafeBufferPointer { buffer in
+            let storage = ByteStorage(buffer: buffer.baseAddress!, count: buffer.count, owner: nil)
+            let slice = ByteSlice(storage: storage, start: 3, end: 3 + bytes.count)
+            XCTAssertEqual(Entities.lookupNamedEntity(slice, allowExtended: extended), expected, name, file: file, line: line)
+        }
+    }
+
+    func testEveryNamedEntityAcrossStorage() {
+        let expected = table(Entities.full)
+        XCTAssertEqual(expected.count, 2125)
+        for name in expected.keys.sorted() { check(name, expected: expected[name], extended: true) }
+    }
+
+    func testBaseAdmissionAcrossStorage() {
+        let base = table(Entities.base)
+        for name in table(Entities.full).keys.sorted() { check(name, expected: base[name], extended: false) }
+    }
+
+    func testUnknownCaseAndBoundaryNames() {
+        let reference = table(Entities.full)
+        let names = ["", "NotEqualTildeX", "NotEqualTild", "notequaltilde", "NotEqualTilde;", "NotEqualTilde\0",
+                     "NotEqualTilde猫", "CounterClockwiseContourIntegralX", "&amp", " a", String(repeating: "X", count: 128)]
+        for name in names { check(name, expected: reference[name], extended: true) }
+        for name in reference.keys.sorted() {
+            check(name + "X", expected: reference[name + "X"], extended: true)
+            check(String(name.dropLast()), expected: reference[String(name.dropLast())], extended: true)
+        }
+    }
+
+    func testPublicUnescapeAdmissionRules() throws {
+        XCTAssertEqual(try Entities.unescape("&NotEqualTilde;|&CounterClockwiseContourIntegral;"), "\u{2242}\u{338}|\u{2233}")
+        XCTAssertEqual(try Entities.unescape("&NotEqualTilde|&NotEqualTildeX;"), "&NotEqualTilde|&NotEqualTildeX;")
+        XCTAssertEqual(try Entities.unescape(string: "&amp=1 &NotEqualTilde;", strict: true), "&amp=1 \u{2242}\u{338}")
+        XCTAssertEqual(try Entities.unescape(string: "&amp=1 &NotEqualTilde;", strict: false), "&=1 \u{2242}\u{338}")
+        let text = "&NotNestedGreaterGreater;&NotGreaterFullEqual;"
+        XCTAssertEqual(try Entities.unescape(Array(text.utf8)), Array("\u{2aa2}\u{338}\u{2267}\u{338}".utf8))
+    }
+
+    func testPublicStringDataAndBufferParsing() throws {
+        let input = "<p title='&NotEqualTilde; &CounterClockwiseContourIntegral;'>&NotSquareSubset; &NotARealLongEntity;</p>"
+        let bytes = Array(input.utf8)
+        let string = try SwiftSoup.parse(input)
+        let data = try SwiftSoup.parse(Data(bytes))
+        let pointer = try SwiftSoup.parse(withBytes: { parse in try bytes.withUnsafeBufferPointer { try parse($0) } })
+        for document in [string, data, pointer] {
+            let p = try XCTUnwrap(document.select("p").first())
+            XCTAssertEqual(try p.attr("title"), "\u{2242}\u{338} \u{2233}")
+            XCTAssertEqual(try p.text(), "\u{228f}\u{338} &NotARealLongEntity;")
+        }
+    }
+
+    func testRetainedStorageAndRepeatedLookups() {
+        var bytes = Array("xxNotEqualTildeyy".utf8)
+        let storage = ByteStorage(array: bytes)
+        let slice = ByteSlice(storage: storage, start: 2, end: bytes.count - 2)
+        bytes.replaceSubrange(2..<(bytes.count - 2), with: Array("OtherLongName".utf8))
+        for _ in 0..<256 {
+            XCTAssertEqual(Entities.lookupNamedEntity(slice, allowExtended: true), [UnicodeScalar(0x2242)!, UnicodeScalar(0x338)!])
+            XCTAssertNil(Entities.lookupNamedEntity(slice, allowExtended: false))
+        }
+    }
+}


### PR DESCRIPTION
Part 4/8 of the SwiftSoup correctness/runtime reconciliation from lake-of-fire/SwiftSoup. Depends on #414. This PR targets that topic branch so its diff is incremental; review/merge the stack in order and retarget to master as prerequisites land.

Batches unchanged Unicode output in entity escaping, uses the existing multipoint-entity lookup dictionary, and skips inline-CSS reconstruction when no slash can introduce a comment. Regression tests retain escaping, decoding, malformed input and cleaning behavior.

Validation: `swift test -c release --jobs 2` on Apple Swift 6.3.3 / arm64 macOS: Executed 781 tests, with 0 failures (0 unexpected) in 11.342 (11.412) seconds.

Built on current upstream `35f7e1b0049236edcc351c0f10e7beddd0d4e76c`; upstream PR #411 and its escaped-ID regression coverage are retained. Source is extracted from the reviewed fork tree `a197bd5620a062f210686541dd38499c1913d342` without importing its merge/publication-workflow history. Exact head: `c9963eea9f21a4f013f992d83fddbcb225ec9387`.

No new performance measurements are claimed for this integration under host load. Historical evidence is kept separate in part 8. This submission does not update upstream master or a release branch.

Stack order: #412 → #413 → #414 → #415 → #416 → #417 → #418 → #419.
