### PR TITLE
Preserve token boundaries and batch byte and text operations

### DIFF
--- a/Sources/ByteSlice.swift
+++ b/Sources/ByteSlice.swift
@@ -159,6 +159,13 @@ struct ByteSlice: RandomAccessCollection, Hashable, Sendable {
     func withUnsafeBufferPointer<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R {
         return try withUnsafeBytes(body)
     }
+
+    /// All backing stores expose contiguous bytes for the duration of the closure.
+    @usableFromInline
+    @inline(__always)
+    func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R? {
+        return try withUnsafeBytes(body)
+    }
 }
 
 extension ByteSlice {
@@ -169,45 +176,37 @@ extension ByteSlice {
 
     @inline(__always)
     func lowercased() -> ByteSlice {
-        var needsLower = false
-        for b in self {
-            if b >= 65 && b <= 90 { needsLower = true; break }
-        }
-        if !needsLower { return self }
-        var out: [UInt8] = []
-        out.reserveCapacity(count)
-        for b in self {
-            if b >= 65 && b <= 90 {
-                out.append(b + 32)
-            } else {
-                out.append(b)
+        return withUnsafeBytes { bytes in
+            guard let firstUppercase = bytes.firstIndex(where: { $0 >= 65 && $0 <= 90 }) else {
+                return self
             }
+            var lowered = Array(bytes)
+            for index in firstUppercase..<lowered.count {
+                let byte = lowered[index]
+                if byte >= 65 && byte <= 90 {
+                    lowered[index] = byte + 32
+                }
+            }
+            return ByteSlice.fromArray(lowered)
         }
-        let storage = ByteStorage(array: out)
-        return ByteSlice(storage: storage, start: 0, end: out.count)
     }
 
     @inline(__always)
     func trim() -> ByteSlice {
-        @inline(__always)
-        func isWhitespace(_ byte: UInt8) -> Bool {
-            return byte == TokeniserStateVars.spaceByte ||
-                (byte >= TokeniserStateVars.tabByte && byte <= TokeniserStateVars.carriageReturnByte)
+        return withUnsafeBytes { bytes in
+            @inline(__always)
+            func isWhitespace(_ byte: UInt8) -> Bool {
+                return byte == TokeniserStateVars.spaceByte ||
+                    (byte >= TokeniserStateVars.tabByte && byte <= TokeniserStateVars.carriageReturnByte)
+            }
+            var lower = 0
+            var upper = bytes.count
+            while lower < upper, isWhitespace(bytes[lower]) { lower += 1 }
+            while lower < upper, isWhitespace(bytes[upper - 1]) { upper -= 1 }
+            return self[lower..<upper]
         }
-
-        var s = start
-        var e = end
-        var trimmed = false
-        while s < e, isWhitespace(storage.byte(at: s)) {
-            s &+= 1
-            trimmed = true
-        }
-        while s < e, isWhitespace(storage.byte(at: e - 1)) {
-            e &-= 1
-            trimmed = true
-        }
-        return trimmed ? ByteSlice(storage: storage, start: s, end: e) : self
     }
+
 }
 
 extension ByteSlice {
@@ -230,20 +229,22 @@ extension ByteSlice {
     @inline(__always)
     static func == (lhs: ByteSlice, rhs: ByteSlice) -> Bool {
         if lhs.count != rhs.count { return false }
-        var i = lhs.startIndex
-        while i < lhs.endIndex {
-            if lhs[i] != rhs[i] { return false }
-            i = lhs.index(after: i)
+        return lhs.withUnsafeBytes { left in
+            rhs.withUnsafeBytes { right in
+                for index in 0..<left.count {
+                    if left[index] != right[index] { return false }
+                }
+                return true
+            }
         }
-        return true
     }
 
     @usableFromInline
     @inline(__always)
     func hash(into hasher: inout Hasher) {
         hasher.combine(count)
-        for b in self {
-            hasher.combine(b)
+        withUnsafeBytes { bytes in
+            hasher.combine(bytes: UnsafeRawBufferPointer(bytes))
         }
     }
 }

--- a/Sources/CharacterExt.swift
+++ b/Sources/CharacterExt.swift
@@ -51,6 +51,14 @@ extension Character {
     /// - returns: `true` if `self` normalized contains a single code unit that is a member of the supplied character set.
     func isMemberOfCharacterSet(_ set: CharacterSet) -> Bool {
 
+        // A single ASCII scalar is already canonically normalized. Do not use
+        // Character.asciiValue: it also maps the two-scalar CRLF Character to LF.
+        let scalars = unicodeScalars
+        if let scalar = scalars.first, scalar.value < 0x80,
+           scalars.index(after: scalars.startIndex) == scalars.endIndex {
+            return set.contains(scalar)
+        }
+
         let normalized = String(self).precomposedStringWithCanonicalMapping
         let unicodes = normalized.unicodeScalars
 

--- a/Sources/String.swift
+++ b/Sources/String.swift
@@ -348,24 +348,22 @@ extension String {
         return self.hasPrefix(string)
     }
     
-	func indexOf(_ substring: String, _ offset: Int ) -> Int {
-        if(offset > count) {return -1}
-
-        let maxIndex = self.count - substring.count
-        if(maxIndex >= 0) {
-            for index in offset...maxIndex {
-                let rangeSubstring = self.index(self.startIndex, offsetBy: index)..<self.index(self.startIndex, offsetBy: index + substring.count)
-                #if swift(>=4)
-                let selfSubstring = self[rangeSubstring]
-                #else
-                let selfSubstring = self.substring(with: rangeSubstring)
-                #endif
-                if selfSubstring == substring {
-                    return index
-                }
-            }
+    func indexOf(_ substring: String, _ offset: Int) -> Int {
+        // Offsets and candidate windows remain Character-based. Advance the
+        // two bounds instead of rescanning from startIndex for every window.
+        guard offset >= 0,
+              var lower = index(startIndex, offsetBy: offset, limitedBy: endIndex),
+              var upper = index(lower, offsetBy: substring.count, limitedBy: endIndex) else {
+            return -1
         }
-        return -1
+        var position = offset
+        while true {
+            if self[lower..<upper] == substring { return position }
+            guard upper < endIndex else { return -1 }
+            formIndex(after: &lower)
+            formIndex(after: &upper)
+            position += 1
+        }
     }
 
     @inline(__always)
@@ -468,35 +466,37 @@ extension String {
         otherOffset: Int,
         targetLength: Int
     ) -> Bool {
-        if ((otherOffset < 0) || (selfOffset < 0)
-            || (selfOffset > self.count - targetLength)
-            || (otherOffset > other.count - targetLength)) {
+        guard selfOffset >= 0, otherOffset >= 0, targetLength >= 0,
+              var lhs = index(startIndex, offsetBy: selfOffset, limitedBy: endIndex),
+              var rhs = other.index(other.startIndex, offsetBy: otherOffset, limitedBy: other.endIndex) else {
             return false
         }
-
-        for i in 0..<targetLength {
-            let charSelf: Character = self[i + selfOffset]
-            let charOther: Character = other[i + otherOffset]
+        // Keep Character equality and per-Character case folding. Advance each
+        // cursor once instead of reconstructing it from the start per comparison.
+        for _ in 0..<targetLength {
+            guard lhs != endIndex, rhs != other.endIndex else { return false }
+            let charSelf = self[lhs]
+            let charOther = other[rhs]
             if ignoreCase {
-                if charSelf.lowercase != charOther.lowercase {
-                    return false
-                }
+                if charSelf.lowercase != charOther.lowercase { return false }
             } else if charSelf != charOther {
                 return false
             }
+            formIndex(after: &lhs)
+            other.formIndex(after: &rhs)
         }
         return true
     }
 
     @inline(__always)
     func startsWith(_ input: String, _ offset: Int) -> Bool {
-        if ((offset < 0) || (offset > count - input.count)) {
+        guard offset >= 0,
+              var cursor = index(startIndex, offsetBy: offset, limitedBy: endIndex) else {
             return false
         }
-        for i in 0..<input.count {
-            let charSelf: Character = self[i + offset]
-            let charOther: Character = input[i]
-            if charSelf != charOther { return false }
+        for expected in input {
+            guard cursor != endIndex, self[cursor] == expected else { return false }
+            formIndex(after: &cursor)
         }
         return true
     }

--- a/Sources/StringUtil.swift
+++ b/Sources/StringUtil.swift
@@ -354,13 +354,18 @@ open class StringUtil {
      * - returns: if string is blank
      */
     public static func isBlank(_ string: String) -> Bool {
-        if (string.isEmpty) {
-            return true
-        }
+        return isBlankTextBytes(string.utf8)
+    }
 
-        for chr in string {
-            if (!StringUtil.isWhitespace(chr)) {
-                return false
+    // CharacterExt's whitespace set consists only of these ASCII scalars
+    // (including the CRLF Character). Any other byte makes the text nonblank,
+    // including malformed UTF-8, which String(decoding:) would replace.
+    @inline(__always)
+    static func isBlankTextBytes<Bytes: Collection>(_ bytes: Bytes) -> Bool where Bytes.Element == UInt8 {
+        for byte in bytes {
+            switch byte {
+            case 0x09, 0x0A, 0x0C, 0x0D, 0x20: continue
+            default: return false
             }
         }
         return true
@@ -1159,10 +1164,21 @@ open class StringUtil {
             }
             let next = idx &+ scalarByteCount
             if next > count { return }
-            accum.write(contentsOf: basePtr.advanced(by: idx), count: scalarByteCount)
+            // Batch adjacent non-ASCII sequences that need no whitespace rewrite.
+            // Preserve the existing lead-byte stepping and truncated-tail behavior.
+            var runEnd = next
+            while runEnd < count {
+                let lead = basePtr[runEnd]
+                if lead < TokeniserStateVars.asciiUpperLimitByte { break }
+                if lead == utf8NBSPLead && runEnd + 1 < count && basePtr[runEnd + 1] == utf8NBSPTrail { break }
+                let width = lead < utf8Lead3Min ? 2 : (lead < utf8Lead4Min ? 3 : 4)
+                if width > count - runEnd { break }
+                runEnd += width
+            }
+            accum.write(contentsOf: basePtr.advanced(by: idx), count: runEnd - idx)
             lastWasWhite = false
             reachedNonWhite = true
-            idx = next
+            idx = runEnd
         }
     }
 

--- a/Sources/TokenQueue.swift
+++ b/Sources/TokenQueue.swift
@@ -210,6 +210,7 @@ open class TokenQueue {
     }
 
     open func consumeToIgnoreCase(_ seq: String) -> String {
+        guard !seq.isEmpty else { return "" }
         let start = pos
         let first = seq.substring(0, 1)
         let canScan = first.lowercased() == first.uppercased() // if first is not cased, use index of
@@ -299,38 +300,66 @@ open class TokenQueue {
      - returns: data matched from the queue
      */
     open func chompBalanced(_ open: Character, _ close: Character) -> String {
-        var start = -1
-        var end = -1
+        return chompBalanced(open, close, preservingDelimiters: false)
+    }
+
+    private func chompBalanced(_ open: Character, _ close: Character, preservingDelimiters: Bool) -> String {
+        let start = queue.index(queue.startIndex, offsetBy: pos)
+        // CSS delimiters are code points. A combining mark can share their
+        // Character, and a Unicode prepend character can absorb a following
+        // closer. Preserve the public API's multi-scalar delimiters as well.
+        if open.unicodeScalars.count == 1, close.unicodeScalars.count == 1,
+           let openScalar = open.unicodeScalars.first, let closeScalar = close.unicodeScalars.first {
+            return chompBalanced(in: queue.unicodeScalars, from: start, open: openScalar, close: closeScalar,
+                                 preservingDelimiters: preservingDelimiters)
+        }
+        return chompBalanced(in: queue, from: start, open: open, close: close,
+                             preservingDelimiters: preservingDelimiters)
+    }
+
+    private func chompBalanced<Characters: Collection>(in characters: Characters, from start: String.Index,
+                                                      open: Characters.Element, close: Characters.Element,
+                                                      preservingDelimiters: Bool) -> String
+        where Characters.Index == String.Index,
+              Characters.Element: Equatable & ExpressibleByUnicodeScalarLiteral {
+        var cursor = start
+        var payloadStart: String.Index?
+        var payloadEnd = start
         var depth = 0
-        var last: Character = TokenQueue.empty
-        var inQuote = false
+        var escaped = false
+        var quote: Characters.Element?
 
         repeat {
-            if (isEmpty()) {break}
-            let c = consume()
-            if (last == TokenQueue.empty || last != TokenQueue.ESC) {
-                if ((c=="'" || c=="\"") && c != open) {
-                    inQuote = !inQuote
-                }
-                if (inQuote) {
-                    continue
-                }
-                if (c==open) {
-                    depth+=1
-                    if (start == -1) {
-                        start = pos
-                    }
-                } else if (c==close) {
-                    depth-=1
-                }
+            guard cursor < characters.endIndex else { break }
+            let c = characters[cursor]
+            characters.formIndex(after: &cursor)
+            if escaped {
+                escaped = false
+            } else if c == "\\" {
+                escaped = true
+            } else if let quoteCharacter = quote {
+                if c == quoteCharacter { quote = nil }
+            } else if (c == "'" || c == "\"") && c != open {
+                quote = c
+            } else if c == open {
+                depth += 1
+                if payloadStart == nil { payloadStart = cursor }
+            } else if c == close {
+                depth -= 1
             }
 
-            if (depth > 0 && last != TokenQueue.empty) {
-                end = pos // don't include the outer match pair in the return
+            if depth > 0 && payloadStart != nil {
+                payloadEnd = cursor // don't include the outer match pair
             }
-            last = c
-        } while (depth > 0)
-        return (end >= 0) ? queue.substring(start, end-start) : ""
+        } while depth > 0
+        // A compound selector must retain the actual source spelling, including
+        // partial input. Rebuilding open + payload + close invents a delimiter at
+        // EOF and can bypass the inner numeric parser or change literal content.
+        let result = preservingDelimiters
+            ? String(decoding: queue.utf8[start..<cursor], as: UTF8.self)
+            : payloadStart.map { String(decoding: queue.utf8[$0..<payloadEnd], as: UTF8.self) } ?? ""
+        advanceCssPosition(from: start, to: cursor)
+        return result
     }
 
     /**
@@ -340,16 +369,19 @@ open class TokenQueue {
      */
     public static func unescape(_ input: String) -> String {
         let out = StringBuilder()
-        var last = empty
-        for c in input {
-            if (c == ESC) {
-                if (last != empty && last == TokenQueue.ESC) {
-                    out.append(c)
-                }
+        var escaped = false
+        // Quote one scalar at a time, including within a Swift grapheme. A run
+        // of backslashes is consumed in pairs; a trailing lone escape is dropped
+        // as before. This is text unescaping, not CSS hexadecimal decoding.
+        for scalar in input.unicodeScalars {
+            if escaped {
+                out.appendCodePoint(scalar)
+                escaped = false
+            } else if scalar == "\\" {
+                escaped = true
             } else {
-                out.append(c)
+                out.appendCodePoint(scalar)
             }
-            last = c
         }
         return out.toString()
     }
@@ -410,29 +442,241 @@ open class TokenQueue {
     }
 
     /**
-     Consume a CSS identifier (ID or class) off the queue (letter, digit, `-`, `_`)
-     http://www.w3.org/TR/CSS2/syndata.html#value-def-identifier
+     Consume a CSS identifier (ID or class), decoding simple and hexadecimal escapes.
+     Hex escapes consume one to six digits and one optional CSS whitespace terminator.
+     https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point
      - returns: identifier
      */
     open func consumeCssIdentifier() -> String {
+        let start = queue.index(queue.startIndex, offsetBy: pos)
+        var cursor = start
+        let bytes = queue.utf8
         let accum = StringBuilder()
-        while !isEmpty() {
-            let c = queue.charAt(pos)
-            if c == TokenQueue.ESC {
-                pos += 1
-                if !isEmpty() {
-                    accum.append(queue.charAt(pos))
-                    pos += 1
+        while cursor < bytes.endIndex {
+            let byte = bytes[cursor]
+            if byte == 0x5C { // backslash
+                let escape = cssEscape(at: cursor)
+                if let scalar = escape.scalar {
+                    accum.appendCodePoint(scalar)
+                } else {
+                    // Preserve the existing handling of non-hex escapes and a trailing backslash.
+                    for byte in bytes[bytes.index(after: cursor)..<escape.end] {
+                        accum.append(byte)
+                    }
                 }
-            } else if Character.isLetterOrDigit(c) || c == "-" || c == "_" {
-                accum.append(c)
-                pos += 1
+                cursor = escape.end
+            } else if (byte >= 0x30 && byte <= 0x39) ||
+                        (byte >= 0x41 && byte <= 0x5A) ||
+                        (byte >= 0x61 && byte <= 0x7A) ||
+                        byte == 0x2D || byte == 0x5F || byte >= 0x80 {
+                // CSS permits non-ASCII code points, including combining marks after a hex digit.
+                accum.append(byte)
+                bytes.formIndex(after: &cursor)
             } else {
                 break
             }
         }
-
+        advanceCssPosition(from: start, to: cursor)
         return accum.toString()
+    }
+
+    /// Trim selector padding, not escaped identifier content or non-ASCII code points.
+    internal static func trimCssQuery(_ query: String) -> String {
+        let bytes = query.utf8
+        var start = bytes.startIndex
+        var end = bytes.endIndex
+        while start < end, StringUtil.isAsciiWhitespaceByte(bytes[start]) {
+            bytes.formIndex(after: &start)
+        }
+        while start < end {
+            let previous = bytes.index(before: end)
+            guard StringUtil.isAsciiWhitespaceByte(bytes[previous]) else { break }
+            end = previous
+        }
+        if end < bytes.endIndex {
+            // An odd run of backslashes escapes the first trailing whitespace
+            // code point. Further whitespace is padding. Preserve legacy CRLF
+            // escapes as a pair, just as cssEscape(at:) does.
+            var cursor = end
+            var escaped = false
+            while cursor > start {
+                let previous = bytes.index(before: cursor)
+                guard bytes[previous] == 0x5C else { break }
+                escaped.toggle()
+                cursor = previous
+            }
+            if escaped {
+                let first = bytes[end]
+                bytes.formIndex(after: &end)
+                if first == 0x0D, end < bytes.endIndex, bytes[end] == 0x0A {
+                    bytes.formIndex(after: &end)
+                }
+            }
+        }
+        if start == bytes.startIndex && end == bytes.endIndex { return query }
+        return String(decoding: bytes[start..<end], as: UTF8.self)
+    }
+
+    /// Consume an ASCII ID/class marker even when a following combining mark
+    /// shares its Swift Character. CSS syntax operates on code points.
+    internal func matchChompCssIdentifierPrefix(_ prefix: UInt8) -> Bool {
+        let start = queue.index(queue.startIndex, offsetBy: pos)
+        let bytes = queue.utf8
+        guard start < bytes.endIndex, bytes[start] == prefix else { return false }
+        advanceCssPosition(from: start, to: bytes.index(after: start))
+        return true
+    }
+
+    /// Consume a compound selector up to its next unescaped combinator.
+    /// Scan raw bytes so Unicode graphemes cannot swallow ASCII syntax.
+    internal func consumeCssSubQuery() -> String {
+        var result = ""
+        while !isEmpty() {
+            let start = queue.index(queue.startIndex, offsetBy: pos)
+            let bytes = queue.utf8
+            let byte = bytes[start]
+            if byte == 0x5C {
+                result.append(consumeCssEscapeSequence())
+            } else if byte == 0x28 || byte == 0x5B {
+                let open: Character = byte == 0x28 ? "(" : "["
+                let close: Character = byte == 0x28 ? ")" : "]"
+                result.append(chompBalanced(open, close, preservingDelimiters: true))
+            } else if TokenQueue.isCssSubQueryBoundary(byte) {
+                break
+            } else {
+                var end = bytes.index(after: start)
+                while end < bytes.endIndex, !TokenQueue.isCssSubQueryBoundary(bytes[end]) {
+                    bytes.formIndex(after: &end)
+                }
+                result.append(String(decoding: bytes[start..<end], as: UTF8.self))
+                advanceCssPosition(from: start, to: end)
+            }
+        }
+        return result
+    }
+
+    private static func isCssSubQueryBoundary(_ byte: UInt8) -> Bool {
+        if StringUtil.isAsciiWhitespaceByte(byte) { return true }
+        switch byte {
+        case 0x5C, 0x28, 0x5B, 0x2C, 0x3E, 0x2B, 0x7E: return true
+        default: return false
+        }
+    }
+
+    /// Preserve an entire escape while splitting a selector. Its optional whitespace is not a combinator.
+    internal func consumeCssEscapeSequence() -> String {
+        let start = queue.index(queue.startIndex, offsetBy: pos)
+        guard start < queue.endIndex, queue.utf8[start] == 0x5C else { return "" }
+        let end = cssEscape(at: start).end
+        let escaped = String(decoding: queue.utf8[start..<end], as: UTF8.self)
+        advanceCssPosition(from: start, to: end)
+        return escaped
+    }
+
+    /// Consume a comma-separated CSS selector list without splitting escapes,
+    /// quoted text, attribute selectors, or nested functional expressions.
+    internal func consumeCssSelectorList() -> [String] {
+        var branches: [String] = []
+        var branch = ""
+        var quote: UInt8?
+        while !isEmpty() {
+            let start = queue.index(queue.startIndex, offsetBy: pos)
+            let bytes = queue.utf8
+            let byte = bytes[start]
+            if byte == 0x5C { // backslash
+                branch += consumeCssEscapeSequence()
+            } else if let openQuote = quote {
+                let end = queue.unicodeScalars.index(after: start)
+                branch += String(decoding: bytes[start..<end], as: UTF8.self)
+                advanceCssPosition(from: start, to: end)
+                if byte == openQuote { quote = nil }
+            } else if byte == 0x22 || byte == 0x27 { // double or single quote
+                quote = byte
+                let end = queue.unicodeScalars.index(after: start)
+                branch += String(decoding: bytes[start..<end], as: UTF8.self)
+                advanceCssPosition(from: start, to: end)
+            } else if byte == 0x28 || byte == 0x5B { // ( or [
+                let open: Character = byte == 0x28 ? "(" : "["
+                let close: Character = byte == 0x28 ? ")" : "]"
+                branch += chompBalanced(open, close, preservingDelimiters: true)
+            } else if byte == 0x2C { // comma
+                branches.append(branch)
+                branch = ""
+                let end = bytes.index(after: start)
+                advanceCssPosition(from: start, to: end)
+            } else {
+                // Advance ordinary runs together instead of repeatedly resolving
+                // a Character offset for every scalar in a long selector.
+                var end = bytes.index(after: start)
+                while end < bytes.endIndex {
+                    let next = bytes[end]
+                    if next == 0x5C || next == 0x22 || next == 0x27 ||
+                        next == 0x28 || next == 0x5B || next == 0x2C { break }
+                    bytes.formIndex(after: &end)
+                }
+                branch += String(decoding: bytes[start..<end], as: UTF8.self)
+                advanceCssPosition(from: start, to: end)
+            }
+        }
+        branches.append(branch)
+        return branches
+    }
+
+    /// A nil scalar means a non-hex escape: retain its literal contents after the backslash.
+    private func cssEscape(at start: String.Index) -> (end: String.Index, scalar: UnicodeScalar?) {
+        let bytes = queue.utf8
+        var cursor = bytes.index(after: start)
+        var value: UInt32 = 0
+        var digits = 0
+        while cursor < bytes.endIndex, digits < 6, let digit = TokenQueue.cssHexValue(bytes[cursor]) {
+            value = value * 16 + digit
+            digits += 1
+            bytes.formIndex(after: &cursor)
+        }
+        if digits == 0 {
+            if cursor < bytes.endIndex {
+                let first = bytes[cursor]
+                cursor = queue.unicodeScalars.index(after: cursor)
+                // Retain the legacy non-hex CRLF escape behavior.
+                if first == 0x0D, cursor < bytes.endIndex, bytes[cursor] == 0x0A {
+                    bytes.formIndex(after: &cursor)
+                }
+            }
+            return (cursor, nil)
+        }
+        if cursor < bytes.endIndex {
+            let terminator = bytes[cursor]
+            if StringUtil.isAsciiWhitespaceByte(terminator) {
+                bytes.formIndex(after: &cursor)
+                // CSS preprocessing treats CRLF as one newline, not two terminators.
+                if terminator == 0x0D, cursor < bytes.endIndex, bytes[cursor] == 0x0A {
+                    bytes.formIndex(after: &cursor)
+                }
+            }
+        }
+        let replacement: UnicodeScalar = "\u{FFFD}"
+        return (cursor, value == 0 ? replacement : (UnicodeScalar(value) ?? replacement))
+    }
+
+    @inline(__always)
+    private static func cssHexValue(_ byte: UInt8) -> UInt32? {
+        switch byte {
+        case 0x30...0x39: return UInt32(byte - 0x30)
+        case 0x41...0x46: return UInt32(byte - 0x41 + 10)
+        case 0x61...0x66: return UInt32(byte - 0x61 + 10)
+        default: return nil
+        }
+    }
+
+    private func advanceCssPosition(from start: String.Index, to end: String.Index) {
+        if end.samePosition(in: queue) != nil {
+            pos += queue.distance(from: start, to: end)
+        } else {
+            // An ASCII syntax character can share a grapheme with a following combining mark.
+            // Retain every unconsumed code point when advancing through that grapheme.
+            queue = String(decoding: queue.utf8[end...], as: UTF8.self)
+            pos = 0
+        }
     }
 
     /**

--- a/Tests/SwiftSoupTests/ByteSliceBufferTest.swift
+++ b/Tests/SwiftSoupTests/ByteSliceBufferTest.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import SwiftSoup
+
+final class ByteSliceBufferTest: XCTestCase {
+    private final class Owner {
+        let pointer: UnsafeMutablePointer<UInt8>
+        let count: Int
+        init(_ bytes: [UInt8]) {
+            count = bytes.count
+            pointer = .allocate(capacity: max(count, 1))
+            for (index, byte) in bytes.enumerated() { pointer.advanced(by: index).initialize(to: byte) }
+        }
+        deinit { pointer.deinitialize(count: count); pointer.deallocate() }
+    }
+
+    private func views(_ bytes: [UInt8], offset: Int) -> [ByteSlice] {
+        let padded = Array(repeating: UInt8(253), count: offset) + bytes + [254, 255]
+        let owner = Owner(padded)
+        let storages = [ByteStorage(array: padded), ByteStorage(data: Data(padded)),
+                        ByteStorage(buffer: UnsafePointer(owner.pointer), count: padded.count, owner: owner)]
+        var result = storages.map { ByteSlice(storage: $0, start: offset, end: offset + bytes.count) }
+        let nonzeroData = Data([1, 2, 3] + padded).dropFirst(3)
+        result.append(ByteSlice(storage: ByteStorage(data: nonzeroData), start: offset, end: offset + bytes.count))
+        result.append(ByteSlice.fromArray([42] + bytes + [43])[1..<(bytes.count + 1)])
+        return result
+    }
+
+    func testEqualViewsHashIdenticallyAcrossStorageAndOffsets() {
+        for length in [0, 1, 2, 7, 8, 15, 16, 17, 31, 32, 63, 64, 65, 255, 256, 257] {
+            let bytes = (0..<length).map { UInt8(truncatingIfNeeded: $0 &* 37) }
+            for offset in 0..<8 {
+                let slices = views(bytes, offset: offset)
+                let referenceHash = slices[0].hashValue
+                for lhs in slices {
+                    XCTAssertEqual(lhs.toArray(), bytes)
+                    XCTAssertEqual(lhs.hashValue, referenceHash)
+                    for rhs in slices { XCTAssertEqual(lhs, rhs) }
+                }
+                XCTAssertEqual(Set(slices).count, 1)
+                let dictionary = [slices[0]: length]
+                for slice in slices { XCTAssertEqual(dictionary[slice], length) }
+            }
+        }
+    }
+
+    func testDifferentBytesAndLengthsDoNotCompareEqual() {
+        for length in [1, 2, 7, 8, 15, 16, 17, 31, 32, 63, 64, 65, 257] {
+            let bytes = (0..<length).map { UInt8(truncatingIfNeeded: $0) }
+            let originals = views(bytes, offset: 3)
+            for index in Set([0, length / 2, length - 1]) {
+                var changed = bytes
+                changed[index] ^= 255
+                for lhs in originals {
+                    for rhs in views(changed, offset: 7) { XCTAssertNotEqual(lhs, rhs) }
+                }
+            }
+            for lhs in originals { XCTAssertNotEqual(lhs, ByteSlice.fromArray(bytes + [0])) }
+        }
+    }
+
+    func testEmptyAndZeroContainingViews() {
+        let empty = views([], offset: 4)
+        for slice in empty { XCTAssertEqual(slice, ByteSlice.empty) }
+        let values: [[UInt8]] = [[], [0], [0, 0], [0, 1], [1, 0], [255, 0, 254]]
+        var dictionary: [ByteSlice: Int] = [:]
+        for (i, bytes) in values.enumerated() { dictionary[views(bytes, offset: 1)[0]] = i }
+        for (i, bytes) in values.enumerated() {
+            for slice in views(bytes, offset: 6) { XCTAssertEqual(dictionary[slice], i) }
+        }
+    }
+    func testEqualityWithLongCommonPrefixes() {
+        for length in [511, 512, 1023, 1024, 4095, 4096] {
+            let bytes = (0..<length).map { UInt8(truncatingIfNeeded: $0 &* 37) }
+            let original = ByteSlice.fromArray(bytes)
+            for offset in [0, 1, 3, 7] {
+                for view in views(bytes, offset: offset) { XCTAssertEqual(original, view) }
+                for index in [0, length / 2, length - 1] {
+                    var changed = bytes
+                    changed[index] ^= 255
+                    for view in views(changed, offset: offset) {
+                        XCTAssertNotEqual(original, view)
+                        XCTAssertNotEqual(view, original)
+                    }
+                }
+            }
+        }
+    }
+
+    func testASCIIScansMatchArrayReferenceAcrossBackingStores() {
+        func whitespace(_ byte: UInt8) -> Bool { byte == 32 || (byte >= 9 && byte <= 13) }
+        var cases: [[UInt8]] = [[], [32], [9, 10, 11, 12, 13, 32], [0, 65, 0], [65], [90], [91], [64], [97], [255]]
+        cases += (0..<256).map { [UInt8($0)] }
+        cases += (0..<80).map { i in Array(repeating: UInt8(32), count: i % 7) + Array(("AbC-日本語-" + String(i)).utf8) + [13, 10] }
+        for bytes in cases {
+            let expectedLower = bytes.map { $0 >= 65 && $0 <= 90 ? $0 + 32 : $0 }
+            var begin = 0
+            var end = bytes.count
+            while begin < end && whitespace(bytes[begin]) { begin += 1 }
+            while begin < end && whitespace(bytes[end - 1]) { end -= 1 }
+            for offset in [0, 3, 7] {
+                for view in views(bytes, offset: offset) {
+                    XCTAssertEqual(view.lowercased().toArray(), expectedLower)
+                    XCTAssertEqual(view.trim().toArray(), Array(bytes[begin..<end]))
+                    XCTAssertTrue(view.trim().storage === view.storage)
+                    XCTAssertEqual(Attributes.containsAsciiUppercase(view), bytes.contains { $0 >= 65 && $0 <= 90 })
+                    XCTAssertEqual(view.toArray(), bytes)
+                    if expectedLower == bytes { XCTAssertTrue(view.lowercased().storage === view.storage) }
+                }
+            }
+        }
+    }
+
+}

--- a/Tests/SwiftSoupTests/ByteSliceContiguousStorageTest.swift
+++ b/Tests/SwiftSoupTests/ByteSliceContiguousStorageTest.swift
@@ -1,0 +1,104 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class ByteSliceContiguousStorageTest: XCTestCase {
+    private func read<C: Collection, R>(_ value: C,
+                                      _ body: (UnsafeBufferPointer<C.Element>) throws -> R) rethrows -> R? {
+        try value.withContiguousStorageIfAvailable(body)
+    }
+
+    private func check(_ storage: ByteStorage, count: Int) throws {
+        for start in 0...count {
+            for end in start...count {
+                let slice = ByteSlice(storage: storage, start: start, end: end)
+                var calls = 0
+                let observed = read(slice) { buffer -> [UInt8] in
+                    calls += 1
+                    return Array(buffer)
+                }
+                XCTAssertEqual(calls, 1)
+                XCTAssertEqual(observed, slice.toArray())
+                XCTAssertEqual(Array(slice), slice.toArray())
+                XCTAssertEqual(String(decoding: slice, as: UTF8.self),
+                               String(decoding: slice.toArray(), as: UTF8.self))
+            }
+        }
+    }
+
+    func testGenericDispatchAllRangesAndBackings() throws {
+        let bytes = Array("a日本😀é".utf8) + [0, 255]
+        try check(ByteStorage(array: bytes), count: bytes.count)
+        try check(ByteStorage(data: Data([249] + bytes).dropFirst()), count: bytes.count)
+        try bytes.withUnsafeBufferPointer { buffer in
+            try check(ByteStorage(buffer: buffer.baseAddress!, count: buffer.count, owner: nil),
+                      count: buffer.count)
+        }
+        try check(ByteStorage(array: []), count: 0)
+        try check(ByteStorage(data: Data()), count: 0)
+    }
+
+    func testOptionalResultRemainsAnInvokedClosure() {
+        for slice in [ByteSlice.empty, .fromArray([0, 255])] {
+            var calls = 0
+            let result: Int?? = read(slice) { _ -> Int? in
+                calls += 1
+                return nil
+            }
+            guard case .some(.none) = result else {
+                XCTFail("An invoked closure returning nil must not mean unavailable storage")
+                continue
+            }
+            XCTAssertEqual(calls, 1)
+        }
+    }
+
+    func testThrowingClosurePropagatesUnchanged() {
+        enum Failure: Error { case expected }
+        for slice in [ByteSlice.empty, .fromArray([0, 255])] {
+            XCTAssertThrowsError(try read(slice) { _ -> Int in throw Failure.expected }) {
+                guard case Failure.expected = $0 else {
+                    XCTFail("Unexpected error: \($0)")
+                    return
+                }
+            }
+        }
+    }
+
+    func testMalformedDecodingMatchesArrays() {
+        let cases = (0...255).map { [UInt8($0)] } + [Array(0...255), [240, 159], [192, 175], [237, 160, 128]]
+        for bytes in cases {
+            let storage = ByteStorage(data: Data([250] + bytes + [251]))
+            let slice = ByteSlice(storage: storage, start: 1, end: bytes.count + 1)
+            XCTAssertEqual(String(decoding: slice, as: UTF8.self), String(decoding: bytes, as: UTF8.self))
+            XCTAssertEqual(Array(slice), bytes)
+        }
+    }
+
+    func testTemporaryOwnedBufferSurvivesTheClosure() {
+        final class Owner {
+            let pointer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            init() {
+                for i in 0..<4096 { pointer.advanced(by: i).initialize(to: UInt8(i % 251)) }
+            }
+            deinit { pointer.deinitialize(count: 4096); pointer.deallocate() }
+        }
+        weak var observedOwner: Owner?
+        func makeSlice() -> ByteSlice {
+            let owner = Owner()
+            observedOwner = owner
+            return ByteSlice(storage: ByteStorage(buffer: UnsafePointer(owner.pointer), count: 4096, owner: owner),
+                             start: 5, end: 4090)
+        }
+        func consumeTemporary() {
+            let bytes = read(makeSlice()) { buffer in
+                XCTAssertNotNil(observedOwner)
+                XCTAssertEqual(buffer.count, 4085)
+                return Array(buffer)
+            }
+            XCTAssertEqual(bytes, (5..<4090).map { UInt8($0 % 251) })
+        }
+        consumeTemporary()
+        XCTAssertNil(observedOwner)
+    }
+}

--- a/Tests/SwiftSoupTests/CharacterClassificationFastPathTest.swift
+++ b/Tests/SwiftSoupTests/CharacterClassificationFastPathTest.swift
@@ -1,0 +1,150 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class CharacterClassificationFastPathTest: XCTestCase {
+    // Preserve the pre-optimization definition, including normalization before
+    // deciding whether a Character consists of exactly one scalar.
+    private func original(_ character: Character, _ set: CharacterSet) -> Bool {
+        let normalized = String(character).precomposedStringWithCanonicalMapping.unicodeScalars
+        return normalized.count == 1 && set.contains(normalized.first!)
+    }
+
+    private var sets: [CharacterSet] {
+        [.letters, .decimalDigits, .alphanumerics, .whitespacesAndNewlines,
+         .controlCharacters, .punctuationCharacters, .symbols, .nonBaseCharacters,
+         CharacterSet(), CharacterSet().inverted,
+         CharacterSet(charactersIn: "\0\r\nAe\u{00E9}1"),
+         CharacterSet(charactersIn: "\0\r\nAe\u{00E9}1").inverted]
+    }
+
+    private func check(_ character: Character, file: StaticString = #filePath, line: UInt = #line) {
+        for set in sets {
+            XCTAssertEqual(character.isMemberOfCharacterSet(set), original(character, set),
+                           String(reflecting: character), file: file, line: line)
+        }
+        let letter = original(character, .letters)
+        let digit = original(character, .decimalDigits)
+        XCTAssertEqual(character.isLetter(), letter, file: file, line: line)
+        XCTAssertEqual(Character.isLetter(character), letter, file: file, line: line)
+        XCTAssertEqual(character.isDigit, digit, file: file, line: line)
+        XCTAssertEqual(character.isLetterOrDigit(), letter || digit, file: file, line: line)
+        XCTAssertEqual(Character.isLetterOrDigit(character), letter || digit, file: file, line: line)
+    }
+
+    func testEveryASCIIValueAcrossCharacterSetsAndPublicQueue() {
+        for value in UInt32(0)..<128 {
+            let scalar = UnicodeScalar(value)!
+            let character = Character(scalar)
+            check(character)
+            let word = original(character, .letters) || original(character, .decimalDigits)
+            let queue = TokenQueue(String(character) + "!")
+            XCTAssertEqual(queue.matchesWord(), word)
+            XCTAssertEqual(queue.toString(), String(character) + "!")
+            XCTAssertEqual(TokenQueue("<" + String(character)).matchesStartTag(), original(character, .letters))
+        }
+    }
+
+    func testCRLFIsNotASingleNewlineScalar() {
+        let crlf: Character = "\r\n"
+        XCTAssertEqual(crlf.asciiValue, 10) // Not sufficient for the fast-path guard.
+        for set in sets {
+            XCTAssertFalse(crlf.isMemberOfCharacterSet(set))
+        }
+        XCTAssertTrue(Character("\n").isMemberOfCharacterSet(.newlines))
+        XCTAssertTrue(Character("\r").isMemberOfCharacterSet(.newlines))
+        XCTAssertFalse(crlf.isMemberOfCharacterSet(.newlines))
+        check(crlf)
+    }
+
+    func testASCIIBaseWithCombiningMarksStillNormalizes() {
+        for base in ["A", "e", "n", "1", " ", "#", "\0"] {
+            for suffix in ["\u{0301}", "\u{0308}", "\u{0327}", "\u{030A}", "\u{20E3}",
+                           "\u{FE0F}", "\u{0301}\u{0327}", "\u{200D}", String(repeating: "\u{0301}", count: 64)] {
+                for character in base + suffix { check(character) }
+            }
+        }
+        let decomposed: Character = "e\u{0301}"
+        XCTAssertTrue(decomposed.isMemberOfCharacterSet(CharacterSet(charactersIn: "é")))
+        XCTAssertFalse(decomposed.isMemberOfCharacterSet(CharacterSet(charactersIn: "e")))
+    }
+
+    func testNonASCIIScalarsAndComposedGraphemes() {
+        for text in ["日本語", "éÅÅ", "١２𝟡", "½Ⅸ", "👩🏽‍💻", "🇯🇵", "가", "\u{0344}",
+                     "\u{212A}", "\u{00A0}\u{2003}\u{2028}", "\u{0301}\u{0327}"] {
+            for character in text { check(character) }
+        }
+        var state: UInt64 = 0x4c415353494659
+        for _ in 0..<4096 {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            if let scalar = UnicodeScalar(UInt32(state % 0x110000)) { check(Character(scalar)) }
+        }
+    }
+
+    func testWordAndTagConsumersKeepExactSourceBytes() throws {
+        for spelling in ["section12", "ABCxyz019", "日本語２", "e\u{0301}clair", "éclair", "가", "a\u{20E3}"] {
+            let word = TokenQueue(spelling + "!tail")
+            let expected = String(spelling.prefix { original($0, .letters) || original($0, .decimalDigits) })
+            XCTAssertEqual(Array(word.consumeWord().utf8), Array(expected.utf8))
+            XCTAssertEqual(Array(word.toString().utf8), Array((String(spelling.dropFirst(expected.count)) + "!tail").utf8))
+        }
+        for spelling in ["custom-tag_12:part", "日本語:タグ", "e\u{0301}clair-test"] {
+            let queue = TokenQueue("xx" + spelling + "!")
+            try queue.consume("xx")
+            XCTAssertEqual(Array(queue.consumeTagNameSlice().utf8), Array(spelling.utf8))
+            XCTAssertEqual(queue.toString(), "!")
+        }
+    }
+
+    func testEveryASCIIStarterWithCombiningSuffixesUsesFullCharacter() {
+        let marks = Array(UInt32(0x0300)...UInt32(0x036F)) + [0x200D, 0x20E3, 0xFE0E, 0xFE0F]
+        let memberships: [CharacterSet] = [.letters, .decimalDigits, .nonBaseCharacters,
+                                         CharacterSet(charactersIn: "Aez0\r\n"), CharacterSet().inverted]
+        for value in UInt32(0)..<128 {
+            for mark in marks {
+                let text = String(UnicodeScalar(value)!) + String(UnicodeScalar(mark)!)
+                // Controls may introduce a boundary instead of one grapheme.
+                // Check actual Characters rather than inventing a grouping.
+                for character in text {
+                    for set in memberships {
+                        XCTAssertEqual(character.isMemberOfCharacterSet(set), original(character, set),
+                                       "starter=\(value), mark=\(mark)")
+                    }
+                }
+            }
+        }
+    }
+
+    func testMembershipUsesTheCurrentMutableCharacterSet() {
+        for value in UInt32(0)..<128 {
+            let scalar = UnicodeScalar(value)!
+            let character = Character(scalar)
+            var set = CharacterSet()
+            XCTAssertFalse(character.isMemberOfCharacterSet(set))
+            set.insert(charactersIn: String(scalar))
+            XCTAssertTrue(character.isMemberOfCharacterSet(set))
+            let snapshot = set
+            set.invert()
+            XCTAssertFalse(character.isMemberOfCharacterSet(set))
+            XCTAssertTrue(character.isMemberOfCharacterSet(snapshot))
+            set.insert(charactersIn: "\r\n")
+            XCTAssertFalse(Character("\r\n").isMemberOfCharacterSet(set))
+        }
+    }
+
+    func testBridgedAndSlicedStorageKeepsClassificationAndExactSpelling() {
+        // NUL forces a grapheme boundary even before a leading combining mark.
+        let prefix = String(repeating: "日", count: 1024) + "\0"
+        let suffix = String(repeating: "語", count: 1024)
+        for spelling in ["A", "1", "\0", "\r\n", "e\u{0301}", "\u{0344}", "\u{212A}", "가", "🇯🇵"] {
+            let bridged = NSString(string: prefix + spelling + suffix) as String
+            let begin = bridged.index(bridged.startIndex, offsetBy: 1025)
+            let end = bridged.index(after: begin)
+            let slice = bridged[begin..<end]
+            XCTAssertEqual(Array(slice.utf8), Array(spelling.utf8))
+            check(bridged[begin])
+            check(Character(String(slice)))
+            XCTAssertEqual(Array(bridged.utf8), Array((prefix + spelling + suffix).utf8))
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/RegionCursorTest.swift
+++ b/Tests/SwiftSoupTests/RegionCursorTest.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import SwiftSoup
+
+final class RegionCursorTest: XCTestCase {
+    // Character arrays provide an independent positional model (not String offsets).
+    private func reference(_ text: String, _ needle: String, _ start: Int, _ other: Int,
+                           _ length: Int, _ fold: Bool) -> Bool {
+        let lhs = Array(text), rhs = Array(needle)
+        guard start >= 0, other >= 0, length >= 0,
+              start <= lhs.count, other <= rhs.count,
+              length <= lhs.count - start, length <= rhs.count - other else { return false }
+        for i in 0..<length {
+            let a = String(lhs[start+i]), b = String(rhs[other+i])
+            if fold ? a.lowercased() != b.lowercased() : a != b { return false }
+        }
+        return true
+    }
+
+    func testAllOrdinaryBoundsAgainstCharacterArrayModel() {
+        let samples = ["", "Abc", "日本語", "e\u{301}Éx", "👩🏽‍💻🇯🇵\r\nA", "İıΣσς", "a\0b"]
+        for text in samples {
+            for needle in samples {
+                for start in -1...(text.count + 1) {
+                    for other in -1...(needle.count + 1) {
+                        for length in 0...(needle.count + 1) {
+                            for fold in [false, true] {
+                                XCTAssertEqual(text.regionMatches(ignoreCase: fold, selfOffset: start,
+                                    other: needle, otherOffset: other, targetLength: length),
+                                    reference(text, needle, start, other, length, fold))
+                            }
+                        }
+                    }
+                    XCTAssertEqual(text.startsWith(needle, start),
+                        reference(text, needle, start, 0, needle.count, false))
+                }
+            }
+        }
+    }
+
+    func testCanonicalEquivalenceAndWholeGraphemePolicy() {
+        XCTAssertTrue("xéz".startsWith("e\u{301}", 1))
+        XCTAssertFalse("xe\u{301}z".startsWith("e", 1))
+        XCTAssertTrue("xÉz".regionMatches(ignoreCase: true, selfOffset: 1,
+            other: "qe\u{301}!", otherOffset: 1, targetLength: 1))
+        XCTAssertFalse("👩🏽‍💻!".startsWith("👩", 0))
+        XCTAssertFalse("🇯🇵!".startsWith("🇯", 0))
+        XCTAssertFalse("\r\n!".startsWith("\r", 0))
+        // Do not substitute Foundation case folding (or whole-string lowercasing).
+        XCTAssertFalse("ß".regionMatches(ignoreCase: true, selfOffset: 0,
+            other: "SS", otherOffset: 0, targetLength: 1))
+        XCTAssertFalse("Σ".regionMatches(ignoreCase: true, selfOffset: 0,
+            other: "ς", otherOffset: 0, targetLength: 1))
+    }
+
+    func testHugeOffsetsAndLengthsStayBounded() {
+        for offset in [Int.min, -1, 4, Int.max] {
+            XCTAssertFalse("abc".startsWith("a", offset))
+            XCTAssertFalse("abc".regionMatches(ignoreCase: true, selfOffset: offset,
+                other: "a", otherOffset: 0, targetLength: 1))
+            XCTAssertFalse("abc".regionMatches(ignoreCase: false, selfOffset: 0,
+                other: "a", otherOffset: offset, targetLength: 1))
+        }
+        XCTAssertFalse("abc".regionMatches(ignoreCase: false, selfOffset: 0,
+            other: "abc", otherOffset: 0, targetLength: Int.max))
+        XCTAssertTrue("abc".startsWith("", 3))
+        XCTAssertFalse("abc".startsWith("", 4))
+    }
+
+    func testInvalidNegativeLengthReturnsFalse() {
+        // Internal invalid ranges used to trap; no public TokenQueue API supplies a length.
+        for length in [-1, Int.min] {
+            XCTAssertFalse("abc".regionMatches(ignoreCase: true, selfOffset: 0,
+                other: "abc", otherOffset: 0, targetLength: length))
+        }
+    }
+
+    func testSeededUnicodePrefixChecks() throws {
+        let atoms = ["日", "本", "A", "a", "É", "e\u{301}", "👩🏽‍💻", "🇯🇵", "\r\n", "İ", "\0", " "]
+        var seed: UInt64 = 0xA3D_20260909
+        func next(_ n: Int) -> Int { seed = seed &* 6364136223846793005 &+ 1; return Int((seed >> 32) % UInt64(n)) }
+        for _ in 0..<512 {
+            let text = (0..<next(24)).map { _ in atoms[next(atoms.count)] }.joined()
+            let offset = next(text.count + 1)
+            let chars = Array(text)
+            let prefix = String(chars.prefix(offset))
+            let needle = next(2) == 0 ? String(chars.dropFirst(offset).prefix(next(10)))
+                : (0..<next(8)).map { _ in atoms[next(atoms.count)] }.joined()
+            let q = TokenQueue(text)
+            if !prefix.isEmpty { try q.consume(prefix) }
+            let saved = q.toString()
+            XCTAssertEqual(q.matches(needle), reference(text, needle, offset, 0, needle.count, true))
+            XCTAssertEqual(q.matchesCS(needle), reference(text, needle, offset, 0, needle.count, false))
+            XCTAssertEqual(Array(q.toString().utf8), Array(saved.utf8))
+        }
+    }
+
+    func testPublicQueueConsumeMissExhaustionAndReuse() throws {
+        let q = TokenQueue("É日👩🏽‍💻!")
+        XCTAssertTrue(q.matchesCS("E\u{301}"))
+        XCTAssertFalse(q.matchesCS("é日")) // Capital É versus lowercase é remains case-sensitive.
+        XCTAssertTrue(q.matchChomp("e\u{301}"))
+        XCTAssertTrue(q.matches("日👩🏽‍💻"))
+        XCTAssertThrowsError(try q.consume("other"))
+        XCTAssertEqual(q.toString(), "日👩🏽‍💻!")
+        try q.consume("日👩🏽‍💻!")
+        XCTAssertTrue(q.isEmpty())
+        XCTAssertTrue(q.matches("")); XCTAssertTrue(q.matchesCS(""))
+        XCTAssertFalse(q.matches("x")); XCTAssertFalse(q.matchesCS("x"))
+        q.addFirst("e\u{301}X")
+        XCTAssertTrue(q.matches("Éx")); XCTAssertFalse(q.matchesCS("Éx"))
+        XCTAssertEqual(Array(q.toString().utf8), Array("e\u{301}X".utf8))
+    }
+
+}

--- a/Tests/SwiftSoupTests/StringSearchBoundaryTest.swift
+++ b/Tests/SwiftSoupTests/StringSearchBoundaryTest.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import SwiftSoup
+
+final class StringSearchBoundaryTest: XCTestCase {
+    // Deliberately use Character arrays and independently constructed windows,
+    // not String.index, Foundation search, or the production helper.
+    private func reference(_ text: String, _ needle: String, _ offset: Int) -> Int {
+        let chars = Array(text), width = Array(needle).count
+        guard offset >= 0, offset <= chars.count, width <= chars.count - offset else { return -1 }
+        for i in offset...(chars.count - width) {
+            if String(chars[i..<(i + width)]) == needle { return i }
+        }
+        return -1
+    }
+
+    func testEmptyNeedlesAndBounds() {
+        for text in ["", "abc", "日👩🏽‍💻e\u{301}\r\n"] {
+            for offset in [Int.min, -1, 0, 1, text.count, text.count + 1, Int.max] {
+                for needle in ["", "x", "abc", "a needle longer than the input"] {
+                    XCTAssertEqual(text.indexOf(needle, offset), reference(text, needle, offset))
+                }
+            }
+        }
+    }
+
+    func testSuffixTooShortAndExhaustedSearchReturnNotFound() {
+        XCTAssertEqual("abc".indexOf("xx", 2), -1)
+        XCTAssertEqual("abc".indexOf("x", 3), -1)
+        XCTAssertEqual("日語".indexOf("語語", 1), -1)
+        XCTAssertEqual("日語".indexOf("語", 2), -1)
+        XCTAssertEqual("abc".indexOf("", 3), 3)
+    }
+
+    func testWholeGraphemesAndCanonicalEquivalence() {
+        let texts = ["ae\u{301}z", "aéz", "x👩🏽‍💻y🇯🇵z", "x\r\ny", "x\u{0600}Ay", "x\0y", "가끝", "a\u{301}\u{327}b"]
+        let needles = ["e", "é", "e\u{301}", "\u{301}", "👩", "🏽", "👩🏽‍💻", "🇯", "🇯🇵", "\r", "\n", "\r\n", "A", "\u{0600}A", "\0", "가", "a\u{327}\u{301}"]
+        for text in texts {
+            for needle in needles {
+                for offset in 0...text.count {
+                    XCTAssertEqual(text.indexOf(needle, offset), reference(text, needle, offset), "\(text.debugDescription) / \(needle.debugDescription) @ \(offset)")
+                }
+            }
+        }
+    }
+
+    func testGeneratedCompatibilityOnPreviouslyValidSearchRanges() {
+        var state: UInt64 = 0x1234fedc
+        func next(_ n: Int) -> Int {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Int((state >> 32) % UInt64(n))
+        }
+        let atoms = ["a", "b", "日", "e\u{301}", "é", "👩🏽‍💻", "🇯🇵", "\r\n", "\0", "\u{0600}A", "\u{301}", "(", ")"]
+        for _ in 0..<512 {
+            let text = (0..<next(32)).map { _ in atoms[next(atoms.count)] }.joined()
+            let chars = Array(text)
+            var needles = ["", "absent", atoms[next(atoms.count)], "é", ")"]
+            if !chars.isEmpty {
+                let a = next(chars.count), b = next(chars.count + 1)
+                needles.append(String(chars[min(a,b)..<max(a,b)]))
+            }
+            for needle in needles {
+                let maxOffset = chars.count - needle.count
+                // The old implementation traps when 0 <= offset <= count but
+                // offset > maxOffset >= 0. Boundary fixes have separate tests.
+                for offset in 0...max(0, maxOffset) {
+                    XCTAssertEqual(text.indexOf(needle, offset), reference(text, needle, offset))
+                }
+            }
+        }
+    }
+
+    func testPublicQueueRetainsDelimiterAndExactSourceBytes() {
+        let prefix = "日本e\u{301}👩🏽‍💻\r\n"
+        let queue = TokenQueue(prefix + "éEND")
+        XCTAssertEqual(Array(queue.consumeTo("é").utf8), Array("日本".utf8))
+        XCTAssertEqual(Array(queue.toString().utf8), Array("e\u{301}👩🏽‍💻\r\néEND".utf8))
+        // Case-sensitive search is canonical-equivalence-aware, not byte search.
+        let other = TokenQueue(prefix + "STOPtail")
+        XCTAssertEqual(Array(other.consumeToSlice("STOP").utf8), Array(prefix.utf8))
+        XCTAssertEqual(other.chompTo("STOP"), "")
+        XCTAssertEqual(other.remainder(), "tail")
+    }
+
+    func testPublicQueueMissesPreserveExistingNonconsumingBehavior() throws {
+        let queue = TokenQueue("abcdef")
+        try queue.consume("ab")
+        XCTAssertEqual(queue.consumeTo("missing"), "")
+        XCTAssertEqual(queue.toString(), "cdef")
+        XCTAssertEqual(queue.consumeTo("xyz"), "")
+        XCTAssertEqual(queue.toString(), "cdef")
+        XCTAssertEqual(queue.consumeTo("ef"), "cd")
+        XCTAssertEqual(queue.toString(), "ef")
+    }
+
+    func testPublicQueueExhaustionAndShortSuffixNoLongerTrap() throws {
+        let queue = TokenQueue("abc")
+        try queue.consume("ab")
+        XCTAssertEqual(queue.consumeTo("xx"), "")
+        XCTAssertEqual(queue.toString(), "c")
+        try queue.consume("c")
+        for _ in 0..<4 {
+            XCTAssertEqual(queue.consumeTo("x"), "")
+            XCTAssertEqual(queue.consumeTo(""), "")
+            XCTAssertTrue(queue.isEmpty())
+        }
+        queue.addFirst("日本)")
+        XCTAssertEqual(queue.consumeTo(")"), "日本")
+        XCTAssertEqual(queue.toString(), ")")
+    }
+
+    func testIgnoreCasePublicQueueUsesUncasedSkipWithoutChangingResults() {
+        let cases = ["日本</tAg>後", "abc<x><y></TAG>tail", "日👩🏽‍💻無一致", "abc<", "a\r\nb</TaG>"]
+        for text in cases {
+            let q = TokenQueue(text)
+            let result = q.chompToIgnoreCase("</tag>")
+            let expected = text.range(of: "</tag>", options: .caseInsensitive).map { String(text[..<$0.lowerBound]) } ?? text
+            XCTAssertEqual(Array(result.utf8), Array(expected.utf8))
+        }
+    }
+
+}

--- a/Tests/SwiftSoupTests/TokenQueueEmptyIgnoreCaseDelimiterTests.swift
+++ b/Tests/SwiftSoupTests/TokenQueueEmptyIgnoreCaseDelimiterTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import SwiftSoup
+final class TokenQueueEmptyIgnoreCaseDelimiterTests: XCTestCase {
+    func testConsumeToIgnoreCaseEmptyDelimiterIsNoOp() {
+        let q=TokenQueue("AbC"); XCTAssertEqual(q.consumeToIgnoreCase(""), ""); XCTAssertEqual(q.remainder(), "AbC")
+    }
+    func testChompToIgnoreCaseEmptyDelimiterIsNoOp() {
+        let q=TokenQueue("AbC"); XCTAssertEqual(q.chompToIgnoreCase(""), ""); XCTAssertEqual(q.remainder(), "AbC")
+    }
+    func testEmptyDelimiterAfterPartialConsumptionPreservesRemainder() {
+        let q=TokenQueue("AbC"); XCTAssertEqual(q.consume(), "A"); XCTAssertEqual(q.consumeToIgnoreCase(""), ""); XCTAssertEqual(q.remainder(), "bC")
+    }
+    func testNonemptyIgnoreCaseBehaviorIsUnchanged() {
+        let q=TokenQueue("xxAbCyy"); XCTAssertEqual(q.consumeToIgnoreCase("aBc"), "xx"); XCTAssertEqual(q.chompToIgnoreCase("aBc"), ""); XCTAssertEqual(q.remainder(), "yy")
+    }
+}

--- a/Tests/SwiftSoupTests/WhitespaceRunTest.swift
+++ b/Tests/SwiftSoupTests/WhitespaceRunTest.swift
@@ -1,0 +1,174 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class WhitespaceRunTest: XCTestCase {
+    private struct Observation: Equatable {
+        var bytes: [UInt8]
+        var last: Bool
+        var saw: Bool
+        var callbacks: [[UInt8]]
+    }
+
+    private final class ObservingBuilder: StringBuilder {
+        var callbacks: [[UInt8]] = []
+        override func append(_ value: UInt8) -> StringBuilder {
+            callbacks.append(Array(buffer) + [value])
+            return super.append(value)
+        }
+    }
+
+    // Model only the historical slow path, forced by the leading tab in these
+    // inputs. Deliberately retains permissive byte stepping and drops a truncated
+    // final sequence; this performance patch must not change malformed input.
+    private func reference(_ input: [UInt8], strip: Bool, last: Bool, saw: Bool) -> Observation {
+        var result = Observation(bytes: [90], last: last, saw: saw, callbacks: [])
+        var reached = false
+        var i = 0
+        while i < input.count {
+            let b = input[i]
+            let nbsp = b == 194 && i + 1 < input.count && input[i + 1] == 160
+            let whitespace = [UInt8(9), 10, 12, 13, 32].contains(b) || nbsp
+            if whitespace {
+                if !(strip && !reached) && !result.last {
+                    result.callbacks.append(result.bytes + [32])
+                    result.bytes.append(32)
+                    result.last = true
+                    result.saw = true
+                }
+                i += nbsp ? 2 : 1
+            } else {
+                let width = b < 128 ? 1 : b < 224 ? 2 : b < 240 ? 3 : 4
+                guard width <= input.count - i else { break }
+                result.bytes.append(contentsOf: input[i..<(i + width)])
+                result.last = false
+                reached = true
+                i += width
+            }
+        }
+        return result
+    }
+
+    private func observe(_ slice: ByteSlice, strip: Bool, last: Bool, saw: Bool) -> Observation {
+        let builder = ObservingBuilder(string: "Z")
+        var last = last
+        var saw = saw
+        StringUtil.appendNormalisedWhitespace(builder, string: slice, stripLeading: strip,
+                                              lastWasWhite: &last, sawWhitespace: &saw)
+        return Observation(bytes: Array(builder.buffer), last: last, saw: saw, callbacks: builder.callbacks)
+    }
+
+    private func check(_ input: [UInt8], allStorage: Bool = false, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(input.first, 9, "Force the slow path", file: file, line: line)
+        let padded = [UInt8(77), 78, 79] + input + [80, 81]
+        let array = ByteSlice(storage: ByteStorage(array: padded), start: 3, end: 3 + input.count)
+        var data = Data(padded)
+        data.removeFirst(2) // Retain a nonzero Data.startIndex.
+        XCTAssertEqual(data.startIndex, 2)
+        let dataSlice = ByteSlice(storage: ByteStorage(data: data), start: 1, end: 1 + input.count)
+        for strip in [false, true] {
+            for last in [false, true] {
+                for saw in [false, true] {
+                    let expected = reference(input, strip: strip, last: last, saw: saw)
+                    XCTAssertEqual(observe(array, strip: strip, last: last, saw: saw), expected, file: file, line: line)
+                    if allStorage {
+                        XCTAssertEqual(observe(dataSlice, strip: strip, last: last, saw: saw), expected, file: file, line: line)
+                        padded.withUnsafeBufferPointer { buffer in
+                            let storage = ByteStorage(buffer: buffer.baseAddress!, count: buffer.count, owner: nil)
+                            let slice = ByteSlice(storage: storage, start: 3, end: 3 + input.count)
+                            XCTAssertEqual(observe(slice, strip: strip, last: last, saw: saw), expected, file: file, line: line)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func testUnicodeWhitespaceAndCallbackOrderAcrossStorage() {
+        for text in ["", "日本語", "日本語日本語\t文章です\n終わり", "😀🧑🏽‍💻🇯🇵e\u{301}",
+                     "日本\u{a0}語\u{a0}\u{a0}\r\n次", "\u{3000}\u{2003}\u{200b}\u{b}甲乙", "a日b本c語d"] {
+            check([9] + Array(text.utf8), allStorage: true)
+        }
+    }
+
+    func testEveryLeadByteAndTruncationBoundary() {
+        for lead in UInt8.min...UInt8.max {
+            for width in 0...4 {
+                check([9] + Array("日本語".utf8) + Array(([lead] + [128, 160, 32]).prefix(width)), allStorage: true)
+            }
+        }
+    }
+
+    func testSeededMalformedByteCorpus() {
+        var state: UInt64 = 0x5748495445535043
+        for index in 0..<2048 {
+            var input: [UInt8] = [9]
+            for _ in 0..<(index % 129) {
+                state = state &* 6364136223846793005 &+ 1442695040888963407
+                input.append(UInt8(truncatingIfNeeded: state >> 32))
+            }
+            check(input, allStorage: index.isMultiple(of: 16))
+        }
+    }
+
+    func testTrackingOverloadsAndFastPathStateRemainUnchanged() {
+        let chunks = ["\t日本語\u{a0}", "\t\n続きです", "\t😀e\u{301}\r終", "\t ", ""]
+        for strip in [false, true] {
+            for initial in [false, true] {
+                let expected = StringBuilder()
+                let actual = StringBuilder()
+                var expectedLast = initial
+                var actualLast = initial
+                for text in chunks {
+                    let bytes = Array(text.utf8)
+                    StringUtil.appendNormalisedWhitespace(expected, string: bytes[...], stripLeading: strip, lastWasWhite: &expectedLast)
+                    StringUtil.appendNormalisedWhitespace(actual, string: ByteSlice.fromArray(bytes), stripLeading: strip, lastWasWhite: &actualLast)
+                    XCTAssertEqual(Array(actual.buffer), Array(expected.buffer))
+                    XCTAssertEqual(actualLast, expectedLast)
+                }
+            }
+        }
+        // Preserve existing early-return state, even when the incoming flag is true.
+        let plain = observe(ByteSlice.fromArray(Array("日本語".utf8)), strip: false, last: true, saw: false)
+        XCTAssertEqual(plain.last, true)
+        XCTAssertEqual(plain.saw, false)
+        XCTAssertEqual(plain.bytes, Array("Z日本語".utf8))
+        let empty = observe(.empty, strip: true, last: true, saw: true)
+        XCTAssertEqual(empty, Observation(bytes: [90], last: true, saw: true, callbacks: []))
+    }
+
+    func testAliasedBuilderStorageAndRetainedSnapshots() {
+        let text = "\t日本語日本語\n続き😀\u{a0}終"
+        let builder = StringBuilder(string: text)
+        let snapshot = builder.asByteSlice()
+        let expected = reference(Array(text.utf8), strip: true, last: false, saw: false)
+        builder.clear()
+        builder.append("Z")
+        var last = false
+        var saw = false
+        StringUtil.appendNormalisedWhitespace(builder, string: snapshot, stripLeading: true, lastWasWhite: &last, sawWhitespace: &saw)
+        XCTAssertEqual(Array(builder.buffer), expected.bytes)
+        XCTAssertEqual(snapshot.toArray(), Array(text.utf8))
+        let retained = builder.buffer
+        builder.clear()
+        builder.append(String(repeating: "変更", count: 1024))
+        XCTAssertEqual(Array(retained), expected.bytes)
+        XCTAssertEqual(snapshot.toArray(), Array(text.utf8))
+    }
+
+    func testPublicTextAPIsMutationAndPreservedWhitespace() throws {
+        let doc = try SwiftSoup.parse("<main><p>\t日本語日本語\n次の文</p><p>😀\u{a0}終わり</p><pre>甲\t乙\n丙</pre></main>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        for _ in 0..<3 {
+            XCTAssertEqual(try p.text(), "日本語日本語 次の文")
+            XCTAssertEqual(try p.textUTF8(), Array("日本語日本語 次の文".utf8))
+            XCTAssertEqual(p.ownText(), "日本語日本語 次の文")
+            XCTAssertEqual(try p.text(trimAndNormaliseWhitespace: false), "\t日本語日本語\n次の文")
+        }
+        try p.text("\t変更しました\u{a0}\n新しい文")
+        XCTAssertEqual(try p.text(), "変更しました 新しい文")
+        let pre = try XCTUnwrap(doc.select("pre").first())
+        XCTAssertEqual(try pre.text(), "甲\t乙\n丙")
+        XCTAssertEqual(try doc.text(), "変更しました 新しい文 😀 終わり 甲\t乙\n丙")
+    }
+}


### PR DESCRIPTION
Part 5/8 of the SwiftSoup correctness/runtime reconciliation from lake-of-fire/SwiftSoup. Depends on #415. This PR targets that topic branch so its diff is incremental; review/merge the stack in order and retarget to master as prerequisites land.

Uses scoped backing buffers for ByteSlice hashing/equality, preserves Character/scalar boundaries in token operations, handles empty case-insensitive delimiters, and batches unchanged byte/text runs. CSS token helpers preserve original escapes and delimiters. Tests cover all storage forms, offsets, Unicode boundaries, malformed buffers, and bounded searches. CSS parser wiring follows in part 7.

Validation: `swift test -c release --jobs 2` on Apple Swift 6.3.3 / arm64 macOS: Executed 823 tests, with 0 failures (0 unexpected) in 7.781 (7.835) seconds.

Built on current upstream `35f7e1b0049236edcc351c0f10e7beddd0d4e76c`; upstream PR #411 and its escaped-ID regression coverage are retained. Source is extracted from the reviewed fork tree `a197bd5620a062f210686541dd38499c1913d342` without importing its merge/publication-workflow history. Exact head: `f3e32c07a33c185932e823f7c57e326fbed715fb`.

No new performance measurements are claimed for this integration under host load. Historical evidence is kept separate in part 8. This submission does not update upstream master or a release branch.

Stack order: #412 → #413 → #414 → #415 → #416 → #417 → #418 → #419.

Three selector-integration methods are introduced in part 7 after the nth/parser prerequisites; direct primitive tests stay here. The complete original test files are restored in that part.
