### PR TITLE
Preserve DOM ownership, mutation invariants and cache lifetimes

### DIFF
--- a/Sources/Attribute.swift
+++ b/Sources/Attribute.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 open class Attribute {
+    // Installed only when a mutable reference escapes to a caller or is shared.
+    // Weak ownership preserves the lifetime of detached attributes and DOM trees.
+    internal var mutationOwners: [Weak<Attributes>]? = nil
+
     /// The element type of a dictionary: a tuple containing an individual
     /// key-value pair.
     static let booleanAttributes = ParsingStrings([
@@ -37,8 +41,8 @@ open class Attribute {
     var lowerTrimmedValueSliceCache: ByteSlice? = nil
     
     public init(key: [UInt8], value: [UInt8]) throws {
-        try Validate.notEmpty(string: key)
         let trimmedKey = ByteSlice.fromArray(key).trim()
+        try Validate.notEmpty(string: trimmedKey)
         self.keySlice = trimmedKey
         self.valueSlice = ByteSlice.fromArray(value)
     }
@@ -51,8 +55,9 @@ open class Attribute {
 
     @usableFromInline
     init(keySlice: ByteSlice, valueSlice: ByteSlice) throws {
-        try Validate.notEmpty(string: keySlice)
-        self.keySlice = keySlice.trim()
+        let trimmedKey = keySlice.trim()
+        try Validate.notEmpty(string: trimmedKey)
+        self.keySlice = trimmedKey
         self.valueSlice = valueSlice
     }
     
@@ -85,12 +90,21 @@ open class Attribute {
      */
     @inline(__always)
     open func setKey(key: [UInt8]) throws {
-        try Validate.notEmpty(string: key)
-        keySlice = ByteSlice.fromArray(key).trim()
+        let trimmedKey = ByteSlice.fromArray(key).trim()
+        try Validate.notEmpty(string: trimmedKey)
+        setNormalizedKey(trimmedKey)
+    }
+
+    // The caller validates or normalizes the key before entering this storage-only path.
+    // Normalization must not invoke an arbitrary subclass setter.
+    internal func setNormalizedKey(_ key: ByteSlice) {
+        guard keySlice != key else { return }
+        keySlice = key
         keyBytes = nil
         lowerKeySliceCache = nil
+        notifyMutationOwners(keyChanged: true)
     }
-    
+
     @inline(__always)
     open func setKey(key: String) throws {
         try setKey(key: key.utf8Array)
@@ -135,12 +149,16 @@ open class Attribute {
     @inline(__always)
     open func setValue(value: [UInt8]) -> [UInt8] {
         let old = getValueUTF8()
+        // An overridden getter can differ from the stored value. Only skip an
+        // actual storage no-op, while preserving the public getter's return value.
+        guard valueSliceMaterialized() != ByteSlice.fromArray(value) else { return old }
         valueSlice = ByteSlice.fromArray(value)
         valueSlices = nil
         valueSlicesCount = 0
         valueBytes = nil
         lowerValueSliceCache = nil
         lowerTrimmedValueSliceCache = nil
+        notifyMutationOwners(keyChanged: false)
         return old
     }
     
@@ -347,12 +365,13 @@ open class Attribute {
     @usableFromInline
     @inline(__always)
     func appendValueSlice(_ slice: ByteSlice) {
+        guard !slice.isEmpty else { return }
+        defer { notifyMutationOwners(keyChanged: false) }
         valueBytes = nil
         lowerValueSliceCache = nil
         lowerTrimmedValueSliceCache = nil
-        if var slices = valueSlices {
-            slices.append(slice)
-            valueSlices = slices
+        if valueSlices != nil {
+            valueSlices!.append(slice)
             valueSlicesCount += slice.count
             return
         }
@@ -402,20 +421,31 @@ open class Attribute {
     @inline(__always)
     public func hashCode() -> Int {
         var result = keySlice.hashValue
-        result = 31 * result + valueSliceMaterialized().hashValue
+        // Hash mixing intentionally wraps at the machine word boundary.
+        result = (31 &* result) &+ valueSliceMaterialized().hashValue
         return result
     }
     
+    // Copy immutable byte storage without sharing the mutable Attribute object or observers.
+    internal init(copying other: Attribute) {
+        keySlice = other.keySlice
+        valueSlice = other.valueSlice
+        valueSlices = other.valueSlices
+        valueSlicesCount = other.valueSlicesCount
+    }
+
     @inline(__always)
     public func clone() -> Attribute {
-        do {
-            return try Attribute(key: getKeyUTF8(), value: getValueUTF8())
-        } catch Exception.Error( _, let  msg) {
-            print(msg)
-        } catch {
-            
+        if type(of: self) == BooleanAttribute.self {
+            return BooleanAttribute(copying: self)
         }
-        return try! Attribute(key: [], value: [])
+        if type(of: self) != Attribute.self,
+           let projected = try? Attribute(key: getKeyUTF8(), value: getValueUTF8()) {
+            // Preserve the existing clone contract for custom getter overrides.
+            // Invalid projected keys fall back to the already-validated storage.
+            return projected
+        }
+        return Attribute(copying: self)
     }
 
 }

--- a/Sources/AttributeMutationTracking.swift
+++ b/Sources/AttributeMutationTracking.swift
@@ -1,0 +1,117 @@
+// Mutable references can be shared through put/addAll and retained after removal.
+// Observe weakly, and validate membership by identity before every notification.
+// This avoids adding callbacks or an owner allocation to deferred parser attributes.
+internal extension Attribute {
+    func observeMutations(in owner: Attributes) {
+        // Callers have just obtained this attribute from, or inserted it into,
+        // owner. Re-reading a singly owned list must not rescan the whole list
+        // once per attribute. Mutation notifications still validate membership.
+        if let owners = mutationOwners, owners.count == 1, owners[0].value === owner { return }
+        mutationOwners?.removeAll { reference in
+            guard let existing = reference.value else { return true }
+            // The caller is registering an attribute already in this owner. Avoid
+            // rescanning its array for every item returned by asList / iteration.
+            return existing !== owner && !existing.attributes.contains { $0 === self }
+        }
+        if mutationOwners?.contains(where: { $0.value === owner }) == true { return }
+        if mutationOwners == nil { mutationOwners = [] }
+        mutationOwners?.append(Weak(owner))
+    }
+
+    func notifyMutationOwners(keyChanged: Bool) {
+        mutationOwners?.removeAll { reference in
+            guard let owner = reference.value else { return true }
+            return !owner.attributes.contains { $0 === self }
+        }
+        guard let owners = mutationOwners else { return }
+        for reference in owners {
+            reference.value?.attributeDidMutate(keyChanged: keyChanged)
+        }
+    }
+}
+
+internal extension Attributes {
+    func observeAttributeMutations() {
+        for attribute in attributes { attribute.observeMutations(in: self) }
+    }
+
+    func attributeDidMutate(keyChanged: Bool) {
+        if keyChanged {
+            invalidateKeyIndex()
+            invalidateLowercasedKeysCache()
+            hasUppercaseKeys = attributes.contains { Self.containsAsciiUppercase($0.keySlice) }
+        }
+        notifyMutationOwners()
+    }
+
+    @usableFromInline
+    func addOwner(_ node: Node) {
+        if ownerNode === node { return }
+        additionalOwnerNodes?.removeAll { reference in
+            guard let owner = reference.value else { return true }
+            return owner.attributes !== self
+        }
+        if let first = ownerNode, first.attributes === self {
+            if additionalOwnerNodes?.contains(where: { $0.value === node }) == true { return }
+            if additionalOwnerNodes == nil { additionalOwnerNodes = [] }
+            additionalOwnerNodes?.append(Weak(node))
+        } else {
+            // Remove a promoted owner from the secondary list to notify it once.
+            additionalOwnerNodes?.removeAll { $0.value === node }
+            ownerNode = node
+        }
+    }
+
+    @usableFromInline
+    func notifyMutationOwners() {
+        // Shared collections may outlive their nodes. Release expired observer
+        // boxes and restore the single-owner fast path when the primary expires.
+        additionalOwnerNodes?.removeAll { reference in
+            guard let node = reference.value else { return true }
+            return node.attributes !== self
+        }
+        if ownerNode?.attributes !== self {
+            ownerNode = nil
+            if let promoted = additionalOwnerNodes?.first?.value {
+                ownerNode = promoted
+                additionalOwnerNodes?.removeFirst()
+            }
+        }
+        if additionalOwnerNodes?.isEmpty == true { additionalOwnerNodes = nil }
+        func notify(_ node: Node) {
+            guard node.attributes === self else { return }
+            if let element = node as? Element {
+                element.markAttributeQueryIndexesDirty()
+            } else {
+                node.bumpTextMutationVersion()
+            }
+            node.markSourceDirty()
+        }
+        if let ownerNode { notify(ownerNode) }
+        if let additionalOwnerNodes {
+            for reference in additionalOwnerNodes {
+                if let owner = reference.value { notify(owner) }
+            }
+        }
+    }
+
+    // Query indexes and getters must agree when keys differ only in case or a
+    // direct rename introduces duplicates. Use existing key maps for large lists;
+    // the fallback compares at most three preceding attributes, without a set.
+    func forEachEffectiveAttribute(_ visit: (Attribute, ByteSlice) -> Void) {
+        ensureMaterialized()
+        if hasUppercaseKeys { ensureLowercasedKeyIndex() } else { ensureKeyIndex() }
+        let index = hasUppercaseKeys ? lowercasedKeyIndex : keyIndex
+        for (offset, attribute) in attributes.enumerated() {
+            let key = hasUppercaseKeys ? attribute.lowerKeySlice() : attribute.keySlice
+            if let index {
+                guard index[key] == offset else { continue }
+            } else if attributes[..<offset].contains(where: {
+                Self.equalsIgnoreCase($0.keySlice, key)
+            }) {
+                continue
+            }
+            visit(attribute, key)
+        }
+    }
+}

--- a/Sources/Attributes.swift
+++ b/Sources/Attributes.swift
@@ -46,6 +46,51 @@ open class Attributes: NSCopying {
         var nameBytes: [UInt8]?
         var hasUppercase: Bool
         var value: PendingAttrValue
+
+        // A one-bit prefilter avoids most full-name comparisons in small batches.
+        // Equal names always yield the same bit; a collision is never proof of
+        // equality. Validate exactly the whitespace rule used by ByteSlice.trim().
+        @inline(__always)
+        @usableFromInline
+        func canonicalNameMask() -> UInt64? {
+            func mask(_ bytes: UnsafeBufferPointer<UInt8>) -> UInt64? {
+                guard let first = bytes.first, let last = bytes.last else { return nil }
+                func whitespace(_ byte: UInt8) -> Bool { byte == 32 || (byte >= 9 && byte <= 13) }
+                guard !whitespace(first), !whitespace(last) else { return nil }
+                let previous = bytes.count > 1 ? bytes[bytes.count - 2] : first
+                let signature = (UInt64(first) &* 31) ^ (UInt64(last) &* 17) ^
+                    (UInt64(previous) &* 7) ^ (UInt64(bytes.count) &* 13)
+                return UInt64(1) << (signature & 63)
+            }
+            if let nameBytes { return nameBytes.withUnsafeBufferPointer(mask) }
+            if let nameSlice { return nameSlice.withUnsafeBytes(mask) }
+            return nil
+        }
+
+        @inline(__always)
+        @usableFromInline
+        func hasSameName(as other: PendingAttribute) -> Bool {
+            if let nameBytes {
+                if let otherBytes = other.nameBytes { return nameBytes == otherBytes }
+                return other.nameSlice?.elementsEqual(nameBytes) ?? false
+            }
+            guard let nameSlice else { return false }
+            if let otherBytes = other.nameBytes { return nameSlice.elementsEqual(otherBytes) }
+            return other.nameSlice == nameSlice
+        }
+
+        @usableFromInline
+        func normalizedKey() -> ByteSlice? {
+            let key: ByteSlice
+            if let nameBytes {
+                key = ByteSlice.fromArray(nameBytes).trim()
+            } else if let nameSlice {
+                key = nameSlice.trim()
+            } else {
+                return nil
+            }
+            return key.isEmpty ? nil : key
+        }
     }
 
     @usableFromInline
@@ -61,16 +106,15 @@ open class Attributes: NSCopying {
     var attributes: [Attribute] = [] {
         @inline(__always)
         didSet {
-            ownerElement?.markClassQueryIndexDirty()
-            ownerElement?.markIdQueryIndexDirty()
-            ownerElement?.markAttributeQueryIndexDirty()
-            ownerElement?.markAttributeValueQueryIndexDirty()
-            ownerElement?.markSourceDirty()
+            if !isMaterializing { notifyMutationOwners() }
             invalidateLowercasedKeysCache()
             invalidateKeyIndex()
         }
     }
     
+    // Representation-only materialization must not invalidate DOM caches or source reuse.
+    private var isMaterializing = false
+
     /// Set of lower‑cased UTF‑8 keys for fast O(1) ignore‑case look‑ups
     @usableFromInline
     internal var lowercasedKeysCache: Set<ByteSlice>? = nil
@@ -91,17 +135,38 @@ open class Attributes: NSCopying {
     internal var keyIndexDirty: Bool = true
 
     @usableFromInline
-    internal var pendingAttributes: [PendingAttribute]? = nil
+    internal var pendingAttributes: [PendingAttribute]? = nil {
+        didSet { pendingNamesAreCanonical = false }
+    }
+
+    // Validated once per deferred batch, never once per lookup or serialization.
+    private var pendingNamesAreCanonical = false
     
     @usableFromInline
     internal var pendingAttributesCount: Int = 0
     
-    // TODO: Delegate would be cleaner...
     @usableFromInline
-    weak var ownerElement: SwiftSoup.Element?
+    internal weak var ownerNode: Node?
+    internal var additionalOwnerNodes: [Weak<Node>]? = nil
+
+    // Retain the existing single-owner fast path for targeted internal invalidation.
+    @usableFromInline
+    var ownerElement: SwiftSoup.Element? { ownerNode as? SwiftSoup.Element }
     
     public init() {
         attributes.reserveCapacity(16)
+    }
+
+    private init(copying attributes: [Attribute], hasUppercaseKeys: Bool) {
+        self.attributes = attributes
+        self.hasUppercaseKeys = hasUppercaseKeys
+    }
+
+    /// Adopts a token's deferred attributes before an element owns this collection.
+    internal init(pendingAttributes: [PendingAttribute]) {
+        self.pendingAttributes = pendingAttributes
+        pendingAttributesCount = pendingAttributes.count
+        hasUppercaseKeys = pendingAttributes.contains { $0.hasUppercase }
     }
 
     /// Materializes a deferred attribute, throwing if the key fails validation (e.g. an
@@ -136,14 +201,7 @@ open class Attributes: NSCopying {
     internal func appendPending(_ pending: PendingAttribute) {
         if !attributes.isEmpty {
             // If materialized already, fall back to regular put.
-            let keySlice: ByteSlice
-            if let nameBytes = pending.nameBytes {
-                keySlice = ByteSlice.fromArray(nameBytes).trim()
-            } else if let nameSlice = pending.nameSlice {
-                keySlice = nameSlice.trim()
-            } else {
-                return
-            }
+            guard let keySlice = pending.normalizedKey() else { return }
             // Drop malformed attributes (e.g. an empty-after-trim key) rather than
             // trapping; jsoup does the same. See #392.
             guard let attribute = try? makeMaterializedAttribute(keySlice: keySlice, value: pending.value) else { return }
@@ -165,11 +223,7 @@ open class Attributes: NSCopying {
         }
         invalidateLowercasedKeysCache()
         invalidateKeyIndex()
-        ownerElement?.markClassQueryIndexDirty()
-        ownerElement?.markIdQueryIndexDirty()
-        ownerElement?.markAttributeQueryIndexDirty()
-        ownerElement?.markAttributeValueQueryIndexDirty()
-        ownerElement?.markSourceDirty()
+        notifyMutationOwners()
     }
 
     @usableFromInline
@@ -178,7 +232,7 @@ open class Attributes: NSCopying {
         guard let pending = pendingAttributes, !pending.isEmpty else { return }
         DebugTrace.log("Attributes.ensureMaterialized: pending=\(pending.count)")
         pendingAttributesCount = 0
-        let shouldIndex = shouldBuildKeyIndex()
+        let shouldIndex = attributes.count + pending.count >= Self.keyIndexThreshold
         var localIndex: [ByteSlice: Int]? = nil
         if shouldIndex {
             if !keyIndexDirty, let existing = keyIndex {
@@ -187,13 +241,16 @@ open class Attributes: NSCopying {
                 localIndex = [:]
                 localIndex?.reserveCapacity(attributes.count + pending.count)
                 for (idx, attr) in attributes.enumerated() {
-                    localIndex?[attr.keySlice] = idx
+                    if localIndex?[attr.keySlice] == nil {
+                        localIndex?[attr.keySlice] = idx
+                    }
                 }
             }
         }
-        var touchedClass = false
-        var touchedId = false
-        attributes.reserveCapacity(attributes.count + pending.count)
+        // Build locally so the array observer invalidates owner indexes once,
+        // rather than once for every appended or replaced attribute.
+        var materialized = attributes
+        materialized.reserveCapacity(materialized.count + pending.count)
         for pendingAttr in pending {
             if let nameBytes = pendingAttr.nameBytes {
                 DebugTrace.log("Attributes.ensureMaterialized: nameBytes=\(String(decoding: nameBytes, as: UTF8.self))")
@@ -202,14 +259,7 @@ open class Attributes: NSCopying {
             } else {
                 DebugTrace.log("Attributes.ensureMaterialized: missing name")
             }
-            let keySlice: ByteSlice
-            if let nameBytes = pendingAttr.nameBytes {
-                keySlice = ByteSlice.fromArray(nameBytes).trim()
-            } else if let nameSlice = pendingAttr.nameSlice {
-                keySlice = nameSlice.trim()
-            } else {
-                continue
-            }
+            guard let keySlice = pendingAttr.normalizedKey() else { continue }
             // Drop malformed attributes (e.g. an empty-after-trim key) rather than
             // trapping; jsoup does the same. This is the path #392 hits via
             // getIgnoreCase during select()'s query-index rebuild.
@@ -218,42 +268,28 @@ open class Attributes: NSCopying {
             if Attributes.containsAsciiUppercase(keyForIndex) {
                 hasUppercaseKeys = true
             }
-            let normalizedKey = Attributes.containsAsciiUppercase(keyForIndex) ? keyForIndex.lowercased() : keyForIndex
-            if equalsSlice(normalizedKey, UTF8Arrays.class_) {
-                touchedClass = true
-            }
-            if equalsSlice(normalizedKey, SwiftSoup.Element.idString) {
-                touchedId = true
-            }
             if let index = localIndex?[keyForIndex] {
-                attributes[index] = attribute
+                materialized[index] = attribute
             } else if shouldIndex {
-                localIndex?[keyForIndex] = attributes.count
-                attributes.append(attribute)
-            } else if let index = attributes.firstIndex(where: { $0.keySlice == keyForIndex }) {
-                attributes[index] = attribute
+                localIndex?[keyForIndex] = materialized.count
+                materialized.append(attribute)
+            } else if let index = materialized.firstIndex(where: { $0.keySlice == keyForIndex }) {
+                materialized[index] = attribute
             } else {
-                attributes.append(attribute)
+                materialized.append(attribute)
             }
         }
+        // Initial deferred storage is already the logical contents. A merge into
+        // existing attributes may replace values and must still invalidate owners.
+        isMaterializing = attributes.isEmpty
+        attributes = materialized
+        isMaterializing = false
         if let localIndex {
             keyIndex = localIndex
             keyIndexDirty = false
         } else {
             keyIndexDirty = true
         }
-        lowercasedKeyIndexDirty = true
-        lowercasedKeyIndex = nil
-        lowercasedKeysCache = nil
-        if touchedClass {
-            ownerElement?.markClassQueryIndexDirty()
-        }
-        if touchedId {
-            ownerElement?.markIdQueryIndexDirty()
-        }
-        ownerElement?.markAttributeQueryIndexDirty()
-        ownerElement?.markAttributeValueQueryIndexDirty()
-        ownerElement?.markSourceDirty()
         pendingAttributes?.removeAll(keepingCapacity: true)
     }
 
@@ -345,7 +381,9 @@ open class Attributes: NSCopying {
             var rebuilt: [ByteSlice: Int] = [:]
             rebuilt.reserveCapacity(attributes.count)
             for (index, attr) in attributes.enumerated() {
-                rebuilt[attr.keySlice] = index
+                if rebuilt[attr.keySlice] == nil {
+                    rebuilt[attr.keySlice] = index
+                }
             }
             keyIndex = rebuilt
             keyIndexDirty = false
@@ -386,9 +424,11 @@ open class Attributes: NSCopying {
     @inline(__always)
     open func get(key: [UInt8]) -> [UInt8] {
         DebugTrace.log("Attributes.get(key): \(String(decoding: key, as: UTF8.self))")
-        if attributes.isEmpty, let pendingValue = pendingValueCaseSensitive(key) {
-            DebugTrace.log("Attributes.get: pending value hit")
-            return pendingValue
+        if attributes.isEmpty {
+            if let value = pendingValueCaseSensitive(key) { return value }
+            // Validation may have materialized an ambiguous batch. Otherwise a
+            // miss is conclusive and must not instantiate every Attribute.
+            if attributes.isEmpty { return [] }
         }
         ensureMaterialized()
         if let ix = indexForKey(key) {
@@ -412,11 +452,12 @@ open class Attributes: NSCopying {
     
     @inline(__always)
     open func getIgnoreCase(key: [UInt8]) throws -> [UInt8] {
-        if attributes.isEmpty, let pendingValue = pendingValueIgnoreCase(key) {
-            return pendingValue
+        try Validate.notEmpty(string: key)
+        if attributes.isEmpty {
+            if let value = pendingValueIgnoreCase(key) { return value }
+            if attributes.isEmpty { return [] }
         }
         ensureMaterialized()
-        try Validate.notEmpty(string: key)
         let keySlice = ByteSlice.fromArray(key)
         let hasUppercase = Attributes.containsAsciiUppercase(key)
         if !Self.disableLowercasedKeyIndex, shouldBuildKeyIndex() {
@@ -449,6 +490,7 @@ open class Attributes: NSCopying {
     @inline(__always)
     @usableFromInline
     internal func getIgnoreCaseSlice(key: [UInt8]) throws -> ByteSlice {
+        try Validate.notEmpty(string: key)
         if attributes.isEmpty {
             if let pendingSlice = pendingValueIgnoreCaseSlice(key) {
                 return pendingSlice
@@ -456,9 +498,9 @@ open class Attributes: NSCopying {
             if let pendingValue = pendingValueIgnoreCase(key) {
                 return ByteSlice.fromArray(pendingValue)
             }
+            if attributes.isEmpty { return ByteSlice.empty }
         }
         ensureMaterialized()
-        try Validate.notEmpty(string: key)
         let keySlice = ByteSlice.fromArray(key)
         let hasUppercase = Attributes.containsAsciiUppercase(key)
         if !Self.disableLowercasedKeyIndex, shouldBuildKeyIndex() {
@@ -531,6 +573,7 @@ open class Attributes: NSCopying {
     open func put(attribute: Attribute) {
         ensureMaterialized()
         putMaterialized(attribute)
+        attribute.observeMutations(in: self)
     }
     
     /**
@@ -676,6 +719,7 @@ open class Attributes: NSCopying {
         let originalCount = attributes.count
         for readIndex in 0..<originalCount {
             let attr = attributes[readIndex]
+            attr.observeMutations(in: self)
             let decision = body(attr)
             if let newValue = decision.newValue {
                 _ = attr.setValue(value: newValue)
@@ -726,6 +770,7 @@ open class Attributes: NSCopying {
         ensureMaterialized()
         guard !key.isEmpty else { return }
         if let ix = indexForKey(key) {
+            attributes[ix].observeMutations(in: self)
             attributes[ix].appendValueSlice(slice)
             let normalizedKey = key.lowercased()
             if normalizedKey == UTF8Arrays.class_ {
@@ -761,8 +806,9 @@ open class Attributes: NSCopying {
     
     @inline(__always)
     open func hasKey(key: [UInt8]) -> Bool {
-        if attributes.isEmpty, pendingHasKeyCaseSensitive(key) {
-            return true
+        if attributes.isEmpty {
+            if pendingHasKeyCaseSensitive(key) { return true }
+            if attributes.isEmpty { return false }
         }
         ensureMaterialized()
         return indexForKey(key) != nil
@@ -783,8 +829,9 @@ open class Attributes: NSCopying {
 
     @inline(__always)
     open func hasKeyIgnoreCase(key: [UInt8]) -> Bool {
-        if attributes.isEmpty, pendingHasKeyIgnoreCase(key) {
-            return true
+        if attributes.isEmpty {
+            if pendingHasKeyIgnoreCase(key) { return true }
+            if attributes.isEmpty { return false }
         }
         ensureMaterialized()
         guard !key.isEmpty else { return false }
@@ -813,8 +860,9 @@ open class Attributes: NSCopying {
     
     @inlinable
     open func hasKeyIgnoreCase<T: Collection>(key: T) -> Bool where T.Element == UInt8 {
-        if attributes.isEmpty, pendingHasKeyIgnoreCase(key) {
-            return true
+        if attributes.isEmpty {
+            if pendingHasKeyIgnoreCase(key) { return true }
+            if attributes.isEmpty { return false }
         }
         ensureMaterialized()
         guard !key.isEmpty else { return false }
@@ -849,76 +897,116 @@ open class Attributes: NSCopying {
     @inline(__always)
     @usableFromInline
     internal func pendingHasKeyCaseSensitive(_ key: [UInt8]) -> Bool {
-        return pendingValueCaseSensitive(key) != nil
+        return pendingAttributeCaseSensitive(key) != nil
     }
 
     @inline(__always)
     @usableFromInline
     internal func pendingHasKeyIgnoreCase<T: Collection>(_ key: T) -> Bool where T.Element == UInt8 {
-        return pendingValueIgnoreCase(key) != nil
+        return pendingAttributeIgnoreCase(key) != nil
+    }
+
+    // Deferred reads can stop at the first match only when names are valid,
+    // normalized, and unique. Ambiguous batches use the existing materializer,
+    // which keeps the first position and the last value of an exact duplicate.
+    // Ordinary parser batches stay deferred, and validation is amortized once.
+    @usableFromInline
+    internal func ensureCanonicalPendingNames() {
+        guard !pendingNamesAreCanonical, attributes.isEmpty else { return }
+        guard let pending = pendingAttributes, !pending.isEmpty else {
+            pendingNamesAreCanonical = true
+            return
+        }
+        // Keep worst-case collision work bounded. Larger batches use an exact
+        // hash set; small parser batches avoid its allocation and name wrapping.
+        if pending.count <= 32 {
+            let canonical = withUnsafeTemporaryAllocation(of: UInt64.self, capacity: 32) { masks in
+                masks.initialize(repeating: 0)
+                defer { masks.deinitialize() }
+                var seen: UInt64 = 0
+                for index in pending.indices {
+                    let attr = pending[index]
+                    guard let mask = attr.canonicalNameMask() else { return false }
+                    if seen & mask != 0 {
+                        // Scan cheap stored masks, not whole PendingAttribute values.
+                        for previous in 0..<index where masks[previous] == mask {
+                            if attr.hasSameName(as: pending[previous]) { return false }
+                        }
+                    }
+                    masks[index] = mask
+                    seen |= mask
+                }
+                return true
+            }
+            if !canonical { ensureMaterialized() }
+            pendingNamesAreCanonical = true
+            return
+        }
+        var seen = Set<ByteSlice>()
+        seen.reserveCapacity(pending.count)
+        for attr in pending {
+            guard attr.canonicalNameMask() != nil else {
+                ensureMaterialized()
+                pendingNamesAreCanonical = true
+                return
+            }
+            // Names are already validated; do not trim them a second time.
+            let key = attr.nameBytes.map { ByteSlice.fromArray($0) } ?? attr.nameSlice!
+            guard seen.insert(key).inserted else {
+                ensureMaterialized()
+                pendingNamesAreCanonical = true
+                return
+            }
+        }
+        pendingNamesAreCanonical = true
+    }
+
+    @inline(__always)
+    @usableFromInline
+    internal func pendingAttributeCaseSensitive(_ key: [UInt8]) -> PendingAttribute? {
+        ensureCanonicalPendingNames()
+        guard !key.isEmpty, attributes.isEmpty, let pending = pendingAttributes else { return nil }
+        for attr in pending {
+            if let nameBytes = attr.nameBytes {
+                if nameBytes == key { return attr }
+            } else if let nameSlice = attr.nameSlice, equalsSlice(nameSlice, key) {
+                return attr
+            }
+        }
+        return nil
+    }
+
+    @inline(__always)
+    @usableFromInline
+    internal func pendingAttributeIgnoreCase<T: Collection>(_ key: T) -> PendingAttribute? where T.Element == UInt8 {
+        ensureCanonicalPendingNames()
+        guard !key.isEmpty, attributes.isEmpty, let pending = pendingAttributes else { return nil }
+        for attr in pending {
+            if let nameBytes = attr.nameBytes {
+                if equalsIgnoreCase(nameBytes, key) { return attr }
+            } else if let nameSlice = attr.nameSlice, equalsIgnoreCase(nameSlice, key) {
+                return attr
+            }
+        }
+        return nil
     }
 
     @inline(__always)
     @usableFromInline
     internal func pendingValueCaseSensitive(_ key: [UInt8]) -> [UInt8]? {
-        guard !key.isEmpty, attributes.isEmpty, let pending = pendingAttributes, !pending.isEmpty else {
-            return nil
-        }
-        for pendingAttr in pending {
-            if let nameBytes = pendingAttr.nameBytes {
-                if nameBytes == key {
-                    return materializePendingValue(pendingAttr.value)
-                }
-            } else if let nameSlice = pendingAttr.nameSlice {
-                if equalsSlice(nameSlice, key) {
-                    return materializePendingValue(pendingAttr.value)
-                }
-            }
-        }
-        return nil
+        return pendingAttributeCaseSensitive(key).map { materializePendingValue($0.value) }
     }
 
     @inline(__always)
     @usableFromInline
     internal func pendingValueCaseSensitiveSlice(_ key: [UInt8]) -> ByteSlice? {
-        guard !key.isEmpty, attributes.isEmpty, let pending = pendingAttributes, !pending.isEmpty else {
-            return nil
-        }
-        for pendingAttr in pending {
-            if let nameBytes = pendingAttr.nameBytes {
-                if nameBytes == key {
-                    switch pendingAttr.value {
-                    case .none, .empty:
-                        return ByteSlice.empty
-                    case .slice(let slice):
-                        return slice
-                    case .bytes(let bytes):
-                        return ByteSlice.fromArray(bytes)
-                    default:
-                        return nil
-                    }
-                }
-            } else if let nameSlice = pendingAttr.nameSlice {
-                if equalsSlice(nameSlice, key) {
-                    switch pendingAttr.value {
-                    case .none, .empty:
-                        return ByteSlice.empty
-                    case .slice(let slice):
-                        return slice
-                    case .bytes(let bytes):
-                        return ByteSlice.fromArray(bytes)
-                    default:
-                        return nil
-                    }
-                }
-            }
-        }
-        return nil
+        return pendingAttributeCaseSensitive(key).flatMap { pendingValueSlice($0.value) }
     }
 
     @inline(__always)
     @usableFromInline
     internal func valueSliceCaseSensitive(_ key: [UInt8]) -> ByteSlice? {
+        ensureCanonicalPendingNames()
         if attributes.isEmpty {
             if let pendingSlice = pendingValueCaseSensitiveSlice(key) {
                 return pendingSlice
@@ -938,59 +1026,29 @@ open class Attributes: NSCopying {
     @inline(__always)
     @usableFromInline
     internal func pendingValueIgnoreCase<T: Collection>(_ key: T) -> [UInt8]? where T.Element == UInt8 {
-        guard !key.isEmpty, attributes.isEmpty, let pending = pendingAttributes, !pending.isEmpty else {
-            return nil
-        }
-        for pendingAttr in pending {
-            if let nameBytes = pendingAttr.nameBytes {
-                if equalsIgnoreCase(nameBytes, key) {
-                    return materializePendingValue(pendingAttr.value)
-                }
-            } else if let nameSlice = pendingAttr.nameSlice {
-                if equalsIgnoreCase(nameSlice, key) {
-                    return materializePendingValue(pendingAttr.value)
-                }
-            }
-        }
-        return nil
+        return pendingAttributeIgnoreCase(key).map { materializePendingValue($0.value) }
     }
 
     @inline(__always)
     @usableFromInline
     internal func pendingValueIgnoreCaseSlice<T: Collection>(_ key: T) -> ByteSlice? where T.Element == UInt8 {
-        guard !key.isEmpty, attributes.isEmpty, let pending = pendingAttributes, !pending.isEmpty else {
+        return pendingAttributeIgnoreCase(key).flatMap { pendingValueSlice($0.value) }
+    }
+
+    @inline(__always)
+    @usableFromInline
+    internal func pendingValueSlice(_ value: PendingAttrValue) -> ByteSlice? {
+        switch value {
+        case .none, .empty:
+            return ByteSlice.empty
+        case .slice(let slice):
+            return slice
+        case .bytes(let bytes):
+            return ByteSlice.fromArray(bytes)
+        case .slices:
+            // The byte-returning fallback joins fragmented storage only when needed.
             return nil
         }
-        for pendingAttr in pending {
-            if let nameBytes = pendingAttr.nameBytes {
-                if equalsIgnoreCase(nameBytes, key) {
-                    switch pendingAttr.value {
-                    case .none, .empty:
-                        return ByteSlice.empty
-                    case .slice(let slice):
-                        return slice
-                    case .bytes(let bytes):
-                        return ByteSlice.fromArray(bytes)
-                    default:
-                        return nil
-                    }
-                }
-            } else if let nameSlice = pendingAttr.nameSlice {
-                if equalsIgnoreCase(nameSlice, key) {
-                    switch pendingAttr.value {
-                    case .none, .empty:
-                        return ByteSlice.empty
-                    case .slice(let slice):
-                        return slice
-                    case .bytes(let bytes):
-                        return ByteSlice.fromArray(bytes)
-                    default:
-                        return nil
-                    }
-                }
-            }
-        }
-        return nil
     }
 
     @inline(__always)
@@ -1086,18 +1144,20 @@ open class Attributes: NSCopying {
         guard let incoming = incoming else { return }
         incoming.ensureMaterialized()
         for attr in incoming.attributes {
+            attr.observeMutations(in: incoming)
             put(attribute: attr)
         }
     }
     
     /**
-     Get the attributes as a List, for iteration. Do not modify the keys of the attributes via this view, as changes
-     to keys will not be recognised in the containing set.
-     - returns: an view of the attributes as a List.
+     Get a snapshot of the attribute list containing live, mutable attribute references.
+     Key and value changes update the containing collections; editing the returned array does not.
+     - returns: a snapshot of the attribute references in insertion order.
      */
     @inline(__always)
     open func asList() -> [Attribute] {
         ensureMaterialized()
+        observeAttributeMutations()
         return attributes
     }
     
@@ -1145,14 +1205,7 @@ open class Attributes: NSCopying {
     @usableFromInline
     @inline(__always)
     internal func appendPendingHtml(_ attr: PendingAttribute, _ accum: StringBuilder, _ out: OutputSettings) {
-        let keySlice: ByteSlice
-        if let nameSlice = attr.nameSlice {
-            keySlice = nameSlice.trim()
-        } else if let nameBytes = attr.nameBytes {
-            keySlice = ByteSlice.fromArray(nameBytes).trim()
-        } else {
-            return
-        }
+        guard let keySlice = attr.normalizedKey() else { return }
         accum.append(keySlice)
 
         var valueSlice: ByteSlice? = nil
@@ -1178,7 +1231,7 @@ open class Attributes: NSCopying {
             hasValue = true
             valueSlice = ByteSlice.fromArray(bytes)
         }
-        let keyLower = attr.hasUppercase ? keySlice.lowercased() : keySlice
+        let keyLower = keySlice.lowercased()
         let isImplicitBoolean = {
             switch attr.value {
             case .none: return true
@@ -1207,6 +1260,7 @@ open class Attributes: NSCopying {
     
     @inlinable
     public func html(accum: StringBuilder, out: OutputSettings ) throws {
+        ensureCanonicalPendingNames()
         if attributes.isEmpty, let pending = pendingAttributes, !pending.isEmpty {
             for attr in pending {
                 accum.append(UTF8Arrays.whitespace)
@@ -1263,34 +1317,21 @@ open class Attributes: NSCopying {
     open func lowercaseAllKeys() {
         ensureMaterialized()
         guard hasUppercaseKeys else { return }
-        for ix in attributes.indices {
-            let lowered = attributes[ix].lowerKeySlice()
-            attributes[ix].keySlice = lowered
-            attributes[ix].keyBytes = nil
-            attributes[ix].lowerKeySliceCache = lowered
+        for attribute in attributes {
+            // Notify shared owners, preserving normalization's storage-only behavior.
+            attribute.setNormalizedKey(attribute.lowerKeySlice())
         }
         hasUppercaseKeys = false
         invalidateLowercasedKeysCache()
         invalidateKeyIndex()
-        ownerElement?.markClassQueryIndexDirty()
-        ownerElement?.markIdQueryIndexDirty()
-        ownerElement?.markAttributeQueryIndexDirty()
-        ownerElement?.markAttributeValueQueryIndexDirty()
-        ownerElement?.markSourceDirty()
+        notifyMutationOwners()
     }
     
     @inline(__always)
     public func copy(with zone: NSZone? = nil) -> Any {
         ensureMaterialized()
-        let clone = Attributes()
-        clone.attributes = attributes
-        clone.hasUppercaseKeys = hasUppercaseKeys
-        clone.lowercasedKeysCache = nil
-        clone.lowercasedKeyIndex = nil
-        clone.lowercasedKeyIndexDirty = true
-        clone.keyIndex = nil
-        clone.keyIndexDirty = true
-        return clone
+        let copied = attributes.map { $0.clone() }
+        return Attributes(copying: copied, hasUppercaseKeys: copied.contains { Self.containsAsciiUppercase($0.keySlice) })
     }
     
     @inline(__always)
@@ -1317,12 +1358,9 @@ open class Attributes: NSCopying {
 
     @inline(__always)
     internal static func containsAsciiUppercase(_ key: ByteSlice) -> Bool {
-        for b in key {
-            if b >= 65 && b <= 90 {
-                return true
-            }
+        return key.withUnsafeBytes { bytes in
+            bytes.contains { $0 >= 65 && $0 <= 90 }
         }
-        return false
     }
     
 }
@@ -1330,6 +1368,7 @@ open class Attributes: NSCopying {
 extension Attributes: Sequence {
     public func makeIterator() -> AnyIterator<Attribute> {
         ensureMaterialized()
+        observeAttributeMutations()
         return AnyIterator(attributes.makeIterator())
     }
 }

--- a/Sources/BooleanAttribute.swift
+++ b/Sources/BooleanAttribute.swift
@@ -25,6 +25,10 @@ open class BooleanAttribute: Attribute {
         try super.init(keySlice: keySlice, valueSlice: ByteSlice.empty)
     }
 
+    internal override init(copying other: Attribute) {
+        super.init(copying: other)
+    }
+
     public convenience init(keySlice: ArraySlice<UInt8>) throws {
         try self.init(key: Array(keySlice))
     }

--- a/Sources/DataNode.swift
+++ b/Sources/DataNode.swift
@@ -83,11 +83,8 @@ open class DataNode: Node {
 
     @inline(__always)
     open func getWholeDataUTF8() -> [UInt8] {
-        if let materialized = materializeRawDataIfNeeded() {
-            do {
-                try ensureAttributesForWrite().put(DataNode.DATA_KEY, materialized)
-            } catch {}
-            return materialized
+        if rawDataSlice != nil || rawDataSlices != nil {
+            _ = ensureDataAttributes()
         }
         guard let attributes = attributes else {
             return []
@@ -96,6 +93,40 @@ open class DataNode: Node {
             return slice.toArray()
         }
         return []
+    }
+
+    private func ensureDataAttributes() -> Attributes {
+        if let attributes { return attributes }
+        let bytes = materializeRawDataIfNeeded() ?? []
+        let created = Attributes()
+        // Populate before attaching, so reads do not dirty source or selector caches.
+        try? created.put(DataNode.DATA_KEY, bytes)
+        attributes = created
+        return created
+    }
+
+    internal override func ensureAttributesForWrite() -> Attributes {
+        return ensureDataAttributes()
+    }
+
+    open override func getAttributes() -> Attributes? {
+        return ensureDataAttributes()
+    }
+
+    open override func attr(_ attributeKey: [UInt8]) throws -> [UInt8] {
+        _ = ensureDataAttributes()
+        return try super.attr(attributeKey)
+    }
+
+    open override func hasAttr(_ attributeKey: [UInt8]) -> Bool {
+        _ = ensureDataAttributes()
+        return super.hasAttr(attributeKey)
+    }
+
+    @discardableResult
+    open override func removeAttr(_ attributeKey: [UInt8]) throws -> Node {
+        _ = ensureDataAttributes()
+        return try super.removeAttr(attributeKey)
     }
 
     @usableFromInline
@@ -115,23 +146,11 @@ open class DataNode: Node {
 
     @usableFromInline
     internal func appendSlice(_ slice: ByteSlice) {
+        guard !slice.isEmpty else { return }
         if let attrs = attributes {
-            if !attrs.hasKey(key: DataNode.DATA_KEY) {
-                if let slices = rawDataSlices {
-                    for existing in slices {
-                        attrs.appendValueSlice(key: DataNode.DATA_KEY, slice: existing)
-                    }
-                    rawDataSlices = nil
-                    rawDataSlicesCount = 0
-                } else if let existingSlice = rawDataSlice {
-                    attrs.appendValueSlice(key: DataNode.DATA_KEY, slice: existingSlice)
-                    rawDataSlice = nil
-                }
-            }
             attrs.appendValueSlice(key: DataNode.DATA_KEY, slice: slice)
-        } else if var slices = rawDataSlices {
-            slices.append(slice)
-            rawDataSlices = slices
+        } else if rawDataSlices != nil {
+            rawDataSlices!.append(slice)
             rawDataSlicesCount += slice.count
         } else if let existingSlice = rawDataSlice {
             rawDataSlices = [existingSlice, slice]
@@ -140,6 +159,7 @@ open class DataNode: Node {
         } else {
             rawDataSlice = slice
         }
+        if attributes == nil { bumpTextMutationVersion() }
         markSourceDirty()
     }
 

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -14,50 +14,54 @@ import Foundation
 @usableFromInline
 final class SelectorResultCache {
     @usableFromInline
-    final class LRUNode {
+    final class LRUNode<Value> {
         let key: String
-        var value: Elements
-        var prev: LRUNode?
-        var next: LRUNode?
+        var value: Value
+        var prev: LRUNode<Value>?
+        var next: LRUNode<Value>?
 
-        init(key: String, value: Elements) {
+        init(key: String, value: Value) {
             self.key = key
             self.value = value
         }
     }
 
     @usableFromInline
-    final class LRUMap {
+    final class Storage<Value> {
         let capacity: Int
-        private var nodes: [String: LRUNode] = [:]
-        private var head: LRUNode?
-        private var tail: LRUNode?
+        private var nodes: [SelectorQueryKey: LRUNode<Value>] = [:]
+        private var head: LRUNode<Value>?
+        private var tail: LRUNode<Value>?
 
         init(capacity: Int) {
             self.capacity = max(1, capacity)
         }
 
-        @inline(__always)
-        func contains(_ key: String) -> Bool {
-            return nodes[key] != nil
+        deinit {
+            clear()
         }
 
         @inline(__always)
-        func get(_ key: String) -> Elements? {
-            guard let node = nodes[key] else { return nil }
+        func contains(_ key: String) -> Bool {
+            return nodes[SelectorQueryKey(key)] != nil
+        }
+
+        @inline(__always)
+        func get(_ key: String) -> Value? {
+            guard let node = nodes[SelectorQueryKey(key)] else { return nil }
             moveToHead(node)
             return node.value
         }
 
         @inline(__always)
-        func set(_ key: String, _ value: Elements) -> LRUNode? {
-            if let node = nodes[key] {
+        func set(_ key: String, _ value: Value) -> LRUNode<Value>? {
+            if let node = nodes[SelectorQueryKey(key)] {
                 node.value = value
                 moveToHead(node)
                 return nil
             }
             let node = LRUNode(key: key, value: value)
-            nodes[key] = node
+            nodes[SelectorQueryKey(key)] = node
             insertAtHead(node)
             if nodes.count > capacity {
                 return popTail()
@@ -66,29 +70,35 @@ final class SelectorResultCache {
         }
 
         @inline(__always)
-        func remove(_ key: String) -> Elements? {
-            guard let node = nodes.removeValue(forKey: key) else { return nil }
+        func remove(_ key: String) -> Value? {
+            guard let node = nodes.removeValue(forKey: SelectorQueryKey(key)) else { return nil }
             removeNode(node)
             return node.value
         }
 
         @inline(__always)
-        func popTail() -> LRUNode? {
+        func popTail() -> LRUNode<Value>? {
             guard let tail else { return nil }
             removeNode(tail)
-            nodes.removeValue(forKey: tail.key)
+            nodes.removeValue(forKey: SelectorQueryKey(tail.key))
             return tail
         }
 
         @inline(__always)
         func clear() {
+            // Both links are strong. Break the chain before releasing the map
+            // so cached elements are not kept alive by adjacent LRU nodes.
+            for node in nodes.values {
+                node.prev = nil
+                node.next = nil
+            }
             nodes.removeAll(keepingCapacity: true)
             head = nil
             tail = nil
         }
 
         @inline(__always)
-        private func insertAtHead(_ node: LRUNode) {
+        private func insertAtHead(_ node: LRUNode<Value>) {
             node.prev = nil
             node.next = head
             if let head {
@@ -100,14 +110,14 @@ final class SelectorResultCache {
         }
 
         @inline(__always)
-        private func moveToHead(_ node: LRUNode) {
+        private func moveToHead(_ node: LRUNode<Value>) {
             guard head !== node else { return }
             removeNode(node)
             insertAtHead(node)
         }
 
         @inline(__always)
-        private func removeNode(_ node: LRUNode) {
+        private func removeNode(_ node: LRUNode<Value>) {
             let prev = node.prev
             let next = node.next
             if let prev {
@@ -126,25 +136,46 @@ final class SelectorResultCache {
     }
 
     @usableFromInline
-    let probationary: LRUMap
+    typealias LRUMap = Storage<Elements>
+
     @usableFromInline
-    let protected: LRUMap
+    struct Result {
+        let elements: [Element]
+        let includesOwner: Bool
+
+        init(elements: [Element], includesOwner: Bool) {
+            self.elements = elements
+            self.includesOwner = includesOwner
+        }
+
+        func materialize(owner: Element) -> Elements {
+            if includesOwner {
+                return Elements([owner] + elements)
+            }
+            return Elements(elements)
+        }
+    }
+
+    @usableFromInline
+    let probationary: Storage<Result>
+    @usableFromInline
+    let protected: Storage<Result>
     private let doorkeeperCapacity: Int
-    private var doorkeeper: Set<String> = []
-    private var doorkeeperOrder: [String] = []
+    private var doorkeeper: Set<SelectorQueryKey> = []
+    private var doorkeeperOrder: [SelectorQueryKey] = []
 
     init(capacity: Int) {
         let protectedCap = max(1, (capacity * 3) / 4)
         let probationaryCap = max(1, capacity - protectedCap)
-        probationary = LRUMap(capacity: probationaryCap)
-        protected = LRUMap(capacity: protectedCap)
+        probationary = Storage(capacity: probationaryCap)
+        protected = Storage(capacity: protectedCap)
         doorkeeperCapacity = max(1, capacity)
         doorkeeper.reserveCapacity(doorkeeperCapacity)
         doorkeeperOrder.reserveCapacity(doorkeeperCapacity)
     }
 
     @inline(__always)
-    func get(_ key: String) -> Elements? {
+    func get(_ key: String) -> Result? {
         if let value = protected.get(key) {
             return value
         }
@@ -158,7 +189,7 @@ final class SelectorResultCache {
     }
 
     @inline(__always)
-    func put(_ key: String, _ value: Elements) {
+    func put(_ key: String, _ value: Result) {
         if protected.contains(key) {
             _ = protected.set(key, value)
             return
@@ -167,16 +198,17 @@ final class SelectorResultCache {
             _ = probationary.set(key, value)
             return
         }
-        if doorkeeper.contains(key) {
-            doorkeeper.remove(key)
-            if let idx = doorkeeperOrder.firstIndex(of: key) {
+        let admissionKey = SelectorQueryKey(key)
+        if doorkeeper.contains(admissionKey) {
+            doorkeeper.remove(admissionKey)
+            if let idx = doorkeeperOrder.firstIndex(of: admissionKey) {
                 doorkeeperOrder.remove(at: idx)
             }
             _ = probationary.set(key, value)
             return
         }
-        doorkeeper.insert(key)
-        doorkeeperOrder.append(key)
+        doorkeeper.insert(admissionKey)
+        doorkeeperOrder.append(admissionKey)
         if doorkeeperOrder.count > doorkeeperCapacity {
             let removed = doorkeeperOrder.removeFirst()
             doorkeeper.remove(removed)
@@ -380,13 +412,11 @@ open class Element: Node {
      */
     public convenience init(_ tag: Tag, _ baseUri: String, _ attributes: Attributes, skipChildReserve: Bool = false) {
         self.init(tag, baseUri.utf8Array, attributes, skipChildReserve: skipChildReserve)
-        attributes.ownerElement = self
     }
     
     public init(_ tag: Tag, _ baseUri: [UInt8], _ attributes: Attributes, skipChildReserve: Bool = false) {
         self._tag = tag
         super.init(baseUri, attributes: attributes, skipChildReserve: skipChildReserve)
-        attributes.ownerElement = self
     }
     /**
      Create a new Element from a tag and a base URI.
@@ -399,7 +429,6 @@ open class Element: Node {
      */
     public convenience init(_ tag: Tag, _ baseUri: String, skipChildReserve: Bool = false) {
         self.init(tag, baseUri.utf8Array, skipChildReserve: skipChildReserve)
-        attributes?.ownerElement = self
     }
     
     public init(_ tag: Tag, _ baseUri: [UInt8], skipChildReserve: Bool = false) {
@@ -514,7 +543,6 @@ open class Element: Node {
             return attributes
         }
         let created = Attributes()
-        created.ownerElement = self
         attributes = created
         return created
     }
@@ -541,7 +569,13 @@ open class Element: Node {
         if Element.isAbsAttributeKey(attributeKey) {
             return nil
         }
-        return attributes.valueSliceCaseSensitive(attributeKey)
+        if !attributes.hasUppercaseKeys {
+            return attributes.valueSliceCaseSensitive(attributeKey)
+        }
+        // Attribute predicates are case-insensitive even after case-preserving
+        // mutation. Keep absence distinct from a present, empty value.
+        guard attributes.hasKeyIgnoreCase(key: attributeKey) else { return nil }
+        return try? attributes.getIgnoreCaseSlice(key: attributeKey)
     }
 
     @usableFromInline
@@ -700,6 +734,20 @@ open class Element: Node {
      */
     @inline(__always)
     open func child(_ index: Int) -> Element {
+        let elementType = type(of: self)
+        if index >= 0,
+           elementType == Element.self || elementType == Document.self || elementType == FormElement.self {
+            // Built-in children() views filter this storage without callbacks.
+            // Stop at the requested element instead of materializing every child.
+            var remaining = index
+            for node in childNodes {
+                if let element = node as? Element {
+                    if remaining == 0 { return element }
+                    remaining -= 1
+                }
+            }
+        }
+        // Preserve custom children()/get() projections and out-of-bounds behavior.
         return children().get(index)
     }
     
@@ -834,6 +882,7 @@ open class Element: Node {
         if !isBulkBuilding {
             child.markSourceDirty()
             markSourceDirty()
+            bumpTextMutationVersion()
         }
         return self
     }
@@ -1032,7 +1081,11 @@ open class Element: Node {
     @discardableResult
     @inline(__always)
     public func empty() -> Element {
+        guard !childNodes.isEmpty else { return self }
         markQueryIndexesDirty()
+        // Retained children remain valid independent subtrees, not phantom
+        // members of this element with obsolete sibling positions.
+        for child in childNodes { child.parentNode = nil }
         childNodes.removeAll()
         bumpTextMutationVersion()
         markSourceDirty()
@@ -1091,14 +1144,31 @@ open class Element: Node {
 
     private static func cssEscapeIdentifier(_ identifier: String) -> String {
         var escaped = ""
-        escaped.reserveCapacity(identifier.count)
+        escaped.reserveCapacity(identifier.utf8.count)
 
-        for character in identifier {
-            if Character.isLetterOrDigit(character) || character == "-" || character == "_" {
-                escaped.append(character)
+        let scalars = identifier.unicodeScalars
+        let isLoneHyphen = identifier == "-"
+        for (offset, scalar) in scalars.enumerated() {
+            let value = scalar.value
+            if value == 0 {
+                // CSS cannot represent U+0000 in an identifier.
+                escaped.unicodeScalars.append("\u{FFFD}")
+            } else if value <= 0x20 || value == 0x7F ||
+                        ((0x30...0x39).contains(value) &&
+                         (offset == 0 || (offset == 1 && scalars.first == "-"))) {
+                // Hex-escape controls and leading digits. Also encode spaces so
+                // query trimming cannot remove a trailing escaped literal space.
+                escaped.append("\\")
+                escaped.append(String(value, radix: 16))
+                escaped.append(" ")
+            } else if value >= 0x80 || value == 0x5F ||
+                        (value == 0x2D && !isLoneHyphen) ||
+                        (0x30...0x39).contains(value) ||
+                        (0x41...0x5A).contains(value) || (0x61...0x7A).contains(value) {
+                escaped.unicodeScalars.append(scalar)
             } else {
                 escaped.append("\\")
-                escaped.append(character)
+                escaped.unicodeScalars.append(scalar)
             }
         }
 
@@ -1134,45 +1204,75 @@ open class Element: Node {
      - returns: the next element, or `nil` if there is no next element
      - seealso: ``previousElementSibling()``
      */
-    public func nextElementSibling()throws->Element? {
-        if (parentNode == nil) {return nil}
-        let siblings: Array<Element>? = parent()?.children().array()
-        let index: Int? = try Element.indexInList(self, siblings)
-        try Validate.notNull(obj: index)
-        if let siblings = siblings {
-            if (siblings.count > index!+1) {
-                return siblings[index!+1]
-            } else {
-                return nil
-            }
-        }
-        return nil
+    public func nextElementSibling() throws -> Element? {
+        return try adjacentElementSibling(forward: true)
     }
-    
+
     /**
      Gets the previous element sibling of this element.
      - returns: the previous element, or `nil` if there is no previous element
      - seealso: ``nextElementSibling()``
      */
-    public func previousElementSibling()throws->Element? {
-        if (parentNode == nil) {return nil}
-        let siblings: Array<Element>? = parent()?.children().array()
-        let index: Int? = try Element.indexInList(self, siblings)
-        try Validate.notNull(obj: index)
-        if (index! > 0) {
-            return siblings?[index!-1]
-        } else {
-            return nil
-        }
+    public func previousElementSibling() throws -> Element? {
+        return try adjacentElementSibling(forward: false)
     }
-    
+
+    private func adjacentElementSibling(forward: Bool) throws -> Element? {
+        guard parentNode != nil else { return nil }
+        let parent = parent()
+        try Validate.notNull(obj: parent)
+        let step = forward ? 1 : -1
+        let parentType = type(of: parent!)
+        if parentType != Element.self && parentType != Document.self && parentType != FormElement.self {
+            // Custom subclasses can override children(); preserve that view.
+            let siblings = parent!.children().array()
+            let index = try Element.indexInList(self, siblings)
+            try Validate.notNull(obj: index)
+            let adjacent = index! + step
+            return adjacent >= 0 && adjacent < siblings.count ? siblings[adjacent] : nil
+        }
+
+        let nodes = parent!.childNodes
+        var index = try indexInSiblingNodes(nodes) + step
+        while index >= 0 && index < nodes.count {
+            if let element = nodes[index] as? Element { return element }
+            index += step
+        }
+        return nil
+    }
+
+    private func indexInSiblingNodes(_ nodes: [Node]) throws -> Int {
+        let index = siblingIndex
+        if index >= 0, index < nodes.count, nodes[index] === self {
+            return index
+        }
+        // setSiblingIndex is public; preserve lookup behavior for a stale index.
+        let found = nodes.firstIndex { $0 === self }
+        try Validate.notNull(obj: found)
+        return found!
+    }
+
     /**
      Gets the first element sibling of this element.
      - returns: the first sibling that is an element (aka the parent's first element child)
      */
     public func firstElementSibling() -> Element? {
         // todo: should firstSibling() exclude this?
-        let siblings: Array<Element>? = parent()?.children().array()
+        let parent = parent()
+        if let parent {
+            let parentType = type(of: parent)
+            if parentType == Element.self || parentType == Document.self || parentType == FormElement.self {
+                var endpoint: Element?
+                for node in parent.childNodes {
+                    if let element = node as? Element {
+                        if let endpoint { return endpoint }
+                        endpoint = element
+                    }
+                }
+                return nil // Preserve the existing nil result for fewer than two elements.
+            }
+        }
+        let siblings: Array<Element>? = parent?.children().array()
         return (siblings != nil && siblings!.count > 1) ? siblings![0] : nil
     }
     
@@ -1184,7 +1284,25 @@ open class Element: Node {
      */
     public func elementSiblingIndex()throws->Int {
         if (parent() == nil) {return 0}
-        let x = try Element.indexInList(self, parent()?.children().array())
+        let parent = parent()
+        if let parent {
+            let parentType = type(of: parent)
+            if parentType == Element.self || parentType == Document.self || parentType == FormElement.self {
+                // Built-in parents expose childNodes in order. Count elements without
+                // allocating the complete filtered list or trusting siblingIndex.
+                var index = 0
+                for node in parent.childNodes {
+                    if let element = node as? Element {
+                        if element === self { return index }
+                        index += 1
+                    }
+                }
+                return 0
+            }
+        }
+        // Preserve custom parent()/children()/array() views, including a nil
+        // second parent() result and its original validation error.
+        let x = try Element.indexInList(self, parent?.children().array())
         return x == nil ? 0 : x!
     }
     
@@ -1194,7 +1312,21 @@ open class Element: Node {
      */
     @inline(__always)
     public func lastElementSibling() -> Element? {
-        let siblings: Array<Element>? = parent()?.children().array()
+        let parent = parent()
+        if let parent {
+            let parentType = type(of: parent)
+            if parentType == Element.self || parentType == Document.self || parentType == FormElement.self {
+                var endpoint: Element?
+                for node in parent.childNodes.reversed() {
+                    if let element = node as? Element {
+                        if let endpoint { return endpoint }
+                        endpoint = element
+                    }
+                }
+                return nil // Preserve the existing nil result for fewer than two elements.
+            }
+        }
+        let siblings: Array<Element>? = parent?.children().array()
         return (siblings != nil && siblings!.count > 1) ? siblings![siblings!.count - 1] : nil
     }
     
@@ -1270,9 +1402,9 @@ open class Element: Node {
      */
     @usableFromInline
     func getElementsById(_ id: [UInt8]) -> Elements {
-        let needsTrim = (id.first?.isWhitespace ?? false) || (id.last?.isWhitespace ?? false)
-        let keySlice = ByteSlice.fromArray(id)
-        let key = needsTrim ? keySlice.trim() : keySlice
+        // The parser has already removed selector syntax. Whitespace decoded
+        // from an escape is part of the ID, not query padding.
+        let key = ByteSlice.fromArray(id)
         if key.isEmpty {
             return Elements()
         }
@@ -1298,12 +1430,8 @@ open class Element: Node {
     public func getElementById(_ id: String) throws -> Element? {
         let idBytes = id.utf8Array
         try Validate.notEmpty(string: idBytes)
-        let needsTrim = (idBytes.first?.isWhitespace ?? false) || (idBytes.last?.isWhitespace ?? false)
-        let keySlice = ByteSlice.fromArray(idBytes)
-        let key = needsTrim ? keySlice.trim() : keySlice
-        if key.isEmpty {
-            return nil
-        }
+        // This API accepts a literal ID, not a CSS query: whitespace is significant.
+        let key = ByteSlice.fromArray(idBytes)
         if isIdQueryIndexDirty || normalizedIdIndex == nil {
             rebuildQueryIndexesForAllIds()
             isIdQueryIndexDirty = false
@@ -1410,6 +1538,15 @@ open class Element: Node {
         if key.isEmpty {
             return Elements()
         }
+        if key.starts(with: UTF8Arrays.absPrefix) {
+            // abs: attributes are computed from the base URI; the physical
+            // attribute-name index cannot determine whether they exist.
+            let elements = Elements()
+            traverseElementsDepthFirst { element in
+                if element.hasAttr(key) { elements.add(element) }
+            }
+            return elements
+        }
         if isAttributeQueryIndexDirty || normalizedAttributeNameIndex == nil {
             rebuildQueryIndexesForAllAttributes()
             isAttributeQueryIndexDirty = false
@@ -1454,10 +1591,10 @@ open class Element: Node {
                 lowerAscii(bytes[2]) == UTF8Arrays.absPrefix[2] &&
                 bytes[3] == UTF8Arrays.absPrefix[3]
         }
-        if hasAbsPrefix(keyBytes) {
+        let needsTrim = (keyBytes.first?.isWhitespace ?? false) || (keyBytes.last?.isWhitespace ?? false)
+        if hasAbsPrefix(needsTrim ? keyBytes.trim() : keyBytes) {
             return try Collector.collect(Evaluator.AttributeWithValue(key, value), self)
         }
-        let needsTrim = (keyBytes.first?.isWhitespace ?? false) || (keyBytes.last?.isWhitespace ?? false)
         let keySlice = ByteSlice.fromArray(keyBytes)
         let trimmedKeySlice = needsTrim ? keySlice.trim() : keySlice
         let normalizedKey = Attributes.containsAsciiUppercase(trimmedKeySlice) ? trimmedKeySlice.lowercased() : trimmedKeySlice
@@ -2374,22 +2511,29 @@ open class Element: Node {
     }
     
     /**
-     Get the combined data of this element. Data is e.g. the inside of a `script` tag.
+     Get the combined script/style data and comment contents in descendant document order.
+     Ordinary text and declaration nodes are excluded; whitespace is preserved.
      - returns: the data, or empty string if none
      - seealso: ``dataNodes()``
      */
     public func data() -> String {
-        let sb: StringBuilder = StringBuilder()
-        
-        for childNode: Node in childNodes {
-            if let data = (childNode as? DataNode) {
-                sb.append(data.getWholeDataUTF8())
-            } else if let element = (childNode as? Element) {
-                let elementData: String = element.data()
-                sb.append(elementData)
+        let accum = StringBuilder()
+        var pending = Array(childNodes.reversed())
+        while let node = pending.popLast() {
+            if let data = node as? DataNode {
+                if type(of: data) == DataNode.self {
+                    accum.append(data.wholeDataSlice())
+                } else {
+                    // Preserve public getter overrides on custom DataNode subclasses.
+                    accum.append(data.getWholeDataUTF8())
+                }
+            } else if let comment = node as? Comment {
+                accum.append(comment.getDataUTF8())
+            } else if let element = node as? Element {
+                pending.append(contentsOf: element.childNodes.reversed())
             }
         }
-        return sb.toString()
+        return accum.toString()
     }
     
     /**
@@ -2399,7 +2543,7 @@ open class Element: Node {
      */
     public func className() throws -> String {
         guard let attributes else { return "" }
-        let slice = try attributes.getIgnoreCaseSlice(key: Element.classString).trim()
+        let slice = Element.trimClassWhitespace(try attributes.getIgnoreCaseSlice(key: Element.classString))
         return String(decoding: slice, as: UTF8.self)
     }
     
@@ -2410,7 +2554,7 @@ open class Element: Node {
      */
     public func classNameUTF8() throws -> [UInt8] {
         guard let attributes else { return [] }
-        return try attributes.getIgnoreCaseSlice(key: Element.classString).trim().toArray()
+        return Element.trimClassWhitespace(try attributes.getIgnoreCaseSlice(key: Element.classString)).toArray()
     }
     
     /**
@@ -2430,13 +2574,13 @@ open class Element: Node {
         
         while i < len {
             // Skip any leading whitespace
-            while i < len && input[i].isWhitespace {
+            while i < len && StringUtil.isAsciiWhitespaceByte(input[i]) {
                 i += 1
             }
             let start = i
             
             // Find the end of the class name
-            while i < len && !input[i].isWhitespace {
+            while i < len && !StringUtil.isAsciiWhitespaceByte(input[i]) {
                 i += 1
             }
             
@@ -2465,13 +2609,13 @@ open class Element: Node {
         
         while i < len {
             // Skip any leading whitespace
-            while i < len && input[i].isWhitespace {
+            while i < len && StringUtil.isAsciiWhitespaceByte(input[i]) {
                 i += 1
             }
             let start = i
             
             // Find the end of the class name
-            while i < len && !input[i].isWhitespace {
+            while i < len && !StringUtil.isAsciiWhitespaceByte(input[i]) {
                 i += 1
             }
             
@@ -2496,11 +2640,11 @@ open class Element: Node {
         let len = utf8ClassName.count
         var i = 0
         while i < len {
-            while i < len && utf8ClassName[i].isWhitespace {
+            while i < len && StringUtil.isAsciiWhitespaceByte(utf8ClassName[i]) {
                 i += 1
             }
             let start = i
-            while i < len && !utf8ClassName[i].isWhitespace {
+            while i < len && !StringUtil.isAsciiWhitespaceByte(utf8ClassName[i]) {
                 i += 1
             }
             if start < i {
@@ -2555,7 +2699,19 @@ open class Element: Node {
             return false
         }
         if len == wantLen {
-            return StringUtil.equalsIgnoreCase(className, classAttr)
+            // Equal-length attributes can still contain multiple classes or
+            // surrounding whitespace. An escaped class identifier must never
+            // match that entire class list as though it were one token.
+            return classAttr.withUnsafeBytes { bytes in
+                for i in bytes.indices {
+                    let byte = bytes[i]
+                    if StringUtil.isAsciiWhitespaceByte(byte) ||
+                        Attributes.asciiLowercase(byte) != Attributes.asciiLowercase(className[i]) {
+                        return false
+                    }
+                }
+                return true
+            }
         }
 
         @inline(__always)
@@ -2580,7 +2736,7 @@ open class Element: Node {
         var inToken = false
         while i < len {
             let b = classAttr[i]
-            if b.isWhitespace {
+            if StringUtil.isAsciiWhitespaceByte(b) {
                 if inToken {
                     let tokenLen = i - tokenStart
                     if tokenLen == wantLen && equalsIgnoreCaseSlice(classAttr, tokenStart, tokenLen, className) {
@@ -2840,6 +2996,7 @@ open class Element: Node {
     }
     
     override public func hash(into hasher: inout Hasher) {
+        // Equality requires node identity; changing the tag must not change the hash.
         super.hash(into: &hasher)
     }
 }
@@ -2895,6 +3052,24 @@ internal extension Element {
         }
     }
     
+    /// Invalidates all attribute-derived indexes in a single ancestor walk.
+    @usableFromInline
+    @inline(__always)
+    func markAttributeQueryIndexesDirty() {
+        guard !(treeBuilder?.isBulkBuilding ?? false) else { return }
+        var current: Node? = self
+        while let node = current {
+            if let element = node as? Element {
+                element.isClassQueryIndexDirty = true
+                element.isIdQueryIndexDirty = true
+                element.isAttributeQueryIndexDirty = true
+                element.isAttributeValueQueryIndexDirty = true
+                element.invalidateSelectorResultCache()
+            }
+            current = node.parentNode
+        }
+    }
+
     @usableFromInline
     @inline(__always)
     func markClassQueryIndexDirty() {
@@ -2964,12 +3139,11 @@ internal extension Element {
     @inline(__always)
     func cachedSelectorResult(_ query: String) -> Elements? {
         guard let cache = selectorResultCache else { return nil }
-        let root: Node
-        if let cachedRoot = selectorResultCacheRoot, cachedRoot.parentNode == nil {
-            root = cachedRoot
-        } else {
-            root = textMutationRoot()
-            selectorResultCacheRoot = root
+        // Versions belong to a particular tree. A released or reparented root
+        // cannot validate this snapshot, even if the new tree has the same version.
+        guard let root = selectorResultCacheRoot, root.parentNode == nil else {
+            invalidateSelectorResultCache()
+            return nil
         }
         let currentTextVersion = root.textMutationVersion
         if currentTextVersion != selectorResultTextVersion {
@@ -2979,7 +3153,9 @@ internal extension Element {
         }
         if let result = cache.get(query) {
             recordSelectorQuery(query, hit: true)
-            return result
+            // Results are mutable collections. Share their array storage, not the
+            // collection object, so callers cannot modify the cached snapshot.
+            return result.materialize(owner: self)
         }
         recordSelectorQuery(query, hit: false)
         return nil
@@ -2988,6 +3164,13 @@ internal extension Element {
     @usableFromInline
     @inline(__always)
     func storeSelectorResult(_ query: String, _ result: Elements) {
+        // A cached result must not retain its owner. Selectors visit the root
+        // first, so represent that leading element with a marker instead.
+        // Keep custom collections and nonstandard owner placement uncached.
+        guard type(of: result) == Elements.self else { return }
+        let elements = result.array()
+        let includesOwner = elements.first === self
+        guard !elements.dropFirst(includesOwner ? 1 : 0).contains(where: { $0 === self }) else { return }
         let hadCache = selectorResultCache != nil
         if selectorResultCache == nil {
             selectorResultCache = SelectorResultCache(capacity: Element.selectorResultCacheCapacity)
@@ -3010,7 +3193,10 @@ internal extension Element {
             selectorCacheBypassRemaining &-= 1
             return
         }
-        selectorResultCache?.put(query, result)
+        selectorResultCache?.put(query, SelectorResultCache.Result(
+            elements: includesOwner ? Array(elements.dropFirst()) : elements,
+            includesOwner: includesOwner
+        ))
     }
 
     @usableFromInline
@@ -3083,16 +3269,27 @@ internal extension Element {
         }
     }
 
+    // Class tokens use HTML ASCII whitespace; U+000B is part of a token.
+    private static func trimClassWhitespace(_ bytes: ByteSlice) -> ByteSlice {
+        return bytes.withUnsafeBytes { buffer in
+            var start = 0
+            var end = buffer.count
+            while start < end, StringUtil.isAsciiWhitespaceByte(buffer[start]) { start += 1 }
+            while start < end, StringUtil.isAsciiWhitespaceByte(buffer[end - 1]) { end -= 1 }
+            return bytes[start..<end]
+        }
+    }
+
     @inline(__always)
     private static func forEachClassName(in bytes: [UInt8], _ visitor: (ArraySlice<UInt8>) -> Void) {
         var i = 0
         let len = bytes.count
         while i < len {
-            while i < len && bytes[i].isWhitespace {
+            while i < len && StringUtil.isAsciiWhitespaceByte(bytes[i]) {
                 i &+= 1
             }
             let start = i
-            while i < len && !bytes[i].isWhitespace {
+            while i < len && !StringUtil.isAsciiWhitespaceByte(bytes[i]) {
                 i &+= 1
             }
             if start < i {
@@ -3106,12 +3303,12 @@ internal extension Element {
         var i = 0
         let len = bytes.count
         while i < len {
-            while i < len && bytes[i].isWhitespace {
+            while i < len && StringUtil.isAsciiWhitespaceByte(bytes[i]) {
                 i &+= 1
             }
             let start = i
             var hasUppercase = false
-            while i < len && !bytes[i].isWhitespace {
+            while i < len && !StringUtil.isAsciiWhitespaceByte(bytes[i]) {
                 let b = bytes[i]
                 if !hasUppercase && b >= 65 && b <= 90 {
                     hasUppercase = true
@@ -3129,12 +3326,12 @@ internal extension Element {
         var i = 0
         let len = bytes.count
         while i < len {
-            while i < len && bytes[i].isWhitespace {
+            while i < len && StringUtil.isAsciiWhitespaceByte(bytes[i]) {
                 i &+= 1
             }
             let start = i
             var hasUppercase = false
-            while i < len && !bytes[i].isWhitespace {
+            while i < len && !StringUtil.isAsciiWhitespaceByte(bytes[i]) {
                 let b = bytes[i]
                 if !hasUppercase && b >= 65 && b <= 90 {
                     hasUppercase = true
@@ -3221,10 +3418,12 @@ internal extension Element {
                 if let attrs = element.attributes,
                    let classValue = try? attrs.getIgnoreCaseSlice(key: Element.classString),
                    !classValue.isEmpty {
-                    let trimmed = classValue.trim()
-                    if !trimmed.isEmpty {
-                        Element.forEachClassNameWithUppercase(in: trimmed) { className, hasUppercase in
-                            let key = hasUppercase ? className.lowercased() : className
+                    Element.forEachClassNameWithUppercase(in: classValue) { className, hasUppercase in
+                        let key = hasUppercase ? className.lowercased() : className
+                        // One element may repeat a token (including case variants).
+                        // Its tokens are visited together, so only the last entry
+                        // needs checking; no per-element set or query dedup is needed.
+                        if classIndex[key]?.last?.value !== element {
                             classIndex[key, default: []].append(Weak(element))
                         }
                     }
@@ -3241,21 +3440,14 @@ internal extension Element {
             if needsAttributes || needsHotAttributes {
                 DebugTrace.log("rebuildQueryIndexesCombined: attrs for \(element.tagName())")
                 if let attrs = element.attributes {
-                    attrs.ensureMaterialized()
-                    let lowerKeys = attrs.hasUppercaseKeys
-                    for attr in attrs.attributes {
-                        DebugTrace.log("rebuildQueryIndexesCombined: attr key \(String(decoding: attr.getKeyUTF8(), as: UTF8.self))")
-                        let keySlice = attr.keySlice
-                        let key = lowerKeys ? attr.lowerKeySlice() : keySlice
+                    attrs.forEachEffectiveAttribute { attr, key in
                         if needsAttributes {
                             attributeIndex[key, default: []].append(Weak(element))
                         }
                         if needsHotAttributes,
                            (Element.isHotAttributeKey(key) || (dynamicKeys?.contains(key) ?? false)) {
                             let value = attr.lowerTrimmedValueSlice()
-                            var valueIndex = hotAttributeIndex[key] ?? [:]
-                            valueIndex[value, default: []].append(Weak(element))
-                            hotAttributeIndex[key] = valueIndex
+                            hotAttributeIndex[key, default: [:]][value, default: []].append(Weak(element))
                         }
                     }
                 }
@@ -3382,10 +3574,9 @@ internal extension Element {
             if let attrs = element.attributes,
                let classValue = try? attrs.getIgnoreCaseSlice(key: Element.classString),
                !classValue.isEmpty {
-                let trimmed = classValue.trim()
-                if !trimmed.isEmpty {
-                    Element.forEachClassNameWithUppercase(in: trimmed) { className, hasUppercase in
-                        let key = hasUppercase ? className.lowercased() : className
+                Element.forEachClassNameWithUppercase(in: classValue) { className, hasUppercase in
+                    let key = hasUppercase ? className.lowercased() : className
+                    if newIndex[key]?.last?.value !== element {
                         newIndex[key, default: []].append(Weak(element))
                     }
                 }
@@ -3461,11 +3652,7 @@ internal extension Element {
         
         traverseElementsDepthFirst { element in
             if let attrs = element.attributes {
-                attrs.ensureMaterialized()
-                let lowerKeys = attrs.hasUppercaseKeys
-                for attr in attrs.attributes {
-                    let keySlice = attr.keySlice
-                    let key = lowerKeys ? attr.lowerKeySlice() : keySlice
+                attrs.forEachEffectiveAttribute { attr, key in
                     newIndex[key, default: []].append(Weak(element))
                 }
             }
@@ -3502,16 +3689,10 @@ internal extension Element {
         newIndex.reserveCapacity(Element.hotAttributeIndexKeys.count + (dynamicKeys?.count ?? 0))
         traverseElementsDepthFirst { element in
             if let attrs = element.getAttributes() {
-                attrs.ensureMaterialized()
-                let lowerKeys = attrs.hasUppercaseKeys
-                for attr in attrs.attributes {
-                    let keySlice = attr.keySlice
-                    let key = lowerKeys ? attr.lowerKeySlice() : keySlice
-                    guard Element.isHotAttributeKey(key) || (dynamicKeys?.contains(key) ?? false) else { continue }
+                attrs.forEachEffectiveAttribute { attr, key in
+                    guard Element.isHotAttributeKey(key) || (dynamicKeys?.contains(key) ?? false) else { return }
                     let value = attr.lowerTrimmedValueSlice()
-                    var valueIndex = newIndex[key] ?? [:]
-                    valueIndex[value, default: []].append(Weak(element))
-                    newIndex[key] = valueIndex
+                    newIndex[key, default: [:]][value, default: []].append(Weak(element))
                 }
             }
         }

--- a/Sources/HtmlTreeBuilder.swift
+++ b/Sources/HtmlTreeBuilder.swift
@@ -58,6 +58,8 @@ class HtmlTreeBuilder: TreeBuilder {
     private var _framesetOk: Bool = true // if ok to go into frameset
     private var fosterInserts: Bool = false // if next inserts should be fostered
     private var fragmentParsing: Bool = false // if parsing a fragment of html
+    // Only true inside the private fragment parse loop, not manual token processing.
+    private var constructingFragment: Bool = false
 
     private var stackTrackingDirty: Bool = false
     private var stackUnknownTagIdCount: Int = 0
@@ -133,6 +135,8 @@ class HtmlTreeBuilder: TreeBuilder {
             }
         }
         
+        constructingFragment = true
+        defer { constructingFragment = false }
         try runParser()
         if (context != nil && root != nil) {
             return root!.getChildNodes()
@@ -201,7 +205,17 @@ class HtmlTreeBuilder: TreeBuilder {
 
     @inline(__always)
     func markStructuralChange(_ node: Node? = nil) {
-        (node ?? currentElement())?.markSourceDirty(force: true)
+        guard let node = node ?? currentElement() else { return }
+        if (isBulkBuilding || constructingFragment), doc.sourceRangeDirty,
+           doc.dirtySourceRoots[ObjectIdentifier(doc)]?.value === doc {
+            // Only parser-owned construction can use the known document. Public
+            // TreeBuilder stack edits outside parsing must retain owner dispatch.
+            // The current parser tree is already covered. A newly synthesized
+            // detached element also has no document registration to perform.
+            node.markSourceDirty(force: true, registerDirtyRoot: false)
+        } else {
+            node.markSourceDirty(force: true)
+        }
     }
     
     func state() -> HtmlTreeBuilderState {
@@ -544,6 +558,8 @@ class HtmlTreeBuilder: TreeBuilder {
             current.childNodes.append(node)
             node.parentNode = current
             node.setSiblingIndex(current.childNodes.count - 1)
+        } else if fragmentParsing, !fosterInserts, let current, node.parentNode == nil {
+            appendFragmentNode(node, to: current)
         } else {
             try current?.appendChild(node) // doesn't use insertNode, because we don't foster these; and will always have a stack.
         }
@@ -563,6 +579,8 @@ class HtmlTreeBuilder: TreeBuilder {
                 node.parentNode = current
                 current.childNodes.append(node)
                 node.setSiblingIndex(current.childNodes.count - 1)
+            } else if fragmentParsing, node.parentNode == nil {
+                appendFragmentNode(node, to: current)
             } else {
                 try current.appendChild(node)
             }
@@ -577,6 +595,42 @@ class HtmlTreeBuilder: TreeBuilder {
         }
     }
     
+    /// Appends a newly created fragment node to this parser's private tree.
+    /// Keep fragment mutation/range bookkeeping, but reuse its known document.
+    @usableFromInline
+    internal func appendFragmentNode(_ node: Node, to parent: Element) {
+        if constructingFragment, let element = node as? Element {
+            // Mark the new detached element, but do not walk its private
+            // ancestors again: each has already been dirtied on insertion.
+            // No query indexes are built during the fragment parser loop.
+            element.markQueryIndexesDirty()
+            let suppressed = element.suppressQueryIndexDirty
+            element.suppressQueryIndexDirty = true
+            node.parentNode = parent
+            element.suppressQueryIndexDirty = suppressed
+        } else {
+            node.parentNode = parent
+        }
+        node.treeBuilder = parent.treeBuilder
+        parent.childNodes.append(node)
+        node.setSiblingIndex(parent.childNodes.count - 1)
+        if constructingFragment, doc.sourceRangeDirty,
+           doc.dirtySourceRoots[ObjectIdentifier(doc)]?.value === doc {
+            // The registered document already covers this private fragment tree.
+            // Preserve dirty flags without rediscovering/registering that root.
+            node.markSourceDirty(force: false, registerDirtyRoot: false)
+            parent.markSourceDirty(force: false, registerDirtyRoot: false)
+        } else {
+            node.markSourceDirty()
+            parent.markSourceDirty()
+        }
+        // After fragment construction, manual token processing must obey the
+        // same text-predicate invalidation contract as public appendChild.
+        if !constructingFragment && parent.treeBuilder?.isBulkBuilding != true {
+            parent.bumpTextMutationVersion()
+        }
+    }
+
     @discardableResult
     func pop() -> Element {
         let element = stack.removeLast()
@@ -664,7 +718,7 @@ class HtmlTreeBuilder: TreeBuilder {
     
     @discardableResult
     func onStack(_ el: Element) -> Bool {
-        return isElementInQueue(stack, el)
+        return lastIndexOfStackElement(el) != nil
     }
     
     private func isElementInQueue(_ queue: Array<Element?>, _ element: Element?) -> Bool {

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -24,7 +24,9 @@ open class Node: Equatable, Hashable {
     @usableFromInline
     var baseUri: [UInt8]?
     @usableFromInline
-    var attributes: Attributes?
+    var attributes: Attributes? {
+        didSet { attributes?.addOwner(self) }
+    }
 
     @inline(__always)
     internal func ensureAttributesForWrite() -> Attributes {
@@ -32,9 +34,6 @@ open class Node: Equatable, Hashable {
             return attributes
         }
         let created = Attributes()
-        if let element = self as? Element {
-            created.ownerElement = element
-        }
         attributes = created
         return created
     }
@@ -119,6 +118,7 @@ open class Node: Equatable, Hashable {
         }
         self.baseUri = baseUri.trim()
         self.attributes = attributes
+        attributes.addOwner(self)
     }
 
     public init(
@@ -132,6 +132,7 @@ open class Node: Equatable, Hashable {
         }
         self.baseUri = baseUri.trim()
         self.attributes = attributes
+        attributes?.addOwner(self)
     }
     
     public init(
@@ -207,7 +208,7 @@ open class Node: Equatable, Hashable {
     /**
      Get an attribute's value by its key. **Case insensitive.**
      
-     To get an absolute URL from an attribute that may be a relative URL, prefix the key with `abs`,
+     To get an absolute URL from an attribute that may be relative to the element's base URI, prefix the key with `abs`,
      which is a shortcut to the ``absUrl(_:)-(String)`` method.
      
      E.g.:
@@ -294,7 +295,7 @@ open class Node: Equatable, Hashable {
         guard let attributes = attributes else {
             return false
         }
-        if attributeKey.starts(with: Node.abs) {
+        if Node.hasAbsPrefix(attributeKey) {
             let key = ArraySlice(attributeKey.dropFirst(Node.absCount))
             do {
                 let abs = try absUrl(key)
@@ -302,7 +303,8 @@ open class Node: Equatable, Hashable {
                     return true
                 }
             } catch {
-                return false
+                // Invalid virtual suffixes must not hide a physical attribute
+                // with the complete name (for example a literal "abs:").
             }
             
         }
@@ -313,7 +315,7 @@ open class Node: Equatable, Hashable {
     /**
      Remove an attribute from this element.
      - parameter attributeKey: The attribute to remove.
-     - returns: this (for chaining)
+     - returns: this node, for chaining
      */
     @discardableResult
     open func removeAttr(_ attributeKey: [UInt8]) throws -> Node {
@@ -359,10 +361,18 @@ open class Node: Equatable, Hashable {
             
             func head(_ node: Node, _ depth: Int) throws {
                 node.baseUri = baseUri
+                (node as? Element)?.invalidateSelectorResultCache()
             }
             
             func tail(_ node: Node, _ depth: Int) throws {
             }
+        }
+        // Resolved-URL selectors may be cached on any subtree or ancestor.
+        // Physical attribute indexes and text caches do not depend on base URI.
+        var ancestor = parentNode
+        while let node = ancestor {
+            (node as? Element)?.invalidateSelectorResultCache()
+            ancestor = node.parentNode
         }
         try traverse(nodeVisitor(baseUri))
     }
@@ -402,15 +412,15 @@ open class Node: Equatable, Hashable {
         if (!hasAttr(keyStr)) {
             return Node.empty // nothing to make absolute with
         } else {
-            return StringUtil.resolve(String(decoding: baseUri!, as: UTF8.self), relUrl: try attr(keyStr)).utf8Array
+            return StringUtil.resolve(String(decoding: getBaseUriUTF8(), as: UTF8.self), relUrl: try attr(keyStr)).utf8Array
         }
     }
     
     /**
      Get a child node by its 0-based index.
      - parameter index: index of child node
-     - returns: the child node at this index.
      - warning: Crashes if the index is out of bounds!
+     - returns: the child node at this index.
      */
     @inline(__always)
     open func childNode(_ index: Int) -> Node {
@@ -480,13 +490,10 @@ open class Node: Equatable, Hashable {
      */
     @inline(__always)
     open func ownerDocument() -> Document? {
-        if let this =  self as? Document {
-            return this
-        } else if (parentNode == nil) {
-            return nil
-        } else {
-            return parentNode!.ownerDocument()
+        if let document = self as? Document {
+            return document
         }
+        return parentNode?.ownerDocument()
     }
 
     /// A token that changes when text content in this node's tree mutates.
@@ -804,6 +811,7 @@ open class Node: Equatable, Hashable {
     
     @inline(__always)
     public func setParentNode(_ parentNode: Node) throws {
+        try parentNode.validateChildInsertion(self)
         if (self.parentNode != nil) {
             try self.parentNode?.removeChild(self)
         }
@@ -814,6 +822,8 @@ open class Node: Equatable, Hashable {
     public func replaceChild(_ out: Node, _ input: Node) throws {
         try Validate.isTrue(val: out.parentNode === self)
         try Validate.notNull(obj: input)
+        guard out !== input else { return }
+        try validateChildInsertion(input)
         if (input.parentNode != nil) {
             try input.parentNode?.removeChild(input)
         }
@@ -854,7 +864,9 @@ open class Node: Equatable, Hashable {
     
     @inline(__always)
     public func addChildren(_ children: [Node]) throws {
-        //most used. short circuit addChildren(int), which hits reindex children and array copy
+        guard !children.isEmpty else { return }
+        // Validate the whole batch before detaching any input from its current tree.
+        for child in children { try validateChildInsertion(child) }
         for child in children {
             try reparentChild(child)
             childNodes.append(child)
@@ -872,28 +884,46 @@ open class Node: Equatable, Hashable {
     
     @inline(__always)
     public func addChildren(_ index: Int, _ children: [Node]) throws {
+        try Validate.isTrue(val: index >= 0 && index <= childNodes.count, msg: "Insert position out of bounds.")
+        guard !children.isEmpty else { return }
+        for input in children { try validateChildInsertion(input) }
+        var insertionIndex = index
         for input in children.reversed() {
+            // The insertion gap belongs to the original list. Removing an earlier
+            // sibling shifts that gap left before inserting at it.
+            if input.parentNode === self && input.siblingIndex < insertionIndex {
+                insertionIndex -= 1
+            }
             try reparentChild(input)
-            childNodes.insert(input, at: index)
-            reindexChildren(index)
+            childNodes.insert(input, at: insertionIndex)
+            reindexChildren(insertionIndex)
             input.markSourceDirty()
         }
         markSourceDirty()
         bumpTextMutationVersion()
     }
-    
+
     @inline(__always)
-    public func reparentChild(_ child: Node)throws {
-        try child.parentNode?.removeChild(child)
+    public func reparentChild(_ child: Node) throws {
+        // setParentNode validates before removing the old parent link.
         try child.setParentNode(self)
         // propagate builder reference for bulk-append checks
         child.treeBuilder = self.treeBuilder
     }
-    
+
+    @inline(__always)
+    @usableFromInline
+    internal func validateChildInsertion(_ child: Node) throws {
+        // A leaf cannot be an ancestor. Keep the common detached-leaf path cheap.
+        try Validate.isTrue(val: child !== self &&
+            (!child.hasChildNodes() || !child.isAncestor(of: self)),
+            msg: "A node cannot contain itself or one of its ancestors.")
+    }
+
     @usableFromInline
     internal func reindexChildren(_ start: Int) {
         for (index, node) in childNodes[start...].enumerated() {
-            node.setSiblingIndex(start + index)
+            node.siblingIndex = start + index
         }
     }
     
@@ -1033,7 +1063,7 @@ open class Node: Equatable, Hashable {
     
     // if this node has no document (or parent), retrieve the default output settings
     func getOutputSettings() -> OutputSettings {
-        return ownerDocument() != nil ? ownerDocument()!.outputSettings() : (Document([])).outputSettings()
+        return ownerDocument()?.outputSettings() ?? OutputSettings()
     }
     
     /**
@@ -1260,7 +1290,6 @@ open class Node: Equatable, Hashable {
             } else {
                 clone.attributes = attrs.clone()
             }
-            clone.attributes?.ownerElement = clone as? SwiftSoup.Element
         } else {
             clone.attributes = nil
         }

--- a/Sources/SelectorQueryKey.swift
+++ b/Sources/SelectorQueryKey.swift
@@ -1,0 +1,23 @@
+// CSS matches code points, not Swift's canonically equivalent String values.
+// Keep the original String storage; equality compares UTF-8 without allocating a
+// second copy. Canonically equivalent strings may share a hash, which is safe:
+// the byte-exact equality check still keeps their cache entries distinct.
+@usableFromInline
+struct SelectorQueryKey: Hashable, Sendable {
+    private let query: String
+
+    @usableFromInline
+    init(_ query: String) {
+        self.query = query
+    }
+
+    @usableFromInline
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.query.utf8.elementsEqual(rhs.query.utf8)
+    }
+
+    @usableFromInline
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(query)
+    }
+}

--- a/Sources/TextNode.swift
+++ b/Sources/TextNode.swift
@@ -137,12 +137,6 @@ open class TextNode: Node {
     @inline(__always)
     open func getWholeTextUTF8() -> [UInt8] {
         if let attrs = attributes {
-            if _textSlice != nil || _textSlices != nil {
-                materializeTextIfNeeded()
-                do {
-                    try attrs.put(TextNode.TEXT_KEY, _text)
-                } catch {}
-            }
             if let slice = attrs.valueSliceCaseSensitive(TextNode.TEXT_KEY) {
                 return slice.toArray()
             }
@@ -168,28 +162,11 @@ open class TextNode: Node {
 
     @usableFromInline
     internal func appendSlice(_ slice: ByteSlice) {
+        guard !slice.isEmpty else { return }
         if let attrs = attributes {
-            if !attrs.hasKey(key: TextNode.TEXT_KEY) {
-                if let slices = _textSlices {
-                    for existing in slices {
-                        attrs.appendValueSlice(key: TextNode.TEXT_KEY, slice: existing)
-                    }
-                    _textSlices = nil
-                    _textSlicesCount = 0
-                    _text = []
-                } else if let existingSlice = _textSlice {
-                    attrs.appendValueSlice(key: TextNode.TEXT_KEY, slice: existingSlice)
-                    _textSlice = nil
-                    _text = []
-                } else if !_text.isEmpty {
-                    attrs.appendValueSlice(key: TextNode.TEXT_KEY, slice: ByteSlice.fromArray(_text))
-                    _text = []
-                }
-            }
             attrs.appendValueSlice(key: TextNode.TEXT_KEY, slice: slice)
-        } else if var slices = _textSlices {
-            slices.append(slice)
-            _textSlices = slices
+        } else if _textSlices != nil {
+            _textSlices!.append(slice)
             _textSlicesCount += slice.count
         } else if let existingSlice = _textSlice {
             _textSlices = [existingSlice, slice]
@@ -239,43 +216,60 @@ open class TextNode: Node {
      */
     @inline(__always)
     open func isBlank() -> Bool {
+        if type(of: self) == TextNode.self {
+            // Keep the authoritative byte getter and its materialization behavior,
+            // but do not decode the whole value merely to test for ASCII whitespace.
+            return StringUtil.isBlankTextBytes(getWholeTextUTF8())
+        }
         return StringUtil.isBlank(getWholeText())
     }
 
     /**
-     Split this text node into two nodes at the specified string offset. After splitting, this node will contain the
-     original text up to the offset, and will have a new text node sibling containing the text after the offset.
-     - parameter offset: string offset point to split node at.
-     - returns: the newly created text node containing the text after the offset.
+     Split this text node at an extended grapheme cluster (Swift `Character`) offset.
+     The original node keeps the prefix; the returned node contains the suffix and
+     is inserted immediately after it when attached. An offset equal to the number
+     of characters is valid and creates an empty suffix.
+     - parameter offset: character offset, from zero through the character count
+     - returns: the newly created text node
+     - throws: if the offset is outside those bounds, without changing the tree
      */
     open func splitText(_ offset: Int) throws -> TextNode {
-        try Validate.isTrue(val: offset >= 0, msg: "Split offset must be not be negative")
-        let current = getWholeTextUTF8()
-        try Validate.isTrue(val: offset < current.count, msg: "Split offset must not be greater than current text length")
-
-        let head: String = getWholeText().substring(0, offset)
-        let tail: String = getWholeText().substring(offset)
-        text(head)
-        let tailNode: TextNode = TextNode(tail.utf8Array, self.getBaseUriUTF8())
-        if (parent() != nil) {
-            try parent()?.addChildren(siblingIndex+1, tailNode)
+        try Validate.isTrue(val: offset >= 0, msg: "Split offset must not be negative")
+        // Take one snapshot: subclasses may override the public getter.
+        let current = getWholeText()
+        guard let split = current.index(current.startIndex, offsetBy: offset, limitedBy: current.endIndex) else {
+            throw Exception.Error(type: ExceptionType.IllegalArgumentException,
+                                  Message: "Split offset must not exceed the character count")
         }
-        return tailNode
+        return try splitText(head: String(current[..<split]), tail: String(current[split...]))
     }
-    
+
+    /**
+     Split at an exact UTF-8 byte offset on a Unicode scalar boundary. This can
+     separate scalars within a grapheme (such as a letter and its combining mark).
+     Zero and the byte count are valid. Invalid UTF-8 or an offset inside a scalar
+     throws before the node or its parent is modified; bytes are never repaired.
+     */
     open func splitText(utf8Offset: Int) throws -> TextNode {
-        // Ensure UTF-8 offset is within valid bounds
         try Validate.isTrue(val: utf8Offset >= 0, msg: "Split UTF-8 offset must not be negative")
         let current = getWholeTextUTF8()
-        try Validate.isTrue(val: utf8Offset < current.count, msg: "Split UTF-8 offset must not exceed current text length in UTF-8 bytes")
-        
-        // Convert UTF-8 offset to extended grapheme cluster offset
-        let graphemeOffset = Substring(getWholeText().utf8.prefix(utf8Offset)).count
-        
-        // Validate grapheme cluster offset
-        try Validate.isTrue(val: graphemeOffset < current.count, msg: "Split grapheme cluster offset must not exceed current text length")
-        
-        return try splitText(graphemeOffset)
+        try Validate.isTrue(val: utf8Offset <= current.count,
+                            msg: "Split UTF-8 offset must not exceed the byte count")
+        guard let head = String(bytes: current[..<utf8Offset], encoding: .utf8),
+              let tail = String(bytes: current[utf8Offset...], encoding: .utf8) else {
+            throw Exception.Error(type: ExceptionType.IllegalArgumentException,
+                                  Message: "Split UTF-8 offset must separate valid Unicode scalar sequences")
+        }
+        return try splitText(head: head, tail: tail)
+    }
+
+    private func splitText(head: String, tail: String) throws -> TextNode {
+        let tailNode = TextNode(Array(tail.utf8), getBaseUriUTF8())
+        text(head)
+        if let parent = parent() {
+            try parent.addChildren(siblingIndex + 1, tailNode)
+        }
+        return tailNode
     }
 
     override func outerHtmlHead(_ accum: StringBuilder, _ depth: Int, _ out: OutputSettings) throws {
@@ -382,16 +376,17 @@ open class TextNode: Node {
     // attribute fiddling. create on first access.
     @inline(__always)
     private func ensureAttributes() {
-        if (attributes == nil) {
-            attributes = Attributes()
-            do {
-                if let slice = _textSlice {
-                    _text = Array(slice)
-                    _textSlice = nil
-                }
-                try attributes?.put(TextNode.TEXT_KEY, _text)
-            } catch {}
-        }
+        guard attributes == nil else { return }
+        materializeTextIfNeeded()
+        let created = Attributes()
+        // Populate before attaching the owner: materialization is not a DOM edit.
+        try? created.put(TextNode.TEXT_KEY, _text)
+        attributes = created
+    }
+
+    internal override func ensureAttributesForWrite() -> Attributes {
+        ensureAttributes()
+        return attributes!
     }
 
     open override func attr(_ attributeKey: [UInt8]) throws -> [UInt8] {
@@ -417,6 +412,11 @@ open class TextNode: Node {
     open override func attr(_ attributeKey: String, _ attributeValue: String) throws -> Node {
         ensureAttributes()
         return try super.attr(attributeKey, attributeValue)
+    }
+
+    open override func hasAttr(_ attributeKey: [UInt8]) -> Bool {
+        ensureAttributes()
+        return super.hasAttr(attributeKey)
     }
 
     open override func hasAttr(_ attributeKey: String) -> Bool {

--- a/Sources/Token.swift
+++ b/Sources/Token.swift
@@ -648,7 +648,10 @@ open class Token {
         func ensureAttributes() {
             guard let pendingAttributes = _pendingAttributes, !pendingAttributes.isEmpty else { return }
             if _attributes == nil {
-                _attributes = Attributes()
+                _attributes = Attributes(pendingAttributes: pendingAttributes)
+                // The collection now owns the buffer; do not copy it just to clear the token.
+                _pendingAttributes = nil
+                return
             }
             for pending in pendingAttributes {
                 _attributes?.appendPending(pending)

--- a/Tests/SwiftSoupTests/AttributeCopyAllocationTest.swift
+++ b/Tests/SwiftSoupTests/AttributeCopyAllocationTest.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeCopyAllocationTest: XCTestCase {
+    func testCopyPreservesOrderCaseValuesAndBooleans() throws {
+        let parser = Parser.htmlParser().settings(ParseSettings.preserveCase)
+        let doc = try parser.parseInput("<p ID='A' class='one two' disabled data-x='' title='日本語'></p>", "")
+        let source = try XCTUnwrap(doc.getElementsByTag("p").first()?.getAttributes())
+        let copy = source.clone()
+        XCTAssertEqual(try source.html(), try copy.html())
+        XCTAssertEqual(source.asList().map { $0.getKey() }, copy.asList().map { $0.getKey() })
+        XCTAssertEqual(source.asList().map { $0.getValue() }, copy.asList().map { $0.getValue() })
+        XCTAssertEqual(source.hasUppercaseKeys, copy.hasUppercaseKeys)
+        XCTAssertNil(copy.ownerElement)
+        for (first, second) in zip(source.asList(), copy.asList()) {
+            // Clone isolation wins over the old shallow-copy optimization contract.
+            XCTAssertFalse(first === second)
+            let value = first.getValue()
+            _ = second.setValue(value: Array("changed in copy".utf8))
+            XCTAssertEqual(first.getValue(), value)
+        }
+    }
+
+    func testCopyOwnsIndependentArrayAcrossThresholds() throws {
+        for count in [0, 1, 8, 15, 16, 17, 32, 100] {
+            let source = Attributes()
+            for index in 0..<count { try source.put("data-\(index)", "value-\(index)") }
+            let copy = source.clone()
+            try copy.put("only-copy", "copy")
+            try source.put("only-source", "source")
+            XCTAssertFalse(source.hasKey(key: "only-copy"))
+            XCTAssertFalse(copy.hasKey(key: "only-source"))
+            XCTAssertEqual(source.size(), count + 1)
+            XCTAssertEqual(copy.size(), count + 1)
+        }
+    }
+
+    func testRepeatedCopiesAfterIndexedLookups() throws {
+        let source = Attributes()
+        for index in 0..<40 { try source.put("Key-\(index)", "\(index)") }
+        for _ in 0..<5 {
+            for index in 0..<40 { XCTAssertEqual(try source.getIgnoreCase(key: "KEY-\(index)"), "\(index)") }
+            let copy = source.clone()
+            try copy.remove(key: "Key-7")
+            XCTAssertEqual(source.get(key: "Key-7"), "7")
+            XCTAssertFalse(copy.hasKey(key: "Key-7"))
+            XCTAssertEqual(try copy.getIgnoreCase(key: "KEY-39"), "39")
+        }
+    }
+
+    func testDeferredAttributesAndDuplicateKeysMaterializeTheSameWay() throws {
+        for count in [0, 1, 15, 16, 17, 64] {
+            let markup = (0..<count).map { "data-\($0)='\($0)'" }.joined(separator: " ")
+            let document = try SwiftSoup.parse("<p \(markup) title='a &amp; 日本語' title='last'></p>")
+            let source = try XCTUnwrap(document.getElementsByTag("p").first()?.getAttributes())
+            let copy = source.clone()
+            XCTAssertEqual(try source.html(), try copy.html())
+            XCTAssertEqual(source.size(), copy.size())
+            XCTAssertEqual(copy.get(key: "title"), source.get(key: "title"))
+        }
+    }
+    func testCopyStartsWithFreshLookupCachesAndNoOwner() throws {
+        let document = try SwiftSoup.parse("<p ID='a' data-x='1' data-y='2' data-z='3'></p>")
+        let source = try XCTUnwrap(document.getElementsByTag("p").first()?.getAttributes())
+        _ = source.get(key: "data-x")
+        _ = try source.getIgnoreCase(key: "DATA-Y")
+        let copy = source.clone()
+        XCTAssertNil(copy.lowercasedKeysCache)
+        XCTAssertNil(copy.lowercasedKeyIndex)
+        XCTAssertTrue(copy.lowercasedKeyIndexDirty)
+        XCTAssertNil(copy.keyIndex)
+        XCTAssertTrue(copy.keyIndexDirty)
+        XCTAssertNil(copy.pendingAttributes)
+        XCTAssertEqual(copy.pendingAttributesCount, 0)
+        XCTAssertNil(copy.ownerElement)
+        XCTAssertEqual(copy.hasUppercaseKeys, source.hasUppercaseKeys)
+        XCTAssertEqual(try copy.html(), try source.html())
+    }
+
+}

--- a/Tests/SwiftSoupTests/AttributeHashCodeTest.swift
+++ b/Tests/SwiftSoupTests/AttributeHashCodeTest.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeHashCodeTest: XCTestCase {
+    func testHashCodeWrapsIntegerOverflowInsteadOfTrapping() throws {
+        // Find a witness using checked reporting, so this reproduces under any
+        // process hash seed without hard-coding a platform-dependent hash value.
+        let witness = try XCTUnwrap((0..<1024).lazy.map { ByteSlice.fromArray(Array("key-\($0)".utf8)) }
+            .first { $0.hashValue.multipliedReportingOverflow(by: 31).overflow })
+        let attribute = try Attribute(keySlice: witness, valueSlice: ByteSlice.fromArray(Array("value".utf8)))
+        let expected = (31 &* witness.hashValue) &+ attribute.valueSliceMaterialized().hashValue
+        XCTAssertEqual(attribute.hashCode(), expected)
+        XCTAssertEqual(attribute.hashCode(), attribute.clone().hashCode())
+    }
+
+    func testEqualFragmentedAndContiguousAttributesHaveEqualHashes() throws {
+        let first = try Attribute(key: "日本語", value: "one")
+        first.appendValueSlice(ByteSlice.fromArray(Array("&two".utf8)))
+        let second = try Attribute(key: "日本語", value: "one&two")
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.hashCode(), second.hashCode())
+        _ = first.getValueUTF8()
+        XCTAssertEqual(first.hashCode(), second.hashCode())
+        first.setValue(value: Array("changed".utf8))
+        second.setValue(value: Array("changed".utf8))
+        XCTAssertEqual(first.hashCode(), second.hashCode())
+    }
+
+    func testBooleanAndPlainEmptyAttributesRespectEquality() throws {
+        let boolean = try BooleanAttribute(key: Array("custom".utf8))
+        let plain = try Attribute(key: "custom", value: "")
+        XCTAssertEqual(boolean, plain)
+        XCTAssertEqual(boolean.hashCode(), plain.hashCode())
+    }
+}

--- a/Tests/SwiftSoupTests/AttributeHashSafetyTest.swift
+++ b/Tests/SwiftSoupTests/AttributeHashSafetyTest.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeHashSafetyTest: XCTestCase {
+    func testHashMixingWrapsRatherThanTrappingOnOverflow() throws {
+        // Select against this process's randomized hash seed, not a fixed hash value.
+        let attribute = try XCTUnwrap((0..<256).lazy.compactMap { index -> Attribute? in
+            let candidate = try? Attribute(key: "key-\(index)", value: "value")
+            guard let candidate,
+                  candidate.keySlice.hashValue.multipliedReportingOverflow(by: 31).overflow else { return nil }
+            return candidate
+        }.first)
+        let expected = (attribute.keySlice.hashValue &* 31) &+ attribute.valueSliceMaterialized().hashValue
+        XCTAssertEqual(attribute.hashCode(), expected)
+    }
+
+    func testEqualAndClonedAttributesHaveEqualHashesAfterEdits() throws {
+        let first = try Attribute(key: "data-x", value: "日本語")
+        let second = first.clone()
+        XCTAssertEqual(first.hashCode(), second.hashCode())
+        first.setValue(value: Array("changed".utf8))
+        second.setValue(value: Array("changed".utf8))
+        try first.setKey(key: "renamed")
+        try second.setKey(key: "renamed")
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.hashCode(), second.hashCode())
+    }
+
+    func testFragmentedValueHashingDoesNotNotifyOwners() throws {
+        let doc = try SwiftSoup.parse("<p data-v='a'></p>")
+        let p = try XCTUnwrap(doc.body()?.child(0))
+        let attribute = try XCTUnwrap(p.getAttributes()?.asList().first)
+        attribute.appendValueSlice(ByteSlice.fromArray(Array("日本語".utf8)))
+        let expected = try Attribute(key: "data-v", value: "a日本語")
+        let version = doc.textMutationVersion
+        let dirty = p.sourceRangeDirty
+        XCTAssertEqual(attribute.hashCode(), expected.hashCode())
+        XCTAssertEqual(doc.textMutationVersion, version)
+        XCTAssertEqual(p.sourceRangeDirty, dirty)
+    }
+}

--- a/Tests/SwiftSoupTests/AttributeInvalidationTraversalTest.swift
+++ b/Tests/SwiftSoupTests/AttributeInvalidationTraversalTest.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeInvalidationTraversalTest: XCTestCase {
+    func testAllAncestorAttributeIndexesAreInvalidatedWithoutDirtyingTags() throws {
+        let doc = try SwiftSoup.parse("<html><head></head><body><main><section><a id='old' class='before' href='/old'>text</a></section></main></body></html>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        doc.materializeAttributesRecursively()
+        let target = try XCTUnwrap(doc.getElementsByTag("a").first())
+        var roots: [Element] = [target]
+        var parent = target.parent()
+        while let root = parent { roots.append(root); parent = root.parent() }
+        for root in roots {
+            root.rebuildQueryIndexesForAllTags()
+            for _ in 0..<4 { _ = try root.select(".before"); _ = try root.select("[href='/old']") }
+        }
+        try target.attr("data-extra", "yes")
+        for root in roots {
+            XCTAssertFalse(root.isTagQueryIndexDirty)
+            XCTAssertTrue(root.isClassQueryIndexDirty)
+            XCTAssertTrue(root.isIdQueryIndexDirty)
+            XCTAssertTrue(root.isAttributeQueryIndexDirty)
+            XCTAssertTrue(root.isAttributeValueQueryIndexDirty)
+            XCTAssertNil(root.selectorResultCache)
+        }
+        try target.attr("class", "after")
+        try target.attr("id", "new")
+        try target.attr("href", "/new")
+        for root in roots {
+            XCTAssertEqual(try root.select(".before, #old, [href='/old']").size(), 0)
+            XCTAssertTrue(try root.select(".after#new[href='/new'][data-extra]").first() === target)
+        }
+        let serialized = String(decoding: try doc.outerHtmlUTF8(), as: UTF8.self)
+        let reparsed = try SwiftSoup.parse(serialized)
+        XCTAssertEqual(try reparsed.select(".after#new[href='/new'][data-extra]").size(), 1)
+    }
+
+    func testAlreadyDirtyDescendantStillInvalidatesRebuiltAncestor() throws {
+        let doc = try SwiftSoup.parse("<main><section><a id='target' class='before' href='/one'></a></section></main>")
+        doc.materializeAttributesRecursively()
+        let target = try XCTUnwrap(doc.getElementById("target"))
+        let section = try XCTUnwrap(target.parent())
+        section.isClassQueryIndexDirty = true
+        for _ in 0..<4 { _ = try doc.select(".before") }
+        try target.attr("class", "after")
+        XCTAssertEqual(try doc.select(".before").size(), 0)
+        XCTAssertTrue(try doc.select(".after").first() === target)
+    }
+
+    func testLowercasingAllKeysInvalidatesWarmedIndexes() throws {
+        let parser = Parser.htmlParser().settings(ParseSettings.preserveCase)
+        let doc = try parser.parseInput("<main><a ID='node' CLASS='before' HREF='/one'></a></main>", "")
+        let target = try XCTUnwrap(doc.getElementsByTag("a").first())
+        let attrs = try XCTUnwrap(target.getAttributes())
+        _ = Array(attrs)
+        for _ in 0..<4 { _ = try doc.select(".before"); _ = try doc.select("[href='/one']") }
+        attrs.lowercaseAllKeys()
+        XCTAssertTrue(attrs.hasKey(key: "href"))
+        XCTAssertFalse(attrs.hasKey(key: "HREF"))
+        XCTAssertTrue(try doc.select(".before[href='/one']").first() === target)
+    }
+}

--- a/Tests/SwiftSoupTests/AttributeMaterializationTest.swift
+++ b/Tests/SwiftSoupTests/AttributeMaterializationTest.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeMaterializationTest: XCTestCase {
+    private func pending(_ key: String, _ value: String? = nil) -> Attributes.PendingAttribute {
+        let bytes = Array(key.utf8)
+        return Attributes.PendingAttribute(
+            nameSlice: ByteSlice.fromArray(bytes), nameBytes: nil,
+            hasUppercase: Attributes.containsAsciiUppercase(bytes),
+            value: value.map { $0.isEmpty ? .empty : .slice(ByteSlice.fromArray(Array($0.utf8))) } ?? .none
+        )
+    }
+
+    private func appendDeferred(_ items: [Attributes.PendingAttribute], to attrs: Attributes) {
+        attrs.pendingAttributes = items
+        attrs.pendingAttributesCount = items.count
+    }
+
+    func testDuplicateKeysKeepFirstPositionAndLastValue() throws {
+        let attrs = Attributes()
+        for item in [pending("data-a", "first"), pending("Class", "upper"),
+                     pending("class", "lower"), pending("data-a", "last"),
+                     pending("disabled"), pending("empty", ""), pending(" \t ", "drop")] {
+            attrs.appendPending(item)
+        }
+        XCTAssertEqual(Array(attrs).map { $0.getKey() }, ["data-a", "Class", "class", "disabled", "empty"])
+        XCTAssertEqual(attrs.get(key: "data-a"), "last")
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "CLASS"), "upper")
+        XCTAssertTrue(Array(attrs)[3] is BooleanAttribute)
+        XCTAssertFalse(Array(attrs)[4] is BooleanAttribute)
+        XCTAssertEqual(attrs.pendingAttributesCount, 0)
+        XCTAssertTrue(attrs.pendingAttributes?.isEmpty ?? true)
+    }
+
+    func testMaterializationRebuildsAnExistingKeyIndex() throws {
+        let attrs = Attributes()
+        for i in 0..<16 { try attrs.put("k\(i)", "v\(i)") }
+        attrs.ensureKeyIndex()
+        XCTAssertFalse(attrs.keyIndexDirty)
+        appendDeferred([pending("k3", "replacement"), pending("k16", "new"), pending("k3", "last")], to: attrs)
+        attrs.ensureMaterialized()
+        XCTAssertEqual(attrs.size(), 17)
+        XCTAssertEqual(attrs.get(key: "k3"), "last")
+        XCTAssertEqual(attrs.get(key: "k16"), "new")
+        for (index, attr) in Array(attrs).enumerated() {
+            XCTAssertEqual(attrs.keyIndex?[attr.keySlice], index)
+        }
+    }
+
+    func testMaterializationInvalidatesWarmedOwnerIndexes() throws {
+        let doc = try SwiftSoup.parse("<html><head></head><body><div id='old' class='before' data-x='one' title='t'></div></body></html>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        let element = try XCTUnwrap(doc.body()?.children().first())
+        let attrs = try XCTUnwrap(element.getAttributes())
+        _ = Array(attrs)
+        for _ in 0..<4 {
+            XCTAssertEqual(try doc.select(".before").size(), 1)
+            XCTAssertEqual(try doc.select("#old").size(), 1)
+            XCTAssertEqual(try doc.select("[data-x=one]").size(), 1)
+            XCTAssertEqual(try doc.select("[data-new]").size(), 0)
+        }
+        appendDeferred([pending("id", "new"), pending("class", "after"),
+                        pending("data-x", "two"), pending("data-new", "yes")], to: attrs)
+        attrs.ensureMaterialized()
+        XCTAssertEqual(try doc.select(".before, #old, [data-x=one]").size(), 0)
+        XCTAssertTrue(try doc.select(".after#new[data-x=two][data-new]").first() === element)
+        let reparsed = try SwiftSoup.parse(String(decoding: doc.outerHtmlUTF8(), as: UTF8.self))
+        XCTAssertEqual(try reparsed.select(".after#new[data-x=two][data-new]").size(), 1)
+        try attrs.put("class", "again")
+        XCTAssertEqual(try doc.select(".after").size(), 0)
+        XCTAssertEqual(try doc.select(".again").size(), 1)
+    }
+
+    func testInvalidPendingNamesPreserveExistingValues() throws {
+        let attrs = Attributes()
+        try attrs.put("id", "kept")
+        appendDeferred([pending(" \t\n", "discarded"), pending("", "discarded")], to: attrs)
+        attrs.ensureMaterialized()
+        XCTAssertEqual(Array(attrs).map { $0.getKey() }, ["id"])
+        XCTAssertEqual(attrs.get(key: "id"), "kept")
+        XCTAssertEqual(attrs.pendingAttributesCount, 0)
+    }
+
+    func testWideDeferredAttributesSupportRemovalAndCaseInsensitiveLookup() throws {
+        let attrs = Attributes()
+        for i in 0..<128 { attrs.appendPending(pending("Data-Key-\(i)", "v\(i)")) }
+        attrs.appendPending(pending("Data-Key-63", "changed"))
+        XCTAssertEqual(Array(attrs).count, 128)
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "data-key-63"), "changed")
+        try attrs.remove(key: "Data-Key-62")
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "DATA-KEY-63"), "changed")
+        attrs.lowercaseAllKeys()
+        XCTAssertEqual(attrs.get(key: "data-key-127"), "v127")
+        XCTAssertEqual(attrs.size(), 127)
+    }
+
+    func testMultiSliceAndByteValuesMaterializeUnchanged() throws {
+        let attrs = Attributes()
+        var split = pending("data-split")
+        split.value = .slices([ByteSlice.fromArray(Array("日本".utf8)), ByteSlice.fromArray(Array("語&".utf8))], 10)
+        var bytes = pending("data-bytes")
+        bytes.nameSlice = nil
+        bytes.nameBytes = Array(" data-bytes ".utf8)
+        bytes.value = .bytes(Array("value<&".utf8))
+        attrs.appendPending(split)
+        attrs.appendPending(bytes)
+        _ = Array(attrs)
+        XCTAssertEqual(attrs.get(key: "data-split"), "日本語&")
+        XCTAssertEqual(attrs.get(key: "data-bytes"), "value<&")
+        XCTAssertTrue(try attrs.html().contains("日本語&amp;"))
+    }
+    func testDeferredBatchesMatchOrderedReferenceAtThresholds() throws {
+        for existingCount in [0, 1, 3, 4, 8] {
+            for batchCount in [0, 1, 2, 3, 4, 5, 16, 129] {
+                let attrs = Attributes()
+                var expected: [(String, String)] = []
+                for index in 0..<existingCount {
+                    let key = "key-\(index)"
+                    try attrs.put(key, "initial")
+                    expected.append((key, "initial"))
+                }
+                attrs.ensureKeyIndex()
+                let oldArray = Array(attrs)
+                var deferred: [Attributes.PendingAttribute] = []
+                for index in 0..<batchCount {
+                    let rawKey = index % 11 == 0 ? " \t " : " key-\(index % 9) "
+                    let value = "value-\(index)"
+                    deferred.append(pending(rawKey, value))
+                    let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if key.isEmpty { continue }
+                    if let position = expected.firstIndex(where: { $0.0 == key }) {
+                        expected[position] = (key, value)
+                    } else {
+                        expected.append((key, value))
+                    }
+                }
+                appendDeferred(deferred, to: attrs)
+                attrs.ensureMaterialized()
+                XCTAssertEqual(Array(attrs).map { $0.getKey() }, expected.map { $0.0 })
+                XCTAssertEqual(Array(attrs).map { $0.getValue() }, expected.map { $0.1 })
+                XCTAssertEqual(oldArray.map { $0.getValue() }, Array(repeating: "initial", count: existingCount))
+                for (key, value) in expected { XCTAssertEqual(attrs.get(key: key), value) }
+            }
+        }
+    }
+
+}

--- a/Tests/SwiftSoupTests/AttributeObservationReadTest.swift
+++ b/Tests/SwiftSoupTests/AttributeObservationReadTest.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeObservationReadTest: XCTestCase {
+    func testRepeatedSnapshotsAndIteratorsKeepOneWeakObserver() throws {
+        let attrs = Attributes()
+        for index in 0..<128 { try attrs.put("k\(index)", "v") }
+        let snapshot = attrs.asList()
+        for _ in 0..<16 {
+            _ = attrs.asList()
+            _ = Array(attrs)
+        }
+        for attribute in snapshot {
+            XCTAssertEqual(attribute.mutationOwners?.count, 1)
+            XCTAssertTrue(attribute.mutationOwners?.first?.value === attrs)
+        }
+        try snapshot[17].setKey(key: "changed")
+        XCTAssertFalse(attrs.hasKey(key: "k17"))
+        XCTAssertEqual(attrs.get(key: "changed"), "v")
+    }
+
+    func testRepeatedObservationStillPrunesRemovedAndDeadSecondaryOwners() throws {
+        let primary = Attributes()
+        let removed = Attributes()
+        let shared = try Attribute(key: "id", value: "old")
+        primary.put(attribute: shared)
+        removed.put(attribute: shared)
+        var expired: Attributes? = Attributes()
+        expired?.put(attribute: shared)
+        weak var weakExpired = expired
+        expired = nil
+        XCTAssertNil(weakExpired)
+        try removed.remove(key: "id")
+        _ = primary.asList()
+        XCTAssertEqual(shared.mutationOwners?.count, 1)
+        XCTAssertTrue(shared.mutationOwners?.first?.value === primary)
+        shared.setValue(value: Array("new".utf8))
+        XCTAssertEqual(primary.get(key: "id"), "new")
+        XCTAssertFalse(removed.hasKey(key: "id"))
+    }
+
+    func testRetainedSnapshotCanMoveToAnotherOwnerAndBeReinserted() throws {
+        let first = Attributes()
+        try first.put("id", "old")
+        let saved = try XCTUnwrap(first.asList().first)
+        _ = first.asList()
+        try first.remove(key: "id")
+        let second = Attributes()
+        second.put(attribute: saved)
+        XCTAssertEqual(saved.mutationOwners?.count, 1)
+        XCTAssertTrue(saved.mutationOwners?.first?.value === second)
+        _ = second.asList()
+        first.put(attribute: saved)
+        saved.setValue(value: Array("new".utf8))
+        XCTAssertEqual(first.get(key: "id"), "new")
+        XCTAssertEqual(second.get(key: "id"), "new")
+        XCTAssertEqual(saved.mutationOwners?.count, 2)
+    }
+}

--- a/Tests/SwiftSoupTests/AttributeObserverRegistrationTest.swift
+++ b/Tests/SwiftSoupTests/AttributeObserverRegistrationTest.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeObserverRegistrationTest: XCTestCase {
+    func testRepeatedSnapshotsAndIteratorsKeepExactlyOneRegistrationPerOwner() throws {
+        let attributes = Attributes()
+        for index in 0..<128 { try attributes.put("k\(index)", "v\(index)") }
+        let original = attributes.asList()
+        for _ in 0..<32 {
+            let snapshot = attributes.asList()
+            XCTAssertEqual(snapshot.count, original.count)
+            for (index, attribute) in attributes.enumerated() {
+                XCTAssertTrue(attribute === original[index])
+                XCTAssertEqual(attribute.mutationOwners?.count, 1)
+                XCTAssertTrue(attribute.mutationOwners?.first?.value === attributes)
+            }
+        }
+    }
+
+    func testRegistrationStillPrunesOtherRemovedAndExpiredOwners() throws {
+        let shared = try Attribute(key: "class", value: "old")
+        let active = Attributes()
+        let removed = Attributes()
+        var expired: Attributes? = Attributes()
+        active.put(attribute: shared)
+        removed.put(attribute: shared)
+        expired?.put(attribute: shared)
+        XCTAssertEqual(shared.mutationOwners?.count, 3)
+        try removed.remove(key: "class")
+        expired = nil
+        _ = active.asList()
+        XCTAssertEqual(shared.mutationOwners?.count, 1)
+        XCTAssertTrue(shared.mutationOwners?.first?.value === active)
+    }
+
+    func testSharedMutationsAfterReregistrationReachBothDocuments() throws {
+        let first = try SwiftSoup.parse("<p class='before'></p>")
+        let second = try SwiftSoup.parse("<p></p>")
+        let a = try XCTUnwrap(first.body()?.child(0).getAttributes())
+        let b = try XCTUnwrap(second.body()?.child(0).getAttributes())
+        let shared = try XCTUnwrap(a.asList().first)
+        b.put(attribute: shared)
+        for _ in 0..<16 { _ = a.asList(); _ = b.asList() }
+        XCTAssertEqual(try first.select(".before").size(), 1)
+        XCTAssertEqual(try second.select(".before").size(), 1)
+        shared.setValue(value: Array("after".utf8))
+        for doc in [first, second] {
+            XCTAssertEqual(try doc.select(".before").size(), 0)
+            XCTAssertEqual(try doc.select(".after").size(), 1)
+        }
+        XCTAssertEqual(shared.mutationOwners?.count, 2)
+    }
+}

--- a/Tests/SwiftSoupTests/AttributeOwnershipRefinementTest.swift
+++ b/Tests/SwiftSoupTests/AttributeOwnershipRefinementTest.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeOwnershipRefinementTest: XCTestCase {
+    private func firstParagraph(_ doc: Document) throws -> Element {
+        var stack: [Node] = [doc]
+        while let node = stack.popLast() {
+            if let element = node as? Element, element.tagName() == "p" { return element }
+            stack.append(contentsOf: node.childNodes.reversed())
+        }
+        throw NSError(domain: "missing fixture paragraph", code: 1)
+    }
+
+    private final class ProjectedAttribute: Attribute {
+        override func getKeyUTF8() -> [UInt8] { Array("UPPER".utf8) }
+        override func getValueUTF8() -> [UInt8] { Array("visible".utf8) }
+    }
+
+    private final class RejectingKeyAttribute: Attribute {
+        override func setKey(key: [UInt8]) throws {
+            throw NSError(domain: "custom setter rejects changes", code: 1)
+        }
+    }
+
+    func testDeferredAttributeReadDoesNotDirtyParsedSource() throws {
+        let doc = try SwiftSoup.parse("<html><head></head><body><p title='one' CLASS='two' data-v='three'>text</p></body></html>")
+        let p = try firstParagraph(doc)
+        let attrs = try XCTUnwrap(p.attributes)
+        XCTAssertFalse(p.sourceRangeDirty)
+        let documentWasDirty = doc.sourceRangeDirty
+        XCTAssertGreaterThan(attrs.pendingAttributesCount, 0)
+        let version = doc.textMutationVersionToken()
+        XCTAssertEqual(attrs.asList().count, 3)
+        XCTAssertFalse(p.sourceRangeDirty, "materialization is a read, not a DOM edit")
+        XCTAssertEqual(doc.sourceRangeDirty, documentWasDirty)
+        XCTAssertEqual(doc.textMutationVersionToken(), version)
+    }
+
+    func testMaterializationPreservesAlreadyCleanIndexes() throws {
+        let doc = try SwiftSoup.parse("<html><head></head><body><p title='one'>text</p></body></html>")
+        let p = try firstParagraph(doc)
+        let attrs = try XCTUnwrap(p.attributes)
+        // Model indexes previously validated from the deferred representation.
+        p.isClassQueryIndexDirty = false
+        p.isIdQueryIndexDirty = false
+        p.isAttributeQueryIndexDirty = false
+        p.isAttributeValueQueryIndexDirty = false
+        _ = attrs.asList()
+        XCTAssertFalse(p.isClassQueryIndexDirty)
+        XCTAssertFalse(p.isIdQueryIndexDirty)
+        XCTAssertFalse(p.isAttributeQueryIndexDirty)
+        XCTAssertFalse(p.isAttributeValueQueryIndexDirty)
+    }
+
+    func testCloneMaterializationDoesNotDirtyOriginal() throws {
+        let doc = try SwiftSoup.parse("<html><head></head><body><p title='one'>text</p></body></html>")
+        let p = try firstParagraph(doc)
+        let documentWasDirty = doc.sourceRangeDirty
+        let copied = try XCTUnwrap(p.attributes).clone()
+        XCTAssertEqual(doc.sourceRangeDirty, documentWasDirty)
+        XCTAssertFalse(p.sourceRangeDirty)
+        XCTAssertEqual(copied.get(key: "title"), "one")
+    }
+
+    func testAttributeClonePreservesPublicGetterProjection() throws {
+        let custom = try ProjectedAttribute(key: Array("stored".utf8), value: Array("raw".utf8))
+        let copy = custom.clone()
+        XCTAssertEqual(copy.getKey(), "UPPER")
+        XCTAssertEqual(copy.getValue(), "visible")
+        XCTAssertFalse(copy === custom)
+    }
+
+    func testCollectionCloneRecomputesProjectedKeyCase() throws {
+        let attrs = Attributes()
+        attrs.put(attribute: try ProjectedAttribute(key: Array("stored".utf8), value: Array("raw".utf8)))
+        let copy = attrs.clone()
+        XCTAssertEqual(copy.get(key: "UPPER"), "visible")
+        XCTAssertEqual(try copy.getIgnoreCase(key: "upper"), "visible")
+        XCTAssertTrue(copy.hasKeyIgnoreCase(key: "upper"))
+    }
+
+    func testValueSetterNoOpChecksStoredValueNotGetterProjection() throws {
+        let custom = try ProjectedAttribute(key: Array("stored".utf8), value: Array("raw".utf8))
+        let attrs = Attributes()
+        attrs.put(attribute: custom)
+        XCTAssertEqual(custom.setValue(value: Array("visible".utf8)), Array("visible".utf8))
+        XCTAssertEqual(custom.html(), "stored=\"visible\"")
+        XCTAssertEqual(attrs.get(key: "stored"), "visible")
+    }
+
+    func testLowercaseNormalizationDoesNotInvokeCustomSetter() throws {
+        // Normalization has historically updated stored keys rather than calling an open setter.
+        let custom = try RejectingKeyAttribute(key: Array("UPPER".utf8), value: Array("v".utf8))
+        let a = Attributes()
+        let b = Attributes()
+        a.put(attribute: custom)
+        b.put(attribute: custom)
+        XCTAssertTrue(a.hasKey(key: "UPPER"))
+        XCTAssertTrue(b.hasKey(key: "UPPER"))
+        a.lowercaseAllKeys()
+        for attrs in [a, b] {
+            XCTAssertEqual(attrs.get(key: "upper"), "v")
+            XCTAssertFalse(attrs.hasKey(key: "UPPER"))
+            XCTAssertEqual(try attrs.getIgnoreCase(key: "UPPER"), "v")
+        }
+    }
+
+    func testSharedCollectionDropsDeadSecondaryObserversOnMutation() throws {
+        let attrs = Attributes()
+        try attrs.put("title", "old")
+        let survivor = Element(try Tag.valueOf("p"), "", attrs)
+        var owners: [Element] = []
+        for _ in 0..<128 { owners.append(Element(try Tag.valueOf("p"), "", attrs)) }
+        XCTAssertEqual(attrs.additionalOwnerNodes?.count, 128)
+        owners.removeAll()
+        try attrs.put("title", "new")
+        XCTAssertTrue(attrs.additionalOwnerNodes?.isEmpty ?? true)
+        XCTAssertEqual(try survivor.attr("title"), "new")
+    }
+
+    func testDeadPrimaryOwnerPromotesSurvivorOnlyOnce() throws {
+        let attrs = Attributes()
+        try attrs.put("title", "old")
+        var first: Element? = Element(try Tag.valueOf("p"), "", attrs)
+        let second = Element(try Tag.valueOf("p"), "", attrs)
+        weak var expired = first
+        first = nil
+        XCTAssertNil(expired)
+        try attrs.put("title", "new")
+        XCTAssertTrue(attrs.ownerNode === second)
+        XCTAssertTrue(attrs.additionalOwnerNodes?.isEmpty ?? true)
+        for _ in 0..<4 { XCTAssertEqual(try second.select("[title=new]").size(), 1) }
+    }
+
+    func testSharedReferenceSurvivesRepeatedRemoveAndReinsert() throws {
+        let a = Element(try Tag.valueOf("p"), "")
+        let b = Element(try Tag.valueOf("p"), "")
+        let shared = try Attribute(key: "class", value: "v0")
+        a.getAttributes()!.put(attribute: shared)
+        for round in 1...64 {
+            let attrs = b.getAttributes()!
+            attrs.put(attribute: shared)
+            let value = "v\(round)"
+            shared.setValue(value: Array(value.utf8))
+            for element in [a, b] {
+                for _ in 0..<4 { XCTAssertTrue(try element.select("." + value).first() === element) }
+            }
+            try b.removeAttr("class")
+            shared.setValue(value: Array("between".utf8))
+            XCTAssertEqual(try b.select(".between").size(), 0)
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/AttributeOwnershipTest.swift
+++ b/Tests/SwiftSoupTests/AttributeOwnershipTest.swift
@@ -1,0 +1,350 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeOwnershipTest: XCTestCase {
+    private func attribute(_ attrs: Attributes, _ key: String) throws -> Attribute {
+        try XCTUnwrap(attrs.first { $0.getKey() == key })
+    }
+
+    private func assertMatches(_ root: Element, _ query: String, _ expected: [Element],
+                               file: StaticString = #filePath, line: UInt = #line) throws {
+        let evaluator = try QueryParser.parse(query)
+        var stack = [root]
+        var scanned: [Element] = []
+        while let node = stack.popLast() {
+            if try evaluator.matches(root, node) { scanned.append(node) }
+            stack.append(contentsOf: node.childNodes.reversed().compactMap { $0 as? Element })
+        }
+        let ids = expected.map(ObjectIdentifier.init)
+        XCTAssertEqual(scanned.map(ObjectIdentifier.init), ids, "scan: \(query)", file: file, line: line)
+        XCTAssertEqual(try Collector.collect(evaluator, root).array().map(ObjectIdentifier.init), ids,
+                       "collector: \(query)", file: file, line: line)
+        for _ in 0..<4 {
+            XCTAssertEqual(try root.select(query).array().map(ObjectIdentifier.init), ids,
+                           "cached selection: \(query)", file: file, line: line)
+        }
+    }
+
+    func testSharedAttributeValueNotifiesEveryCollection() throws {
+        let a = try SwiftSoup.parse("<p></p>")
+        let b = try SwiftSoup.parse("<p></p>")
+        let pa = try XCTUnwrap(a.select("p").first())
+        let pb = try XCTUnwrap(b.select("p").first())
+        let shared = try Attribute(key: "class", value: "old")
+        pa.getAttributes()!.put(attribute: shared)
+        pb.getAttributes()!.put(attribute: shared)
+        for (doc, p) in [(a, pa), (b, pb)] { try assertMatches(doc, ".old", [p]) }
+        XCTAssertEqual(String(decoding: shared.setValue(value: Array("new".utf8)), as: UTF8.self), "old")
+        for (doc, p) in [(a, pa), (b, pb)] {
+            try assertMatches(doc, ".old", [])
+            try assertMatches(doc, ".new", [p])
+        }
+    }
+
+    func testAddAllRegistersPreviouslyUnexposedSourceAttributes() throws {
+        let a = try SwiftSoup.parse("<p id='old' data-v='first'></p>")
+        let b = try SwiftSoup.parse("<p></p>")
+        let pa = try XCTUnwrap(a.select("p").first())
+        let pb = try XCTUnwrap(b.select("p").first())
+        pb.getAttributes()!.addAll(incoming: pa.getAttributes())
+        try assertMatches(a, "#old", [pa])
+        try assertMatches(b, "#old", [pb])
+        let id = try attribute(pb.getAttributes()!, "id")
+        id.setValue(value: Array("new".utf8))
+        for (doc, p) in [(a, pa), (b, pb)] {
+            try assertMatches(doc, "#old", [])
+            try assertMatches(doc, "#new", [p])
+        }
+    }
+
+    func testSharedCollectionNotifiesEveryElement() throws {
+        let attrs = Attributes()
+        try attrs.put("class", "old")
+        let a = Element(try Tag.valueOf("p"), "", attrs)
+        let b = Element(try Tag.valueOf("p"), "", attrs)
+        for p in [a, b] { try assertMatches(p, ".old", [p]) }
+        try attrs.put("class", "new")
+        for p in [a, b] {
+            try assertMatches(p, ".old", [])
+            try assertMatches(p, ".new", [p])
+        }
+        try attribute(attrs, "class").setKey(key: "title")
+        for p in [a, b] { try assertMatches(p, ".new", []) }
+    }
+
+    func testRenameInvalidatesBothKeyIndexes() throws {
+        let attrs = Attributes()
+        for i in 0..<12 { try attrs.put("k\(i)", "v\(i)") }
+        let a = try attribute(attrs, "k0")
+        XCTAssertEqual(attrs.get(key: "k0"), "v0")
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "K0"), "v0")
+        try a.setKey(key: "RENAMED")
+        XCTAssertFalse(attrs.hasKey(key: "k0"))
+        XCTAssertFalse(attrs.hasKeyIgnoreCase(key: "K0"))
+        XCTAssertEqual(attrs.get(key: "RENAMED"), "v0")
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "renamed"), "v0")
+        XCTAssertTrue(attrs.hasKeyIgnoreCase(key: ArraySlice(Array("renamed".utf8))))
+    }
+
+    func testRenameIntoAndOutOfIdAndClass() throws {
+        let doc = try SwiftSoup.parse("<p title='x'></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let a = try attribute(p.getAttributes()!, "title")
+        try assertMatches(doc, "#x", [])
+        try assertMatches(doc, ".x", [])
+        try a.setKey(key: "ID")
+        try assertMatches(doc, "#x", [p])
+        try a.setKey(key: "CLASS")
+        try assertMatches(doc, "#x", [])
+        try assertMatches(doc, ".x", [p])
+        try a.setKey(key: "title")
+        try assertMatches(doc, ".x", [])
+    }
+
+    func testAsListMutationRemainsLive() throws {
+        let doc = try SwiftSoup.parse("<p class='before'></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let saved = p.getAttributes()!.asList()
+        try assertMatches(doc, ".before", [p])
+        saved[0].setValue(value: Array("after".utf8))
+        try assertMatches(doc, ".before", [])
+        try assertMatches(doc, ".after", [p])
+    }
+
+    func testSavedIteratorDoesNotMutateReplacementAttribute() throws {
+        let doc = try SwiftSoup.parse("<p class='before'></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let iterator = p.getAttributes()!.makeIterator()
+        try p.attr("class", "replacement")
+        let old = try XCTUnwrap(iterator.next())
+        try assertMatches(doc, ".replacement", [p])
+        XCTAssertFalse(doc.isClassQueryIndexDirty)
+        old.setValue(value: Array("stale".utf8))
+        XCTAssertFalse(doc.isClassQueryIndexDirty, "removed references must not invalidate their former owners")
+        try assertMatches(doc, ".replacement", [p])
+        try assertMatches(doc, ".stale", [])
+    }
+
+    func testRemoveAllDetachesOnlyRemovedOwners() throws {
+        let doc = try SwiftSoup.parse("<p class='x' id='a'></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let attrs = p.getAttributes()!
+        let a = try attribute(attrs, "class")
+        let other = Attributes()
+        other.put(attribute: a)
+        attrs.removeAll(keys: [Array("class".utf8)])
+        try assertMatches(doc, ".x", [])
+        a.setValue(value: Array("y".utf8))
+        XCTAssertEqual(other.get(key: "class"), "y")
+        XCTAssertFalse(doc.isClassQueryIndexDirty)
+        try assertMatches(doc, ".y", [])
+    }
+
+    func testCompactCallbackMutationIsObservedWithoutReturnedNewValue() throws {
+        let doc = try SwiftSoup.parse("<p class='old'></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        try assertMatches(doc, ".old", [p])
+        p.getAttributes()!.compactAndMutate { a in
+            a.setValue(value: Array("new".utf8))
+            return AttributeMutation(keep: true)
+        }
+        try assertMatches(doc, ".old", [])
+        try assertMatches(doc, ".new", [p])
+    }
+
+    func testCompactCallbackCanRetainLiveAttribute() throws {
+        let doc = try SwiftSoup.parse("<p class='old'></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        var saved: Attribute?
+        p.getAttributes()!.compactAndMutate { a in
+            saved = a
+            return AttributeMutation(keep: true)
+        }
+        try assertMatches(doc, ".old", [p])
+        saved?.setValue(value: Array("new".utf8))
+        try assertMatches(doc, ".old", [])
+        try assertMatches(doc, ".new", [p])
+    }
+
+    func testCompactValueMutationNotifiesSharedOwners() throws {
+        let doc = try SwiftSoup.parse("<p class='old'></p><b></b>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let b = try XCTUnwrap(doc.select("b").first())
+        b.getAttributes()!.addAll(incoming: p.getAttributes())
+        try assertMatches(b, ".old", [b])
+        p.getAttributes()!.compactAndMutate { _ in AttributeMutation(keep: true, newValue: Array("new".utf8)) }
+        try assertMatches(b, ".old", [])
+        try assertMatches(b, ".new", [b])
+    }
+
+    func testLowercaseAllKeysNotifiesSharedCollectionKeyCache() throws {
+        let a = Attributes()
+        try a.put("UPPER", "v")
+        let b = Attributes()
+        b.addAll(incoming: a)
+        XCTAssertTrue(b.hasKey(key: "UPPER"))
+        XCTAssertFalse(b.hasKey(key: "upper"))
+        a.lowercaseAllKeys()
+        XCTAssertFalse(b.hasKey(key: "UPPER"))
+        XCTAssertEqual(b.get(key: "upper"), "v")
+    }
+
+    func testCloneAndCopyIsolateAttributeObjects() throws {
+        let original = Attributes()
+        try original.put("class", "old")
+        for copy in [original.clone(), original.copy() as! Attributes] {
+            let a = try attribute(original, "class")
+            let b = try attribute(copy, "class")
+            XCTAssertFalse(a === b)
+            b.setValue(value: Array("new".utf8))
+            try b.setKey(key: "ID")
+            XCTAssertEqual(original.get(key: "class"), "old")
+            XCTAssertFalse(original.hasKeyIgnoreCase(key: "id"))
+        }
+    }
+
+    func testElementCloneMutationDoesNotLeakToOriginal() throws {
+        let doc = try SwiftSoup.parse("<p class='old' data-v='before'></p>")
+        let copy = doc.copy() as! Document
+        let original = try XCTUnwrap(doc.select("p").first())
+        let cloned = try XCTUnwrap(copy.select("p").first())
+        try assertMatches(doc, ".old", [original])
+        try assertMatches(copy, ".old", [cloned])
+        try attribute(cloned.getAttributes()!, "class").setValue(value: Array("new".utf8))
+        try assertMatches(doc, ".old", [original])
+        try assertMatches(doc, ".new", [])
+        try assertMatches(copy, ".new", [cloned])
+    }
+
+    func testBooleanCloneRetainsImplicitBooleanSerialization() throws {
+        let a = try BooleanAttribute(key: Array("custom-flag".utf8))
+        let b = a.clone()
+        XCTAssertTrue(b is BooleanAttribute)
+        XCTAssertEqual(a.html(), b.html())
+        let attrs = Attributes()
+        attrs.put(attribute: a)
+        XCTAssertEqual(try attrs.html(), try attrs.clone().html())
+    }
+
+    func testCloneWithDeferredValueSlicesIsIndependent() throws {
+        let attrs = Attributes()
+        let a = try Attribute(key: "data-v", value: "one")
+        attrs.put(attribute: a)
+        a.appendValueSlice(ByteSlice.fromArray(Array("two".utf8)))
+        let copy = attrs.clone()
+        let b = try attribute(copy, "data-v")
+        b.appendValueSlice(ByteSlice.fromArray(Array("three".utf8)))
+        XCTAssertEqual(a.getValue(), "onetwo")
+        XCTAssertEqual(b.getValue(), "onetwothree")
+    }
+
+    func testOwnerReferencesDoNotRetainDOMOrCollections() throws {
+        var saved: Attribute?
+        weak var weakDoc: Document?
+        weak var weakAttrs: Attributes?
+        do {
+            let doc = try SwiftSoup.parse("<p class='old'></p>")
+            let p = try XCTUnwrap(doc.select("p").first())
+            let attrs = p.getAttributes()!
+            weakDoc = doc
+            weakAttrs = attrs
+            saved = try attribute(attrs, "class")
+            try assertMatches(doc, ".old", [p])
+        }
+        XCTAssertNil(weakDoc)
+        XCTAssertNil(weakAttrs)
+        saved?.setValue(value: Array("safe".utf8))
+        XCTAssertEqual(saved?.getValue(), "safe")
+    }
+
+    func testRetainedCollectionDoesNotRetainOwningElements() throws {
+        let attrs = Attributes()
+        try attrs.put("class", "old")
+        weak var first: Element?
+        weak var second: Element?
+        do {
+            let a = Element(try Tag.valueOf("p"), "", attrs)
+            let b = Element(try Tag.valueOf("b"), "", attrs)
+            first = a; second = b
+            try assertMatches(a, ".old", [a])
+            try assertMatches(b, ".old", [b])
+        }
+        XCTAssertNil(first)
+        XCTAssertNil(second)
+        try attrs.put("class", "new")
+        XCTAssertEqual(attrs.get(key: "class"), "new")
+    }
+
+    func testInvalidKeyMutationIsAtomic() throws {
+        let attrs = Attributes()
+        try attrs.put("valid", "v")
+        let a = try attribute(attrs, "valid")
+        for key in ["", " ", "\t\r\n"] {
+            XCTAssertThrowsError(try a.setKey(key: key))
+            XCTAssertEqual(a.getKey(), "valid")
+            XCTAssertEqual(attrs.get(key: "valid"), "v")
+            XCTAssertThrowsError(try Attribute(key: key, value: "v"))
+        }
+    }
+
+    func testCaseVariantAttributeIndexesUseFirstMatchingValue() throws {
+        let doc = try SwiftSoup.parse("<p></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let attrs = p.getAttributes()!
+        try attrs.put("HREF", "first")
+        try attrs.put("href", "second")
+        XCTAssertEqual(try p.attr("href"), "first")
+        try assertMatches(doc, "[href]", [p])
+        try assertMatches(doc, "[href=first]", [p])
+        try assertMatches(doc, "[href=second]", [])
+        try attrs.remove(key: "HREF")
+        try assertMatches(doc, "[href=first]", [])
+        try assertMatches(doc, "[href=second]", [p])
+    }
+
+    func testRenameCollisionPreservesFirstMatchAtEveryIndexSize() throws {
+        for padding in [0, 5, 20] {
+            let doc = try SwiftSoup.parse("<p data-a='first' data-b='second'></p>")
+            let p = try XCTUnwrap(doc.select("p").first())
+            let attrs = p.getAttributes()!
+            for i in 0..<padding { try attrs.put("padding-\(i)", "v") }
+            let second = try attribute(attrs, "data-b")
+            try second.setKey(key: "data-a")
+            XCTAssertEqual(attrs.get(key: "data-a"), "first")
+            XCTAssertEqual(try attrs.getIgnoreCase(key: "DATA-A"), "first")
+            try assertMatches(doc, "[data-a]", [p])
+            try assertMatches(doc, "[data-a=first]", [p])
+            try assertMatches(doc, "[data-a=second]", [])
+        }
+    }
+
+    func testReparentedOwnerInvalidatesDestinationNotOldTree() throws {
+        let a = try SwiftSoup.parse("<p class='old'></p>")
+        let b = try SwiftSoup.parse("<main></main>")
+        let p = try XCTUnwrap(a.select("p").first())
+        let saved = try attribute(p.getAttributes()!, "class")
+        try b.body()!.appendChild(p)
+        try assertMatches(a, ".old", [])
+        try assertMatches(b, ".old", [p])
+        saved.setValue(value: Array("new".utf8))
+        XCTAssertFalse(a.isClassQueryIndexDirty)
+        try assertMatches(b, ".old", [])
+        try assertMatches(b, ".new", [p])
+    }
+
+    func testManySharedOwnersAndRemovalOrders() throws {
+        let shared = try Attribute(key: "class", value: "old")
+        let owners = try (0..<24).map { _ -> Element in
+            let p = Element(try Tag.valueOf("p"), "")
+            p.getAttributes()!.put(attribute: shared)
+            return p
+        }
+        for p in owners { try assertMatches(p, ".old", [p]) }
+        for (i, p) in owners.enumerated() where i % 3 == 0 { try p.removeAttr("class") }
+        shared.setValue(value: Array("new".utf8))
+        for (i, p) in owners.enumerated() {
+            try assertMatches(p, ".old", [])
+            try assertMatches(p, ".new", i % 3 == 0 ? [] : [p])
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/AttributeValueIndexUpdateTest.swift
+++ b/Tests/SwiftSoupTests/AttributeValueIndexUpdateTest.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import SwiftSoup
+
+final class AttributeValueIndexUpdateTest: XCTestCase {
+    private func assertMatchesScan(_ root: Element, _ key: String, _ value: String,
+                                   file: StaticString = #filePath, line: UInt = #line) throws {
+        // Do not use Collector.collect here: it can use the same value index.
+        let evaluator = try Evaluator.AttributeWithValue(key, value)
+        var expected: [Element] = []
+        var stack = [root]
+        while let element = stack.popLast() {
+            if try evaluator.matches(root, element) { expected.append(element) }
+            for child in element.getChildNodes().reversed() {
+                if let child = child as? Element { stack.append(child) }
+            }
+        }
+        let actual = try root.getElementsByAttributeValue(key, value)
+        XCTAssertEqual(actual.array().map(ObjectIdentifier.init), expected.map(ObjectIdentifier.init), file: file, line: line)
+    }
+
+    func testCombinedIndexPreservesUniqueRepeatedAndNormalizedValues() throws {
+        let html = "<main>" + (0..<100).map {
+            "<a id='n\($0)' class='link' href=' /ITEM/\($0) ' rel=' TAG ' data-kind='k\($0 % 7)'>text</a>"
+        }.joined() + "<a href='/日本語' rel='tag'></a></main>"
+        let doc = try SwiftSoup.parse(html)
+        XCTAssertNil(doc.normalizedAttributeValueIndex)
+        try assertMatchesScan(doc, "href", "/item/50")
+        try assertMatchesScan(doc, "rel", "tag")
+        try assertMatchesScan(doc, "href", "/日本語")
+        try assertMatchesScan(doc, "href", "missing")
+        XCTAssertEqual(try doc.getElementsByAttributeValue("rel", "tag").size(), 101)
+        XCTAssertFalse(doc.isClassQueryIndexDirty)
+        XCTAssertNotNil(doc.normalizedClassNameIndex)
+    }
+
+    func testSoloIndexRebuildAfterMutationPreservesOtherIndexes() throws {
+        let doc = try SwiftSoup.parse("<main><a href='/one' rel='tag'>one</a><a href='/two' rel='tag'>two</a></main>")
+        doc.materializeAttributesRecursively()
+        doc.rebuildQueryIndexesForAllTags()
+        XCTAssertNotNil(doc.normalizedClassNameIndex)
+        XCTAssertNotNil(doc.normalizedIdIndex)
+        XCTAssertNotNil(doc.normalizedAttributeNameIndex)
+        let link = try XCTUnwrap(doc.getElementsByTag("a").first())
+        try link.attr("href", "/new")
+        // Prepare unchanged index categories so only the value index is rebuilt.
+        doc.rebuildQueryIndexesForAllTags()
+        let snapshot = try XCTUnwrap(doc.normalizedAttributeValueIndex)
+        doc.isAttributeValueQueryIndexDirty = true
+        doc.rebuildQueryIndexesForHotAttributes()
+        try assertMatchesScan(doc, "href", "/new")
+        try assertMatchesScan(doc, "rel", "tag")
+        let key = ByteSlice.fromArray(Array("rel".utf8))
+        let value = ByteSlice.fromArray(Array("tag".utf8))
+        XCTAssertEqual(snapshot[key]?[value]?.compactMap(\.value).map(ObjectIdentifier.init),
+                       doc.normalizedAttributeValueIndex?[key]?[value]?.compactMap(\.value).map(ObjectIdentifier.init))
+        XCTAssertFalse(doc.isClassQueryIndexDirty)
+        XCTAssertFalse(doc.isIdQueryIndexDirty)
+        XCTAssertFalse(doc.isAttributeQueryIndexDirty)
+    }
+
+    func testDynamicKeysRebuildAndEvictWithoutChangingResults() throws {
+        let attrs = (0..<12).map { "data-k\($0)='v\($0)'" }.joined(separator: " ")
+        let doc = try SwiftSoup.parse("<div \(attrs)></div><span \(attrs)></span>")
+        for key in 0..<12 { try assertMatchesScan(doc, "data-k\(key)", "v\(key)") }
+        for key in (0..<12).reversed() { try assertMatchesScan(doc, "data-k\(key)", "v\(key)") }
+        XCTAssertLessThanOrEqual(doc.dynamicAttributeValueIndexKeySet?.count ?? 0, Element.dynamicAttributeValueIndexMaxKeys)
+    }
+
+    func testValueIndexTracksRepeatedMutationsRemovalAndMoves() throws {
+        let doc = try SwiftSoup.parse("<main><a id='a' href='/old' rel='tag'></a><section><a id='b' href='/old' rel='tag'></a></section></main>")
+        let a = try XCTUnwrap(doc.getElementById("a"))
+        let section = try XCTUnwrap(doc.getElementsByTag("section").first())
+        for _ in 0..<4 { try assertMatchesScan(doc, "href", "/old") }
+        try a.attr("href", "/new")
+        try assertMatchesScan(doc, "href", "/old")
+        try assertMatchesScan(doc, "href", "/new")
+        try a.removeAttr("href")
+        try assertMatchesScan(doc, "href", "/new")
+        try a.attr("href", "/old")
+        try section.appendChild(a)
+        try assertMatchesScan(doc, "href", "/old")
+        let ids = try doc.getElementsByAttributeValue("href", "/old").map { try $0.attr("id") }
+        XCTAssertEqual(ids, ["b", "a"])
+    }
+}

--- a/Tests/SwiftSoupTests/BlankTextBytesTest.swift
+++ b/Tests/SwiftSoupTests/BlankTextBytesTest.swift
@@ -1,0 +1,154 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class BlankTextBytesTest: XCTestCase {
+    // The original public Character predicate is the compatibility oracle.
+    private func reference(_ text: String) -> Bool {
+        text.allSatisfy { StringUtil.isWhitespace($0) }
+    }
+
+    func testEverySingleByteAndAdjacentWhitespace() {
+        for value in UInt16(0)...255 {
+            let byte = UInt8(value)
+            for bytes in [[byte], [32, byte], [byte, 13, 10], [9, 32, byte, 12]] {
+                let text = String(decoding: bytes, as: UTF8.self)
+                let expected = reference(text)
+                XCTAssertEqual(StringUtil.isBlank(text), expected, "\(bytes)")
+                XCTAssertEqual(TextNode(bytes, nil).isBlank(), expected, "\(bytes)")
+            }
+        }
+    }
+
+    func testWhitespaceContractIsNotBroadened() {
+        for text in ["", " ", "\t", "\n", "\r", "\u{c}", "\r\n", " \t\r\n\u{c} "] {
+            XCTAssertTrue(reference(text))
+            XCTAssertTrue(StringUtil.isBlank(text))
+            XCTAssertTrue(TextNode(text, nil).isBlank())
+        }
+        for text in ["\u{b}", "\u{85}", "\u{a0}", "\u{1680}", "\u{2000}", "\u{2028}", "\u{2029}", "\u{202f}", "\u{205f}", "\u{3000}", "\u{feff}", "\0"] {
+            XCTAssertFalse(reference(text))
+            XCTAssertFalse(StringUtil.isBlank(text))
+            XCTAssertFalse(TextNode(text, nil).isBlank())
+        }
+    }
+
+    func testComposedGraphemesAndCanonicalSpelling() {
+        for text in [" \u{301}", "\r\n\u{301}", "\u{301} ", "e\u{301}", "é", "가", "가", "👩🏽‍💻", "🇯🇵", "\u{200d}", "\u{fe0f}"] {
+            for value in [text, " \t" + text + "\r\n", String(repeating: text, count: 32)] {
+                XCTAssertEqual(StringUtil.isBlank(value), reference(value))
+                XCTAssertEqual(TextNode(value, nil).isBlank(), reference(value))
+            }
+        }
+    }
+
+    func testSeededUnicodeAndMalformedBytes() {
+        var seed: UInt64 = 0x62b1a9
+        func next() -> UInt64 {
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            return seed
+        }
+        let pieces = [" ", "\t", "\n", "\r", "\r\n", "\u{c}", "\u{b}", "\0", "\u{a0}", "日本", "e\u{301}", "👩🏽‍💻", "🇯🇵", "\u{301}"]
+        for _ in 0..<2048 {
+            let length = Int(next() % 40)
+            let text = (0..<length).map { _ in pieces[Int(next() % UInt64(pieces.count))] }.joined()
+            XCTAssertEqual(StringUtil.isBlank(text), reference(text))
+            XCTAssertEqual(TextNode(text, nil).isBlank(), reference(text))
+            let bytes = (0..<length).map { _ in UInt8(truncatingIfNeeded: next() >> 32) }
+            let decoded = String(decoding: bytes, as: UTF8.self)
+            let node = TextNode(bytes, nil)
+            XCTAssertEqual(node.isBlank(), reference(decoded))
+            XCTAssertEqual(node.getWholeTextUTF8(), bytes)
+        }
+    }
+
+    func testTextGetterSubclassDispatchAndReadOrder() {
+        final class Projected: TextNode {
+            var calls: [String] = []
+            var projection = " "
+            override func getWholeText() -> String { calls.append("string"); return projection }
+            override func getWholeTextUTF8() -> [UInt8] { calls.append("bytes"); return [88] }
+        }
+        let node = Projected("backing", nil)
+        for projection in [" ", "\u{a0}", "", "日本"] {
+            node.calls = []
+            node.projection = projection
+            XCTAssertEqual(node.isBlank(), reference(projection))
+            XCTAssertEqual(node.calls, ["string"])
+        }
+        final class BytesOnly: TextNode {
+            var reads = 0
+            override func getWholeTextUTF8() -> [UInt8] { reads += 1; return [13, 10] }
+        }
+        let bytes = BytesOnly("not blank", nil)
+        XCTAssertTrue(bytes.isBlank())
+        XCTAssertEqual(bytes.reads, 1)
+    }
+
+    func testSlicedAndFragmentedStorageRemainsMaterializedAsBefore() {
+        for text in [" \r\n", "日本語", "\u{a0}", ""] {
+            let bytes = Array(text.utf8)
+            var padded = [UInt8(88), 89]; padded += bytes; padded += [90]
+            let node = TextNode(slice: ArraySlice(padded[2..<(2 + bytes.count)]), baseUri: nil)
+            XCTAssertEqual(node.isBlank(), reference(text))
+            XCTAssertEqual(node._text, bytes)
+            XCTAssertNil(node.attributes)
+            node.appendSlice(ByteSlice.fromArray([32, 9]))
+            XCTAssertEqual(node.isBlank(), reference(text + " \t"))
+            XCTAssertEqual(node._text, bytes + [32, 9])
+        }
+        let fragmented = TextNode(slice: ByteSlice.fromArray([32]), baseUri: nil)
+        fragmented.appendSlice(ByteSlice.fromArray([0xC2]))
+        fragmented.appendSlice(ByteSlice.fromArray([0xA0]))
+        XCTAssertFalse(fragmented.isBlank())
+        XCTAssertEqual(fragmented._text, [32, 0xC2, 0xA0])
+    }
+
+    func testAttributeEditsRemainAuthoritative() throws {
+        let node = TextNode("pending", nil)
+        let attribute = try XCTUnwrap(node.getAttributes().asList().first)
+        for bytes in [[UInt8](), [32, 13, 10], [0xFF], Array("日本".utf8)] {
+            attribute.setValue(value: bytes)
+            XCTAssertEqual(node.isBlank(), reference(String(decoding: bytes, as: UTF8.self)))
+            XCTAssertEqual(node.getWholeTextUTF8(), bytes)
+        }
+        try attribute.setKey(key: "renamed")
+        XCTAssertTrue(node.isBlank())
+        try node.attr("text", "new")
+        XCTAssertFalse(node.isBlank())
+        try node.removeAttr("text")
+        XCTAssertTrue(node.isBlank())
+    }
+
+    func testBlankReadDoesNotDirtySourceOrWarmedSelectors() throws {
+        let doc = try SwiftSoup.parse("<main><p> \t </p><p>日本 &amp; text</p></main>")
+        let queries = ["p", "p:contains(日本)", "p:empty", "p:matches(text)"]
+        let before = try queries.map { try doc.select($0).array().map(ObjectIdentifier.init) }
+        let html = try doc.outerHtmlUTF8()
+        let token = doc.textMutationVersionToken()
+        for p in try doc.select("p") {
+            for text in p.textNodes() {
+                let dirty = text.sourceRangeDirty
+                for _ in 0..<8 { XCTAssertEqual(text.isBlank(), reference(text.getWholeText())) }
+                XCTAssertEqual(text.sourceRangeDirty, dirty)
+            }
+        }
+        XCTAssertEqual(doc.textMutationVersionToken(), token)
+        XCTAssertEqual(try doc.outerHtmlUTF8(), html)
+        XCTAssertEqual(try queries.map { try doc.select($0).array().map(ObjectIdentifier.init) }, before)
+        let first = try XCTUnwrap(doc.select("p").first())
+        first.textNodes()[0].text("日本")
+        XCTAssertTrue(first.hasText())
+        XCTAssertEqual(try doc.select("p:contains(日本)").size(), 2)
+    }
+
+    func testPublicHasTextEachTextAndSerialization() throws {
+        let doc = try SwiftSoup.parse("<main><p> \r\n </p><p>日本</p><p>&nbsp;</p><p>e&#x301;</p><p>\u{b}</p></main>")
+        let paragraphs = try doc.select("p")
+        XCTAssertEqual(paragraphs.array().map { $0.hasText() }, [false, true, true, true, true])
+        XCTAssertEqual(try paragraphs.eachText().count, 4)
+        let copy = doc.copy() as! Document
+        XCTAssertEqual(try copy.outerHtmlUTF8(), try doc.outerHtmlUTF8())
+        XCTAssertEqual(try copy.text(), try doc.text())
+    }
+}

--- a/Tests/SwiftSoupTests/ChildIndexedReadTest.swift
+++ b/Tests/SwiftSoupTests/ChildIndexedReadTest.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import SwiftSoup
+
+private final class ChildReadTrace {
+    var events: [String] = []
+}
+
+private final class ChildReadProjection: Elements {
+    let trace: ChildReadTrace
+    var answer: Element
+    init(_ answer: Element, _ trace: ChildReadTrace) {
+        self.answer = answer
+        self.trace = trace
+        super.init()
+    }
+    override func get(_ index: Int) -> Element {
+        trace.events.append("get:\(index)")
+        return answer
+    }
+    override func array() -> [Element] {
+        trace.events.append("array")
+        return []
+    }
+}
+
+private final class ChildReadParent: Element {
+    var projection: ChildReadProjection!
+    override func children() -> Elements {
+        projection.trace.events.append("children")
+        return projection
+    }
+}
+
+private final class ChildReadNodeView: Element {
+    var reads = 0
+    override func getChildNodes() -> [Node] {
+        reads += 1
+        return []
+    }
+}
+
+final class ChildIndexedReadTest: XCTestCase {
+    private func make(_ tag: String = "section") throws -> Element {
+        try Element(Tag.valueOf(tag), "")
+    }
+
+    private func verify(_ parent: Element, _ expected: [Element],
+                        file: StaticString = #filePath, line: UInt = #line) {
+        for (index, child) in expected.enumerated() {
+            XCTAssertTrue(parent.child(index) === child, file: file, line: line)
+        }
+    }
+
+    func testMixedNodeListsAgainstExplicitModel() throws {
+        for width in [0, 1, 2, 3, 8, 32, 64, 257] {
+            let parent = try make()
+            var expected: [Element] = []
+            for i in 0..<width {
+                try parent.appendChild(TextNode("日\(i)", ""))
+                try parent.appendChild(Comment("gap".utf8.map { $0 }, []))
+                try parent.appendChild(DataNode(Array("data".utf8), []))
+                let child = try make(i.isMultiple(of: 2) ? "p" : "em")
+                expected.append(child)
+                try parent.appendChild(child)
+            }
+            try parent.appendChild(TextNode("tail", ""))
+            verify(parent, expected)
+        }
+    }
+
+    func testDocumentAndFormAndDeepCopy() throws {
+        let document = Document("")
+        let form = try FormElement(Tag.valueOf("form"), [])
+        for parent in [document as Element, form] {
+            let children = try (0..<9).map { try make($0.isMultiple(of: 2) ? "input" : "p") }
+            for child in children {
+                try parent.appendChild(Comment([120], []))
+                try parent.appendChild(child)
+            }
+            verify(parent, children)
+            let clone = parent.copy() as! Element
+            let copied = clone.children().array()
+            verify(clone, copied)
+            XCTAssertEqual(copied.count, children.count)
+            for i in children.indices { XCTAssertFalse(copied[i] === children[i]) }
+        }
+    }
+
+    func testCustomChildrenAndGetKeepExactDispatchAndInvalidIndices() throws {
+        let trace = ChildReadTrace()
+        let parent = try ChildReadParent(Tag.valueOf("main"), "")
+        let physical = try make("p")
+        let projected = try make("aside")
+        try parent.appendChild(physical)
+        parent.projection = ChildReadProjection(projected, trace)
+        // A custom get() can define these indices: do not precondition them early.
+        for index in [Int.min, -1, 0, 1, Int.max] {
+            trace.events = []
+            XCTAssertTrue(parent.child(index) === projected)
+            XCTAssertEqual(trace.events, ["children", "get:\(index)"])
+        }
+        parent.projection.answer = physical
+        XCTAssertTrue(parent.child(0) === physical)
+    }
+
+    func testPublicNodeViewDoesNotReplaceChildrenContract() throws {
+        let parent = try ChildReadNodeView(Tag.valueOf("main"), "")
+        let child = try make()
+        try parent.appendChild(child)
+        XCTAssertTrue(parent.child(0) === child)
+        XCTAssertEqual(parent.reads, 0)
+    }
+
+    func testStaleSiblingIndexesAreNotUsed() throws {
+        let parent = try make()
+        let expected = try (0..<12).map { _ in try make() }
+        for child in expected { try parent.appendChild(child) }
+        for stale in [Int.min, -1, 0, 99, Int.max] {
+            for child in expected { child.setSiblingIndex(stale) }
+            verify(parent, expected)
+        }
+        // Restore public indexes before any later structural operation.
+        for (i, child) in expected.enumerated() { child.setSiblingIndex(i) }
+    }
+
+    func testSeededMovesRemovalsAndEmpty() throws {
+        let left = try make("main"), right = try make("aside")
+        var lists: [[Element]] = [[], []]
+        var seed: UInt64 = 0xC411D
+        for i in 0..<384 {
+            seed = seed &* 6364136223846793005 &+ 1
+            let side = Int(seed % 2), parent = side == 0 ? left : right
+            if i % 7 == 0 {
+                parent.empty()
+                lists[side].removeAll()
+            } else if !lists[1-side].isEmpty && i % 3 == 0 {
+                let child = lists[1-side].removeFirst()
+                try parent.prependChild(child)
+                lists[side].insert(child, at: 0)
+            } else {
+                let child = try make(i.isMultiple(of: 2) ? "p" : "b")
+                try parent.appendChild(TextNode("t", ""))
+                try parent.appendChild(child)
+                lists[side].append(child)
+            }
+            verify(left, lists[0])
+            verify(right, lists[1])
+        }
+    }
+
+    func testReadsKeepSourceAndWarmedSelection() throws {
+        let document = try SwiftSoup.parse("<main>x<p id='a'>日</p><!--c--><p id='b'>語</p></main>")
+        let parent = try XCTUnwrap(document.select("main").first())
+        let expected = parent.children().array()
+        let html = try document.outerHtml().utf8.map { $0 }
+        let selected = try parent.select("p").array().map(ObjectIdentifier.init)
+        for _ in 0..<64 {
+            verify(parent, expected)
+            XCTAssertEqual(try parent.select("p").array().map(ObjectIdentifier.init), selected)
+            XCTAssertEqual(try document.outerHtml().utf8.map { $0 }, html)
+        }
+        try parent.child(0).attr("id", "changed")
+        XCTAssertTrue(try document.select("#changed").first() === expected[0])
+        XCTAssertEqual(try document.select("#a").size(), 0)
+    }
+}

--- a/Tests/SwiftSoupTests/DOMOperationBenchmarkTest.swift
+++ b/Tests/SwiftSoupTests/DOMOperationBenchmarkTest.swift
@@ -1,0 +1,139 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+/// Opt-in release benchmarks for small DOM operations. Setup is not timed.
+///
+/// SWIFTSOUP_OPERATION_BENCHMARK=1 swift test -c release --filter DOMOperationBenchmarkTest
+/// Use the same file, toolchain, sizes and iterations in baseline/candidate worktrees.
+/// Alternate execution order, run A/A controls, and keep profiling separate from timing.
+final class DOMOperationBenchmarkTest: XCTestCase {
+    private func configuration() throws -> (count: Int, iterations: Int) {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["SWIFTSOUP_OPERATION_BENCHMARK"] == "1" else {
+            throw XCTSkip("Set SWIFTSOUP_OPERATION_BENCHMARK=1 to run release benchmarks")
+        }
+        let count = Int(environment["SWIFTSOUP_OPERATION_COUNT"] ?? "256") ?? 0
+        let iterations = Int(environment["SWIFTSOUP_OPERATION_ITERATIONS"] ?? "1000") ?? 0
+        guard (1...100_000).contains(count), (1...1_000_000).contains(iterations) else {
+            throw NSError(domain: "DOMOperationBenchmark", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid benchmark count or iteration count"])
+        }
+        return (count, iterations)
+    }
+
+    private func document(_ count: Int) throws -> Document {
+        let paragraphs = (0..<count).map {
+            "<p id='p\($0)' class='entry' data-n='\($0)'><b>日本語</b>text</p>"
+        }.joined()
+        let document = try SwiftSoup.parse("<main>\(paragraphs)</main>")
+        document.outputSettings().prettyPrint(pretty: false)
+        return document
+    }
+
+    @discardableResult
+    private func run(_ name: String, count: Int, iterations: Int,
+                     operation: () throws -> UInt64) throws -> UInt64 {
+        var checksum: UInt64 = 0
+        let warmups = 3
+        for _ in 0..<warmups { checksum &+= try operation() }
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations { checksum &+= try operation() }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        let result: [String: Any] = [
+            "operation": name, "count": count, "iterations": iterations,
+            "warmups": warmups, "elapsed_ms": Double(elapsed) / 1_000_000,
+            "checksum": String(checksum)
+        ]
+        let data = try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys])
+        print("SWIFTSOUP_OPERATION_RESULT " + String(decoding: data, as: UTF8.self))
+        return checksum
+    }
+
+    func testNormalizedLeafText() throws {
+        try leafText(normalize: true)
+    }
+
+    func testRawLeafText() throws {
+        try leafText(normalize: false)
+    }
+
+    private func leafText(normalize: Bool) throws {
+        let config = try configuration()
+        let document = try document(config.count)
+        let leaves = try document.getElementsByTag("b").array()
+        let checksum = try run(normalize ? "leaf-text" : "leaf-text-raw",
+                               count: config.count, iterations: config.iterations) {
+            var bytes: UInt64 = 0
+            for leaf in leaves { bytes &+= UInt64(try leaf.text(trimAndNormaliseWhitespace: normalize).utf8.count) }
+            return bytes
+        }
+        XCTAssertEqual(checksum, UInt64(config.iterations + 3) * UInt64(config.count) * UInt64("日本語".utf8.count))
+        withExtendedLifetime(document) {}
+    }
+
+    func testAttributeCopy() throws {
+        let config = try configuration()
+        let document = try document(config.count)
+        let attributes = try document.getElementsByTag("p").map { $0.getAttributes()! }
+        for attributes in attributes { _ = Array(attributes) }
+        let checksum = try run("attributes-copy", count: config.count, iterations: config.iterations) {
+            var size: UInt64 = 0
+            for attributes in attributes { size &+= UInt64(attributes.clone().size()) }
+            return size
+        }
+        XCTAssertEqual(checksum, UInt64(config.iterations + 3) * UInt64(config.count) * 3)
+        withExtendedLifetime(document) {}
+    }
+
+    func testDocumentCopy() throws {
+        let config = try configuration()
+        let document = try document(config.count)
+        // Keep materialization outside the timed deep-copy operation.
+        document.materializeAttributesRecursively()
+        let checksum = try run("document-copy", count: config.count, iterations: config.iterations) {
+            let copy = document.copy() as! Document
+            return UInt64(copy.childNodeSize())
+        }
+        XCTAssertEqual(checksum, UInt64(config.iterations + 3) * UInt64(document.childNodeSize()))
+        let copy = document.copy() as! Document
+        // Compare DOM serialization under the same explicit output policy.
+        copy.outputSettings().prettyPrint(pretty: false)
+        XCTAssertEqual(try copy.outerHtml(), try document.outerHtml())
+        XCTAssertTrue(try copy.getElementsByTag("b").first()?.ownerDocument() === copy)
+    }
+
+    func testSiblingReindex() throws {
+        let config = try configuration()
+        let document = try document(config.count)
+        let root = try XCTUnwrap(document.getElementsByTag("main").first())
+        let checksum = try run("siblings-reindex", count: config.count, iterations: config.iterations) {
+            root.reindexChildren(0)
+            return UInt64(root.childNode(config.count - 1).siblingIndex)
+        }
+        XCTAssertEqual(checksum, UInt64(config.iterations + 3) * UInt64(config.count - 1))
+        for (index, child) in root.getChildNodes().enumerated() {
+            XCTAssertEqual(child.siblingIndex, index)
+            XCTAssertTrue(child.parent() === root)
+        }
+        withExtendedLifetime(document) {}
+    }
+
+    func testSiblingRotation() throws {
+        let config = try configuration()
+        let document = try document(config.count)
+        let root = try XCTUnwrap(document.getElementsByTag("main").first())
+        let checksum = try run("siblings-rotate", count: config.count, iterations: config.iterations) {
+            try root.insertChildren(0, [root.childNode(config.count - 1)])
+            return UInt64(root.childNode(config.count - 1).siblingIndex)
+        }
+        XCTAssertEqual(checksum, UInt64(config.iterations + 3) * UInt64(config.count - 1))
+        let offset = (config.iterations + 3) % config.count
+        for (index, child) in root.getChildNodes().enumerated() {
+            XCTAssertEqual(child.siblingIndex, index)
+            XCTAssertTrue(child.parent() === root)
+            XCTAssertEqual(try child.attr("id"), "p\((index - offset + config.count) % config.count)")
+        }
+        withExtendedLifetime(document) {}
+    }
+}

--- a/Tests/SwiftSoupTests/DataTraversalTest.swift
+++ b/Tests/SwiftSoupTests/DataTraversalTest.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import SwiftSoup
+
+final class DataTraversalTest: XCTestCase {
+    private func assertSelection(_ root: Element, _ query: String, _ expected: [Element],
+                                 file: StaticString = #filePath, line: UInt = #line) throws {
+        let evaluator = try QueryParser.parse(query)
+        var stack = [root]
+        var scanned: [Element] = []
+        while let element = stack.popLast() {
+            if try evaluator.matches(root, element) { scanned.append(element) }
+            stack.append(contentsOf: element.childNodes.reversed().compactMap { $0 as? Element })
+        }
+        let identities = expected.map(ObjectIdentifier.init)
+        XCTAssertEqual(scanned.map(ObjectIdentifier.init), identities, query, file: file, line: line)
+        XCTAssertEqual(try Collector.collect(evaluator, root).array().map(ObjectIdentifier.init), identities,
+                       query, file: file, line: line)
+        for _ in 0..<4 {
+            XCTAssertEqual(try root.select(query).array().map(ObjectIdentifier.init), identities,
+                           query, file: file, line: line)
+        }
+    }
+
+    private final class CustomDataNode: DataNode {
+        override func getWholeDataUTF8() -> [UInt8] { Array("custom".utf8) }
+    }
+
+    func testDataNodeSubclassGetterRemainsAuthoritative() throws {
+        let element = Element(try Tag.valueOf("script"), "")
+        try element.appendChild(CustomDataNode(Array("stored".utf8), []))
+        XCTAssertEqual(element.data(), "custom")
+    }
+
+    func testDataIncludesCommentsInDocumentOrder() throws {
+        let doc = try SwiftSoup.parse("<main><!--a--><script>b</script><section><!--c--><style>d</style>ignored</section><!--e--></main>")
+        let main = try XCTUnwrap(doc.select("main").first())
+        XCTAssertEqual(main.data(), "abcde")
+        XCTAssertEqual(try doc.select("section").first()?.data(), "cd")
+        try assertSelection(doc, "main:containsData(abcde)", [main])
+    }
+
+    func testOrdinaryTextAndDeclarationAreNotData() throws {
+        let doc = try SwiftSoup.parse("<!doctype html><html><head></head><body><p>ignored</p><!--kept--></body></html>")
+        XCTAssertEqual(doc.data(), "kept")
+        XCTAssertEqual(try doc.select("p").first()?.data(), "")
+        XCTAssertEqual(try doc.text(), "ignored")
+    }
+
+    func testContainsDataIsCaseInsensitiveWithoutNormalizingWhitespace() throws {
+        let doc = try SwiftSoup.parse("<main><!--MiX\n  Ed--></main>")
+        let main = try XCTUnwrap(doc.select("main").first())
+        XCTAssertEqual(main.data(), "MiX\n  Ed")
+        try assertSelection(doc, "main:containsData(mix\n  ed)", [main])
+        try assertSelection(doc, "main:containsData(mix ed)", [])
+    }
+
+    func testUnicodeCommentBytesArePreserved() throws {
+        let value = "日本e\u{301}👩‍💻 &amp;"
+        let doc = try SwiftSoup.parse("<main><!--" + value + "--></main>")
+        let main = try XCTUnwrap(doc.select("main").first())
+        XCTAssertEqual(Array(main.data().utf8), Array(value.utf8))
+        try assertSelection(doc, "main:containsData(日本)", [main])
+    }
+
+    func testTraversalDoesNotMaterializeSingleSliceData() throws {
+        let doc = try SwiftSoup.parse("<script>one</script>")
+        let script = try XCTUnwrap(doc.select("script").first())
+        let data = try XCTUnwrap(script.childNodes.first as? DataNode)
+        XCTAssertNil(data.attributes)
+        let version = doc.textMutationVersionToken()
+        let dirty = data.sourceRangeDirty
+        XCTAssertEqual(script.data(), "one")
+        XCTAssertNil(data.attributes)
+        XCTAssertEqual(doc.textMutationVersionToken(), version)
+        XCTAssertEqual(data.sourceRangeDirty, dirty)
+    }
+
+    func testFragmentedDataDoesNotDirtySourceOnRead() throws {
+        let doc = try SwiftSoup.parse("<script></script>")
+        let script = try XCTUnwrap(doc.select("script").first())
+        let data = DataNode(slice: ByteSlice.fromArray(Array("one".utf8)), baseUri: [])
+        data.appendSlice(ByteSlice.fromArray(Array("two".utf8)))
+        try script.appendChild(data)
+        let version = doc.textMutationVersionToken()
+        let dirty = data.sourceRangeDirty
+        XCTAssertEqual(script.data(), "onetwo")
+        XCTAssertEqual(script.data(), "onetwo")
+        XCTAssertEqual(doc.textMutationVersionToken(), version)
+        XCTAssertEqual(data.sourceRangeDirty, dirty)
+    }
+
+    func testDeepDataTraversalPreservesOrder() throws {
+        let root = Element(try Tag.valueOf("main"), "")
+        var ancestors = [root]
+        for index in 0..<1500 {
+            let child = Element(try Tag.valueOf("div"), "")
+            try ancestors.last!.appendChild(Comment(Array("a".utf8), []))
+            try ancestors.last!.appendChild(child)
+            try ancestors.last!.appendChild(DataNode(Array(String(index % 10).utf8), []))
+            ancestors.append(child)
+        }
+        try ancestors.last!.appendChild(Comment(Array("middle".utf8), []))
+        let suffix = (0..<1500).reversed().map { String($0 % 10) }.joined()
+        XCTAssertEqual(root.data(), String(repeating: "a", count: 1500) + "middle" + suffix)
+        // Explicit teardown avoids making this a test of recursive ARC destruction.
+        for node in ancestors.dropFirst().reversed() { try node.remove() }
+    }
+
+    func testCommentRemovalAndReparentingInvalidatesBothRoots() throws {
+        let doc = try SwiftSoup.parse("<main><!--kept--></main><aside></aside>")
+        let main = try XCTUnwrap(doc.select("main").first())
+        let aside = try XCTUnwrap(doc.select("aside").first())
+        let comment = try XCTUnwrap(main.childNodes.first as? Comment)
+        try assertSelection(doc, "main:containsData(kept)", [main])
+        try assertSelection(doc, "aside:containsData(kept)", [])
+        try aside.appendChild(comment)
+        try assertSelection(doc, "main:containsData(kept)", [])
+        try assertSelection(doc, "aside:containsData(kept)", [aside])
+        try comment.remove()
+        XCTAssertEqual(doc.data(), "")
+        try assertSelection(doc, "aside:containsData(kept)", [])
+    }
+
+    func testEmptyCommentAndDataAddNoSeparators() throws {
+        let doc = try SwiftSoup.parse("<main><!----><script>a</script><!----><script></script><!--b--></main>")
+        XCTAssertEqual(try doc.select("main").first()?.data(), "ab")
+    }
+    func testCommentObjectMutationUpdatesSourceReuseAndDataSelectors() throws {
+        let doc = try SwiftSoup.parse("<html><head></head><body><main><!--before--></main></body></html>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        let main = try XCTUnwrap(doc.select("main").first())
+        let comment = try XCTUnwrap(main.getChildNodes().first as? Comment)
+        let a = try XCTUnwrap(comment.getAttributes()?.first(where: { _ in true }))
+        try assertSelection(doc, "main:containsData(before)", [main])
+        a.setValue(value: Array("after".utf8))
+        XCTAssertEqual(comment.getData(), "after")
+        try assertSelection(doc, "main:containsData(before)", [])
+        try assertSelection(doc, "main:containsData(after)", [main])
+        for bytes in [try doc.outerHtmlUTF8(), try doc.outerHtmlUTF8WithoutSourceReuse(), try doc.outerHtmlUTF8ReusingSourceOutsideBody()] {
+            let html = String(decoding: bytes, as: UTF8.self)
+            XCTAssertTrue(html.contains("<!--after-->"))
+            XCTAssertFalse(html.contains("<!--before-->"))
+        }
+    }
+
+}

--- a/Tests/SwiftSoupTests/DeferredAttributeConsistencyTest.swift
+++ b/Tests/SwiftSoupTests/DeferredAttributeConsistencyTest.swift
@@ -1,0 +1,283 @@
+import XCTest
+@testable import SwiftSoup
+
+final class DeferredAttributeConsistencyTest: XCTestCase {
+    private func item(_ key: String, _ value: String, bytes: Bool = false) -> Attributes.PendingAttribute {
+        let keyBytes = Array(key.utf8)
+        return Attributes.PendingAttribute(
+            nameSlice: bytes ? nil : ByteSlice.fromArray(keyBytes),
+            nameBytes: bytes ? keyBytes : nil,
+            hasUppercase: Attributes.containsAsciiUppercase(keyBytes),
+            value: .slice(ByteSlice.fromArray(Array(value.utf8))))
+    }
+
+    private func deferred(_ pairs: [(String, String)], bytes: Bool = false) -> Attributes {
+        Attributes(pendingAttributes: pairs.map { item($0.0, $0.1, bytes: bytes) })
+    }
+
+    func testDuplicateExactLookupDoesNotChangeAfterMaterialization() throws {
+        for bytes in [false, true] {
+            let attrs = deferred([("id", "first"), ("title", "x"), ("id", "last")], bytes: bytes)
+            XCTAssertTrue(attrs.attributes.isEmpty)
+            XCTAssertEqual(attrs.get(key: "id"), "last")
+            XCTAssertEqual(try attrs.getIgnoreCase(key: "ID"), "last")
+            XCTAssertEqual(attrs.valueSliceCaseSensitive(Array("id".utf8))?.toArray(), Array("last".utf8))
+            XCTAssertEqual(try attrs.getIgnoreCaseSlice(key: Array("ID".utf8)).toArray(), Array("last".utf8))
+            XCTAssertEqual(attrs.size(), 2)
+            XCTAssertEqual(attrs.get(key: "id"), "last")
+        }
+    }
+
+    func testIgnoreCaseKeepsFirstVariantButItsLastExactValue() throws {
+        for bytes in [false, true] {
+            for count in [0, 2, 20] {
+                let padding = (0..<count).map { ("k\($0)", "v\($0)") }
+                let attrs = deferred(padding + [("ID", "old-upper"), ("id", "lower"), ("ID", "new-upper")], bytes: bytes)
+                XCTAssertEqual(try attrs.getIgnoreCase(key: "Id"), "new-upper")
+                XCTAssertEqual(try attrs.getIgnoreCaseSlice(key: Array("iD".utf8)).toArray(), Array("new-upper".utf8))
+                XCTAssertEqual(attrs.get(key: "id"), "lower")
+                _ = attrs.size()
+                XCTAssertEqual(try attrs.getIgnoreCase(key: "Id"), "new-upper")
+                XCTAssertEqual(attrs.get(key: "id"), "lower")
+            }
+        }
+    }
+
+    func testPaddedNamesAreNormalizedBeforeDeferredLookups() throws {
+        for bytes in [false, true] {
+            for query in ["id", " id ", "ID", " ID "] {
+                let attrs = deferred([(" id ", "value")], bytes: bytes)
+                let expected = query == "id" ? "value" : ""
+                XCTAssertEqual(attrs.get(key: query), expected, query)
+                let insensitive = query == "id" || query == "ID" ? "value" : ""
+                XCTAssertEqual(try attrs.getIgnoreCase(key: query), insensitive, query)
+                _ = attrs.size()
+                XCTAssertEqual(attrs.get(key: query), expected, query)
+            }
+        }
+    }
+
+    func testPaddedSliceLookupDoesNotDependOnWhichGetterRanFirst() throws {
+        for bytes in [false, true] {
+            let attrs = deferred([(" id ", "value")], bytes: bytes)
+            XCTAssertEqual(attrs.valueSliceCaseSensitive(Array("id".utf8))?.toArray(), Array("value".utf8))
+            XCTAssertNil(attrs.valueSliceCaseSensitive(Array(" id ".utf8)))
+        }
+    }
+
+    func testInvalidPendingNamesAreNeverPresent() throws {
+        for bytes in [false, true] {
+            for key in [" ", "\t", " \n\t "] {
+                let attrs = deferred([(key, "discard")], bytes: bytes)
+                XCTAssertFalse(attrs.hasKey(key: key))
+                XCTAssertFalse(attrs.hasKeyIgnoreCase(key: Array(key.utf8)[...]))
+                XCTAssertEqual(attrs.get(key: key), "")
+                XCTAssertEqual(attrs.size(), 0)
+            }
+        }
+    }
+
+    func testDeferredSerializationMatchesMaterializedSerialization() throws {
+        for bytes in [false, true] {
+            for syntax in [OutputSettings.Syntax.html, .xml] {
+                let attrs = deferred([("id", "old"), ("title", "日本<&\""), ("id", "new"), (" \t ", "drop"), (" data-x ", "x")], bytes: bytes)
+                let settings = OutputSettings().syntax(syntax: syntax)
+                let before = StringBuilder()
+                try attrs.html(accum: before, out: settings)
+                _ = attrs.size()
+                let after = StringBuilder()
+                try attrs.html(accum: after, out: settings)
+                XCTAssertEqual(before.toString(), after.toString())
+                XCTAssertEqual(attrs.asList().map { $0.getKey() }, ["id", "title", "data-x"])
+                XCTAssertFalse(before.toString().contains("old"))
+                XCTAssertFalse(before.toString().contains("drop"))
+            }
+        }
+    }
+
+    func testNameBytesTakePrecedenceOverNameSliceOnEveryPath() throws {
+        var pending = item("slice-key", "v")
+        pending.nameBytes = Array("byte-key".utf8)
+        let attrs = Attributes(pendingAttributes: [pending])
+        XCTAssertEqual(try attrs.html(), " byte-key=\"v\"")
+        XCTAssertEqual(attrs.get(key: "byte-key"), "v")
+        XCTAssertEqual(attrs.get(key: "slice-key"), "")
+        XCTAssertEqual(attrs.asList().map { $0.getKey() }, ["byte-key"])
+    }
+
+    func testMalformedMissingNameDoesNotLeaveSerializationWhitespace() throws {
+        var pending = item("unused", "v")
+        pending.nameSlice = nil
+        let attrs = Attributes(pendingAttributes: [pending])
+        XCTAssertEqual(try attrs.html(), "")
+        XCTAssertEqual(attrs.size(), 0)
+    }
+
+    func testDuplicateBooleanAndExplicitEmptyValuesAgreeBeforeAndAfter() throws {
+        for lastIsBoolean in [false, true] {
+            var first = item("custom", "old")
+            var last = item("custom", "")
+            if lastIsBoolean { last.value = .none } else { first.value = .none }
+            let attrs = Attributes(pendingAttributes: [first, item("id", "kept"), last])
+            let before = try attrs.html()
+            XCTAssertEqual(attrs.get(key: "custom"), "")
+            _ = attrs.size()
+            XCTAssertEqual(try attrs.html(), before)
+            XCTAssertEqual(attrs.asList().first is BooleanAttribute, lastIsBoolean)
+        }
+    }
+
+    func testFragmentedDuplicateValueKeepsSelectedExactVariant() throws {
+        var fragments = item("ID", "unused")
+        fragments.value = .slices([ByteSlice.fromArray(Array("日本".utf8)), ByteSlice.fromArray(Array("語".utf8))], 9)
+        let attrs = Attributes(pendingAttributes: [item("ID", "old"), item("id", "lower"), fragments])
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "id"), "日本語")
+        XCTAssertEqual(try attrs.getIgnoreCaseSlice(key: Array("id".utf8)).toArray(), Array("日本語".utf8))
+        XCTAssertEqual(attrs.get(key: "id"), "lower")
+        _ = attrs.size()
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "id"), "日本語")
+    }
+
+    func testPublicParsedDuplicateAttributeLookupIsReadOrderIndependent() throws {
+        let doc = try SwiftSoup.parse("<p id='old' id='new' class='before' class='after'></p>")
+        let p = try XCTUnwrap(doc.body()?.getChildNodes().first as? Element)
+        let attrs = try XCTUnwrap(p.getAttributes())
+        XCTAssertEqual(try p.attr("id"), "new")
+        XCTAssertEqual(p.id(), "new")
+        XCTAssertEqual(try p.className(), "after")
+        _ = attrs.size()
+        XCTAssertEqual(try p.attr("id"), "new")
+        for _ in 0..<4 {
+            XCTAssertEqual(try doc.select("#old, .before").size(), 0)
+            XCTAssertTrue(try doc.select("#new.after").first() === p)
+        }
+    }
+
+    func testDeferredLookupAndSerializationDoNotDirtyOwners() throws {
+        let attrs = deferred([("id", "old"), ("id", "new"), (" \t ", "drop")])
+        let element = Element(try Tag.valueOf("p"), "", attrs)
+        let version = element.textMutationVersionToken()
+        let dirty = element.sourceRangeDirty
+        XCTAssertEqual(try element.attr("id"), "new")
+        let before = try attrs.html()
+        _ = attrs.size()
+        XCTAssertEqual(try attrs.html(), before)
+        XCTAssertEqual(element.textMutationVersionToken(), version)
+        XCTAssertEqual(element.sourceRangeDirty, dirty)
+    }
+
+    func testGeneratedDeferredStatesMatchImmediateInsertionModel() throws {
+        let names = ["id", "ID", "class", "CLASS", "data-x", " data-x ", "x", " x\t", "\t", " ", "é", "e\u{301}"]
+        let queries = ["id", "ID", "class", "CLASS", "data-x", " data-x ", "x", " x\t", "missing", "é", "e\u{301}"]
+        var state: UInt64 = 0x7a91_264e_310b_882f
+        func next(_ upper: Int) -> Int {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Int((state >> 32) % UInt64(upper))
+        }
+        for fixture in 0..<256 {
+            var pending: [Attributes.PendingAttribute] = []
+            let model = Attributes()
+            let length = fixture % 4 == 0 ? 1 : 4 + next(40)
+            for index in 0..<length {
+                let name = names[next(names.count)]
+                let text = ["", "value\(index)", "日本<&\"", "é", "e\u{301}"][next(5)]
+                var attr = item(name, text, bytes: next(2) == 0)
+                let rawName = Array(name.utf8)
+                let rawValue = Array(text.utf8)
+                let kind = next(5)
+                if kind == 0 {
+                    attr.value = .none
+                    if let value = try? BooleanAttribute(key: rawName) { model.put(attribute: value) }
+                } else {
+                    switch kind {
+                    case 1: attr.value = .bytes(rawValue)
+                    case 2:
+                        let middle = rawValue.count / 2
+                        attr.value = .slices([ByteSlice.fromArray(Array(rawValue[..<middle])), ByteSlice.fromArray(Array(rawValue[middle...]))], rawValue.count)
+                    default: break
+                    }
+                    if let value = try? Attribute(key: rawName, value: rawValue) { model.put(attribute: value) }
+                }
+                pending.append(attr)
+            }
+            // Each API starts from fresh deferred storage: a missing-key lookup
+            // through a different API must not materialize later test cases.
+            func fresh() -> Attributes { Attributes(pendingAttributes: pending) }
+            for query in queries {
+                let raw = Array(query.utf8)
+                XCTAssertEqual(fresh().get(key: query), model.get(key: query), "fixture \(fixture) \(query)")
+                XCTAssertEqual(try fresh().getIgnoreCase(key: query), try model.getIgnoreCase(key: query), "fixture \(fixture) \(query)")
+                XCTAssertEqual(fresh().hasKey(key: query), model.hasKey(key: query))
+                XCTAssertEqual(fresh().hasKeyIgnoreCase(key: raw[...]), model.hasKeyIgnoreCase(key: raw[...]))
+                XCTAssertEqual(fresh().valueSliceCaseSensitive(raw)?.toArray(), model.valueSliceCaseSensitive(raw)?.toArray())
+                XCTAssertEqual(try fresh().getIgnoreCaseSlice(key: raw), try model.getIgnoreCaseSlice(key: raw))
+            }
+            for syntax in [OutputSettings.Syntax.html, .xml] {
+                let settings = OutputSettings().syntax(syntax: syntax)
+                let actual = StringBuilder()
+                let expected = StringBuilder()
+                try fresh().html(accum: actual, out: settings)
+                try model.html(accum: expected, out: settings)
+                XCTAssertEqual(actual.buffer, expected.buffer, "fixture \(fixture)")
+            }
+            XCTAssertEqual(fresh().asList().map { $0.getKeyUTF8() }, model.asList().map { $0.getKeyUTF8() })
+            XCTAssertEqual(fresh().asList().map { $0.getValueUTF8() }, model.asList().map { $0.getValueUTF8() })
+        }
+    }
+
+    func testUnambiguousDeferredReadsAndSerializationStayDeferred() throws {
+        let attrs = deferred([("id", "new"), ("title", "text")])
+        XCTAssertEqual(attrs.get(key: "id"), "new")
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "ID"), "new")
+        XCTAssertTrue(attrs.hasKey(key: "title"))
+        XCTAssertEqual(try attrs.html(), " id=\"new\" title=\"text\"")
+        XCTAssertTrue(attrs.attributes.isEmpty, "successful reads must not allocate mutable attributes")
+    }
+
+    func testAppendingAfterDeferredReadsCannotReuseStaleValues() throws {
+        let attrs = deferred([("ID", "old"), ("id", "lower")])
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "id"), "old")
+        _ = try attrs.html()
+        attrs.appendPending(item("ID", "new"))
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "id"), "new")
+        XCTAssertEqual(attrs.get(key: "id"), "lower")
+        XCTAssertEqual(try attrs.html(), " ID=\"new\" id=\"lower\"")
+        _ = attrs.size()
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "id"), "new")
+    }
+
+    func testReplacingValidatedPendingBatchRevalidatesNames() throws {
+        let attrs = deferred([("id", "old")])
+        XCTAssertEqual(attrs.get(key: "id"), "old")
+        XCTAssertTrue(attrs.attributes.isEmpty)
+        attrs.pendingAttributes = [item("id", "first"), item("id", "last")]
+        attrs.pendingAttributesCount = 2
+        XCTAssertEqual(attrs.get(key: "id"), "last")
+        XCTAssertEqual(try attrs.html(), " id=\"last\"")
+    }
+
+    func testSmallAndWideValidationAgreeOnAllTrimWhitespace() throws {
+        for count in [0, 7, 8, 32] {
+            for byte in [9, 10, 11, 12, 13, 32] {
+                let space = String(UnicodeScalar(byte)!)
+                for bytes in [false, true] {
+                    let pairs = (0..<count).map { ("k\($0)", "v") } + [(space + "id" + space, "value"), (space, "drop")]
+                    let attrs = deferred(pairs, bytes: bytes)
+                    XCTAssertEqual(attrs.get(key: "id"), "value")
+                    XCTAssertFalse(attrs.hasKey(key: space))
+                    XCTAssertFalse(try attrs.html().contains("drop"))
+                    XCTAssertEqual(attrs.size(), count + 1)
+                }
+            }
+        }
+    }
+
+    func testWideDeferredDuplicateLookupUsesLastValueImmediately() throws {
+        let pairs = (0..<4096).map { ("key-\($0)", "v\($0)") }
+        let attrs = deferred(pairs + [("key-0", "last")])
+        XCTAssertEqual(attrs.get(key: "key-0"), "last")
+        XCTAssertEqual(attrs.size(), 4096)
+        XCTAssertEqual(attrs.asList().first?.getKey(), "key-0")
+        XCTAssertEqual(attrs.get(key: "key-4095"), "v4095")
+    }
+}

--- a/Tests/SwiftSoupTests/DeferredAttributeLegacyContractTest.swift
+++ b/Tests/SwiftSoupTests/DeferredAttributeLegacyContractTest.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import SwiftSoup
+
+final class DeferredAttributeLegacyContractTest: XCTestCase {
+    private func pending(_ pairs: [(String, String?)]) throws -> Attributes {
+        let token = Token.StartTag()
+        for (key, value) in pairs {
+            token.appendAttributeName(Array(key.utf8))
+            if let value {
+                if value.isEmpty { token.setEmptyAttributeValue() }
+                else { token.appendAttributeValue(ByteSlice.fromArray(Array(value.utf8))) }
+            }
+            try token.newAttribute()
+        }
+        return token.getAttributes()
+    }
+
+    func testTextNodeBytePresenceBeforeAnyOtherAttributeAccess() throws {
+        let text = TextNode("before", "")
+        XCTAssertNil(text.attributes)
+        XCTAssertTrue(text.hasAttr(Array("text".utf8)))
+        XCTAssertTrue(text.hasAttr(Array("TeXt".utf8)))
+        XCTAssertFalse(text.hasAttr(Array("missing".utf8)))
+        XCTAssertEqual(text.getWholeText(), "before")
+        XCTAssertTrue(text.hasAttr("text"))
+    }
+
+    func testDuplicateValueIsStableAcrossMaterialization() throws {
+        for padding in [0, 1, 8] {
+            let pairs: [(String, String?)] = [("duplicate", "before"), ("duplicate", "after")]
+                + (0..<padding).map { ("k\($0)", "v\($0)") }
+            let attributes = try pending(pairs)
+            XCTAssertEqual(attributes.get(key: "duplicate"), "after")
+            XCTAssertEqual(try attributes.getIgnoreCase(key: "DUPLICATE"), "after")
+            XCTAssertEqual(String(decoding: try attributes.getIgnoreCaseSlice(key: Array("duplicate".utf8)), as: UTF8.self), "after")
+            XCTAssertEqual(attributes.size(), padding + 1)
+            XCTAssertEqual(attributes.get(key: "duplicate"), "after")
+        }
+    }
+
+    func testCaseVariantsRetainFirstKeyPositionAndLastExactValue() throws {
+        for pairs in [
+            [("A", "first"), ("a", "lower"), ("A", "last")],
+            [("A", "first"), ("A", "last"), ("a", "lower")]
+        ] {
+            let attributes = try pending(pairs.map { ($0.0, Optional($0.1)) })
+            XCTAssertEqual(attributes.get(key: "A"), "last")
+            XCTAssertEqual(attributes.get(key: "a"), "lower")
+            XCTAssertEqual(try attributes.getIgnoreCase(key: "a"), "last")
+            XCTAssertEqual(attributes.size(), 2)
+            XCTAssertEqual(try attributes.getIgnoreCase(key: "a"), "last")
+            XCTAssertEqual(attributes.asList().map { $0.getKey() }, ["A", "a"])
+        }
+    }
+
+    func testTrimmedAndMalformedKeysHaveStablePresence() throws {
+        let attributes = try pending([(" title ", "trimmed"), (" \t", "invalid")])
+        XCTAssertEqual(attributes.get(key: "title"), "trimmed")
+        XCTAssertTrue(attributes.hasKey(key: "title"))
+        XCTAssertFalse(attributes.hasKey(key: " title "))
+        XCTAssertFalse(attributes.hasKey(key: " \t"))
+        XCTAssertEqual(try attributes.getIgnoreCase(key: "TITLE"), "trimmed")
+        XCTAssertEqual(attributes.size(), 1)
+        XCTAssertEqual(attributes.get(key: "title"), "trimmed")
+    }
+
+    func testDeferredHTMLMatchesMaterializedAttributeHTML() throws {
+        let attributes = try pending([("checked", nil), ("duplicate", "before"), ("duplicate", "after"), (" title ", "x"), (" \t", "invalid")])
+        let before = try attributes.html()
+        _ = attributes.size()
+        XCTAssertEqual(before, try attributes.html())
+    }
+
+    func testMalformedPresenceChecksStartFromFreshDeferredStorage() throws {
+        for key in [" title ", " \t", ""] {
+            let attributes = try pending([(" title ", "trimmed"), (" \t", "invalid")])
+            XCTAssertFalse(attributes.hasKey(key: key), key)
+            XCTAssertFalse(attributes.hasKeyIgnoreCase(key: Array(key.utf8)), key)
+        }
+    }
+
+    func testDuplicateIdsAndClassesAgreeWithWarmedSelectors() throws {
+        let html = "<p id='old' id='new' class='before' class='after' data-v='one' data-v='two'></p>"
+        for firstRead in 0..<4 {
+            let doc = try SwiftSoup.parse(html)
+            let p = try XCTUnwrap(doc.body()?.child(0))
+            let attrs = try XCTUnwrap(p.getAttributes())
+            if firstRead == 0 { XCTAssertEqual(try p.attr("id"), "new") }
+            if firstRead == 1 { XCTAssertTrue(try doc.select("#new").first() === p) }
+            if firstRead == 2 { XCTAssertTrue(try doc.select(".after").first() === p) }
+            if firstRead == 3 { _ = attrs.clone() }
+            for _ in 0..<3 {
+                XCTAssertEqual(try p.attr("id"), "new")
+                XCTAssertTrue(try doc.select("#new.after[data-v=two]").first() === p)
+                XCTAssertEqual(try doc.select("#old, .before, [data-v=one]").size(), 0)
+                _ = attrs.asList()
+            }
+        }
+    }
+
+    func testAppendingAfterADeferredReadInvalidatesCanonicalView() throws {
+        let attrs = try pending([("data-v", "first")])
+        XCTAssertEqual(attrs.get(key: "data-v"), "first")
+        attrs.appendPending(Attributes.PendingAttribute(nameSlice: ByteSlice.fromArray(Array("data-v".utf8)), nameBytes: nil, hasUppercase: false, value: .bytes(Array("last".utf8))))
+        XCTAssertEqual(attrs.get(key: "data-v"), "last")
+        XCTAssertEqual(attrs.size(), 1)
+        XCTAssertEqual(attrs.get(key: "data-v"), "last")
+    }
+
+    func testAmbiguousDeferredReadsMaterializeWithoutDirtyingOwners() throws {
+        let doc = try SwiftSoup.parse("<p id='old' id='new' class='before' class='after'></p>")
+        let p = try XCTUnwrap(doc.body()?.child(0))
+        let attrs = try XCTUnwrap(p.getAttributes())
+        XCTAssertTrue(attrs.attributes.isEmpty)
+        let dirty = p.sourceRangeDirty
+        let version = doc.textMutationVersion
+        XCTAssertEqual(try p.attr("id"), "new")
+        _ = try attrs.html()
+        XCTAssertFalse(attrs.attributes.isEmpty, "ambiguous names now use authoritative materialized storage")
+        XCTAssertEqual(attrs.get(key: "class"), "after")
+        XCTAssertEqual(p.sourceRangeDirty, dirty)
+        XCTAssertEqual(doc.textMutationVersion, version)
+    }
+
+    func testBooleanExplicitValuesSerializeConsistently() throws {
+        for key in ["disabled", "DISABLED", "custom"] {
+            for value in [nil, "", key, key.lowercased(), "different"] as [String?] {
+                for syntax in [OutputSettings.Syntax.html, .xml] {
+                    let attrs = try pending([(key, value)])
+                    let out = OutputSettings().syntax(syntax: syntax)
+                    let before = StringBuilder()
+                    try attrs.html(accum: before, out: out)
+                    _ = attrs.size()
+                    let after = StringBuilder()
+                    try attrs.html(accum: after, out: out)
+                    XCTAssertEqual(before.toString(), after.toString(), "\(key)=\(String(describing: value)), \(syntax)")
+                }
+            }
+        }
+    }
+
+    func testReadsPreserveSourceReuseAndStableRegeneratedSerialization() throws {
+        let html = "<p id='old' id='new' class='before' class='after'>日本語</p>"
+        let doc = try SwiftSoup.parse(html)
+        let p = try XCTUnwrap(doc.body()?.child(0))
+        let settings = doc.outputSettings().prettyPrint(pretty: false)
+        let original = try p.outerHtmlUTF8Internal(settings, allowRawSource: true)
+        let regenerated = try p.outerHtmlUTF8Internal(settings, allowRawSource: false)
+        XCTAssertEqual(p.getAttributes()?.get(key: "id"), "new")
+        XCTAssertEqual(try p.attr("id"), "new")
+        _ = p.getAttributes()?.asList()
+        XCTAssertEqual(try p.outerHtmlUTF8Internal(settings, allowRawSource: true), original)
+        XCTAssertEqual(try p.outerHtmlUTF8Internal(settings, allowRawSource: false), regenerated)
+        try p.attr("id", "edited")
+        let edited = try SwiftSoup.parse(String(decoding: p.outerHtmlUTF8Internal(settings, allowRawSource: true), as: UTF8.self))
+        XCTAssertEqual(try edited.select("#edited.after").size(), 1)
+        XCTAssertEqual(try edited.select("#old, #new, .before").size(), 0)
+    }
+
+    func testTextBytePresenceOnParsedNodesDoesNotDirtySourceOrRestoreRemovedText() throws {
+        let doc = try SwiftSoup.parse("<p>日本語</p>")
+        let p = try XCTUnwrap(doc.body()?.child(0))
+        let text = try XCTUnwrap(p.getChildNodes().first as? TextNode)
+        let dirty = text.sourceRangeDirty
+        let version = doc.textMutationVersion
+        XCTAssertNil(text.attributes)
+        XCTAssertTrue(text.hasAttr(Array("TEXT".utf8)))
+        XCTAssertEqual(text.sourceRangeDirty, dirty)
+        XCTAssertEqual(doc.textMutationVersion, version)
+        try text.removeAttr(Array("text".utf8))
+        XCTAssertFalse(text.hasAttr(Array("text".utf8)))
+        XCTAssertEqual(text.getWholeText(), "")
+    }
+}

--- a/Tests/SwiftSoupTests/DeferredAttributeModelTest.swift
+++ b/Tests/SwiftSoupTests/DeferredAttributeModelTest.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import SwiftSoup
+
+final class DeferredAttributeModelTest: XCTestCase {
+    private struct Generator {
+        var state: UInt64
+        mutating func next(_ limit: Int) -> Int {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Int((state >> 32) % UInt64(limit))
+        }
+    }
+
+    private func makePending(_ key: String, _ value: String, _ variant: Int) -> Attributes.PendingAttribute {
+        let bytes = Array(key.utf8)
+        let slice = ByteSlice.fromArray(bytes)
+        let payload = Array(value.utf8)
+        let pendingValue: Attributes.PendingAttrValue
+        switch variant % 5 {
+        case 0: pendingValue = .none
+        case 1: pendingValue = .empty
+        case 2: pendingValue = .bytes(payload)
+        case 3: pendingValue = .slice(ByteSlice.fromArray(payload))
+        default:
+            let middle = payload.count / 2
+            pendingValue = .slices([
+                ByteSlice.fromArray(Array(payload[..<middle])),
+                ByteSlice.fromArray(Array(payload[middle...]))
+            ], payload.count)
+        }
+        return Attributes.PendingAttribute(
+            nameSlice: variant % 2 == 0 ? slice : nil,
+            nameBytes: variant % 2 == 0 ? nil : bytes,
+            hasUppercase: Attributes.containsAsciiUppercase(bytes), value: pendingValue
+        )
+    }
+
+    func testSeededDeferredMapsMatchEagerPublicWritesAcrossReadOrders() throws {
+        let keys = ["A", "a", "class", "Class", "id", "id ", " title ", "data-v", "\t", "", "日本", "é", "x", "y", "z"]
+        for seed in 0..<256 {
+            var random = Generator(state: UInt64(seed + 1))
+            var items: [Attributes.PendingAttribute] = []
+            let reference = Attributes()
+            let length = [0, 1, 3, 4, 5, 16, 65, 129][seed % 8]
+            for offset in 0..<length {
+                let key = keys[random.next(keys.count)]
+                let value = "value-\(offset)-日本&<"
+                let variant = random.next(10)
+                items.append(makePending(key, value, variant))
+                if variant % 5 == 0 {
+                    try? reference.put(attribute: BooleanAttribute(key: Array(key.utf8)))
+                } else {
+                    try? reference.put(key, variant % 5 == 1 ? "" : value)
+                }
+            }
+            let actual = Attributes(pendingAttributes: items)
+            for index in 0..<keys.count {
+                let key = keys[(index + seed) % keys.count]
+                switch index % 4 {
+                case 0:
+                    XCTAssertEqual(actual.get(key: key), reference.get(key: key), "seed \(seed), \(key)")
+                case 1:
+                    XCTAssertEqual(actual.hasKey(key: key), reference.hasKey(key: key), "seed \(seed), \(key)")
+                case 2:
+                    XCTAssertEqual(actual.hasKeyIgnoreCase(key: Array(key.utf8)), reference.hasKeyIgnoreCase(key: Array(key.utf8)), "seed \(seed), \(key)")
+                default:
+                    if key.isEmpty {
+                        XCTAssertThrowsError(try actual.getIgnoreCase(key: key))
+                    } else {
+                        XCTAssertEqual(try actual.getIgnoreCase(key: key), try reference.getIgnoreCase(key: key), "seed \(seed), \(key)")
+                    }
+                }
+            }
+            for syntax in [OutputSettings.Syntax.html, .xml] {
+                let settings = OutputSettings().syntax(syntax: syntax)
+                let lhs = StringBuilder()
+                let rhs = StringBuilder()
+                try actual.html(accum: lhs, out: settings)
+                try reference.html(accum: rhs, out: settings)
+                XCTAssertEqual(lhs.toString(), rhs.toString(), "seed \(seed), \(syntax)")
+            }
+            XCTAssertEqual(actual.asList().map { $0.getKey() }, reference.asList().map { $0.getKey() }, "seed \(seed)")
+            XCTAssertEqual(actual.asList().map { $0.getValue() }, reference.asList().map { $0.getValue() }, "seed \(seed)")
+        }
+    }
+
+    func testAlternatingDeferredReadsAndWritesMatchEagerMap() throws {
+        let actual = Attributes()
+        let reference = Attributes()
+        for index in 0..<192 {
+            let key = ["A", "a", "id", "class", " title ", "data-v", "\t"][index % 7]
+            let value = "v\(index)"
+            let item = makePending(key, value, 2 + (index % 3))
+            actual.appendPending(item)
+            try? reference.put(key, value)
+            for query in ["A", "a", "id", "class", "title", "data-v"] {
+                XCTAssertEqual(actual.get(key: query), reference.get(key: query))
+                XCTAssertEqual(try actual.getIgnoreCase(key: query), try reference.getIgnoreCase(key: query))
+            }
+            if index % 11 == 0 { _ = actual.clone() }
+            if index % 19 == 0 {
+                try actual.remove(key: "id")
+                try reference.remove(key: "id")
+            }
+            XCTAssertEqual(try actual.html(), try reference.html())
+        }
+    }
+
+    func testNameBytesTakePrecedenceOverAnObsoleteNameSlice() throws {
+        let attributes = Attributes(pendingAttributes: [Attributes.PendingAttribute(
+            nameSlice: ByteSlice.fromArray(Array("obsolete".utf8)), nameBytes: Array(" current ".utf8),
+            hasUppercase: false, value: .bytes(Array("value".utf8))
+        )])
+        XCTAssertEqual(try attributes.html(), " current=\"value\"")
+        XCTAssertEqual(attributes.get(key: "current"), "value")
+        XCTAssertEqual(attributes.asList().map { $0.getKey() }, ["current"])
+    }
+
+    func testEveryLookupIsAlsoCheckedAsTheFirstRead() throws {
+        let keys = ["A", "a", "id", "class", " title ", "title", "missing", " \t"]
+        for seed in 0..<128 {
+            var random = Generator(state: UInt64(seed + 1000))
+            var items: [Attributes.PendingAttribute] = []
+            let reference = Attributes()
+            for offset in 0..<(1 + seed % 33) {
+                let key = keys[random.next(keys.count - 1)]
+                let variant = random.next(10)
+                let value = "v\(offset)日本&"
+                items.append(makePending(key, value, variant))
+                if variant % 5 == 0 {
+                    try? reference.put(attribute: BooleanAttribute(key: Array(key.utf8)))
+                } else {
+                    try? reference.put(key, variant % 5 == 1 ? "" : value)
+                }
+            }
+            for key in keys {
+                for operation in 0..<6 {
+                    let actual = Attributes(pendingAttributes: items)
+                    let bytes = Array(key.utf8)
+                    let message = "seed \(seed), first operation \(operation), key \(key)"
+                    switch operation {
+                    case 0:
+                        XCTAssertEqual(actual.get(key: key), reference.get(key: key), message)
+                    case 1:
+                        XCTAssertEqual(try actual.getIgnoreCase(key: key), try reference.getIgnoreCase(key: key), message)
+                    case 2:
+                        XCTAssertEqual(actual.hasKey(key: bytes), reference.hasKey(key: bytes), message)
+                    case 3:
+                        XCTAssertEqual(actual.hasKeyIgnoreCase(key: ArraySlice(bytes)), reference.hasKeyIgnoreCase(key: ArraySlice(bytes)), message)
+                    case 4:
+                        XCTAssertEqual(try actual.getIgnoreCaseSlice(key: bytes), try reference.getIgnoreCaseSlice(key: bytes), message)
+                    default:
+                        XCTAssertEqual(actual.valueSliceCaseSensitive(bytes), reference.valueSliceCaseSensitive(bytes), message)
+                    }
+                }
+            }
+        }
+    }
+
+    func testCanonicalizationRetainsValueSlicesAndDoesNotAlterTheInputSnapshot() throws {
+        let first = ByteSlice.fromArray(Array("first".utf8))
+        let last = ByteSlice.fromArray(Array("日本語".utf8))
+        let key = ByteSlice.fromArray(Array("title".utf8))
+        let input = [
+            Attributes.PendingAttribute(nameSlice: key, nameBytes: nil, hasUppercase: false, value: .slice(first)),
+            Attributes.PendingAttribute(nameSlice: key, nameBytes: nil, hasUppercase: false, value: .slice(last))
+        ]
+        let attributes = Attributes(pendingAttributes: input)
+        XCTAssertEqual(try attributes.getIgnoreCaseSlice(key: Array("title".utf8)), last)
+        XCTAssertEqual(attributes.size(), 1)
+        let retained = try attributes.getIgnoreCaseSlice(key: Array("title".utf8))
+        XCTAssertTrue(retained.storage === last.storage)
+        XCTAssertEqual(input.count, 2)
+        guard case let .slice(original) = input[0].value else { return XCTFail("Original slice missing") }
+        XCTAssertTrue(original.storage === first.storage)
+    }
+}

--- a/Tests/SwiftSoupTests/DeferredLookupRefinementTest.swift
+++ b/Tests/SwiftSoupTests/DeferredLookupRefinementTest.swift
@@ -1,0 +1,217 @@
+import XCTest
+@testable import SwiftSoup
+
+final class DeferredLookupRefinementTest: XCTestCase {
+    private func pending(_ keys: [String], bytes: Bool = false) -> Attributes {
+        Attributes(pendingAttributes: keys.enumerated().map { i, key in
+            let raw = Array(key.utf8)
+            return Attributes.PendingAttribute(nameSlice: bytes ? nil : ByteSlice.fromArray(raw),
+                nameBytes: bytes ? raw : nil, hasUppercase: Attributes.containsAsciiUppercase(raw),
+                value: .bytes(Array("v\(i)".utf8)))
+        })
+    }
+
+    func testMissingExactLookupDoesNotMaterialize() {
+        for count in [1, 8, 32, 64, 65, 256] {
+            let attrs = pending((0..<count).map { "data-k\($0)" })
+            XCTAssertEqual(attrs.get(key: "missing"), "")
+            XCTAssertTrue(attrs.attributes.isEmpty)
+            XCTAssertEqual(attrs.pendingAttributesCount, count)
+            XCTAssertEqual(attrs.get(key: "data-k0"), "v0")
+        }
+    }
+
+    func testMissingIgnoreCaseLookupDoesNotMaterialize() throws {
+        for count in [1, 8, 32, 64, 65] {
+            let attrs = pending((0..<count).map { "DATA-k\($0)" }, bytes: true)
+            XCTAssertEqual(try attrs.getIgnoreCase(key: "missing"), "")
+            XCTAssertTrue(attrs.attributes.isEmpty)
+            XCTAssertEqual(try attrs.getIgnoreCase(key: "data-K0"), "v0")
+        }
+    }
+
+    func testMissingSliceLookupDoesNotMaterialize() throws {
+        let attrs = pending(["id", "title", "data-x"])
+        XCTAssertEqual(try attrs.getIgnoreCaseSlice(key: Array("MISS".utf8)).count, 0)
+        XCTAssertTrue(attrs.attributes.isEmpty)
+        XCTAssertNil(attrs.valueSliceCaseSensitive(Array("miss".utf8)))
+        XCTAssertTrue(attrs.attributes.isEmpty)
+    }
+
+    func testMissingPresenceLookupDoesNotMaterialize() {
+        for kind in 0..<3 {
+            let attrs = pending(["ID", "title", "data-x"])
+            switch kind {
+            case 0: XCTAssertFalse(attrs.hasKey(key: "missing"))
+            case 1: XCTAssertFalse(attrs.hasKeyIgnoreCase(key: "MISSING"))
+            default: XCTAssertFalse(attrs.hasKeyIgnoreCase(key: Array("?MISSING?".utf8).dropFirst().dropLast()))
+            }
+            XCTAssertTrue(attrs.attributes.isEmpty)
+            XCTAssertTrue(attrs.hasKeyIgnoreCase(key: "id"))
+        }
+    }
+
+    func testInvalidLookupIsAtomic() throws {
+        for kind in 0..<2 {
+            let attrs = pending(["id", "title"])
+            if kind == 0 { XCTAssertThrowsError(try attrs.getIgnoreCase(key: "")) }
+            else { XCTAssertThrowsError(try attrs.getIgnoreCaseSlice(key: [])) }
+            XCTAssertTrue(attrs.attributes.isEmpty)
+            XCTAssertEqual(attrs.pendingAttributesCount, 2)
+        }
+    }
+
+    func testEmptyPresenceQueriesStayDeferred() {
+        let attrs = pending(["id"])
+        XCTAssertFalse(attrs.hasKey(key: ""))
+        XCTAssertFalse(attrs.hasKeyIgnoreCase(key: ""))
+        XCTAssertFalse(attrs.hasKeyIgnoreCase(key: Array<UInt8>()[...]))
+        XCTAssertTrue(attrs.attributes.isEmpty)
+    }
+
+    func testNegativeLookupThenAppendAndMutation() throws {
+        let attrs = pending(["id"])
+        XCTAssertEqual(attrs.get(key: "title"), "")
+        let incoming = pending(["title"])
+        attrs.appendPending(incoming.pendingAttributes![0])
+        XCTAssertEqual(attrs.get(key: "title"), "v0")
+        let ref = try XCTUnwrap(attrs.asList().first { $0.getKey() == "title" })
+        ref.setValue(value: Array("new".utf8))
+        XCTAssertEqual(attrs.get(key: "title"), "new")
+        try attrs.remove(key: "title")
+        XCTAssertEqual(attrs.get(key: "title"), "")
+    }
+
+    func testMissingLookupStillNormalizesAmbiguousBatches() throws {
+        let attrs = pending(["id", " id ", "\t", "id", "ID"])
+        XCTAssertEqual(attrs.get(key: "missing"), "")
+        XCTAssertEqual(attrs.get(key: "id"), "v3")
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "Id"), "v3")
+        XCTAssertEqual(attrs.asList().map { $0.getKey() }, ["id", "ID"])
+    }
+
+    func testDistinctCollidingNamesRemainDeferred() {
+        // Equal lengths and identical endpoints intentionally collide in the cheap prefilter.
+        for count in [8, 32, 64, 65, 256] {
+            let keys = (0..<count).map { String(format: "k%04dz", $0) }
+            for bytes in [false, true] {
+                let attrs = pending(keys, bytes: bytes)
+                XCTAssertEqual(attrs.get(key: keys[count - 1]), "v\(count - 1)")
+                XCTAssertTrue(attrs.attributes.isEmpty)
+                XCTAssertEqual(attrs.size(), count)
+            }
+        }
+    }
+
+    func testDuplicateDetectionAtEverySmallBatchPosition() {
+        for count in [2, 8, 32, 64, 65] {
+            for index in 0..<(count - 1) {
+                var keys = (0..<count).map { String(format: "k%04dz", $0) }
+                keys[count - 1] = keys[index]
+                let attrs = pending(keys, bytes: index.isMultiple(of: 2))
+                XCTAssertEqual(attrs.get(key: keys[index]), "v\(count - 1)")
+                XCTAssertEqual(attrs.size(), count - 1)
+                XCTAssertEqual(attrs.asList()[index].getValue(), "v\(count - 1)")
+            }
+        }
+    }
+
+    func testValidationResetsAfterNegativeLookupAndRawReplacement() {
+        let attrs = pending(["id", "title"])
+        XCTAssertEqual(attrs.get(key: "none"), "")
+        let replacement = pending(["id", "id"])
+        attrs.pendingAttributes = replacement.pendingAttributes
+        attrs.pendingAttributesCount = 2
+        XCTAssertEqual(attrs.get(key: "id"), "v1")
+        XCTAssertEqual(attrs.size(), 1)
+    }
+
+    func testColdNegativeLookupDoesNotDirtySourceOrSelectors() throws {
+        let doc = try SwiftSoup.parse("<p id='a' data-x='v'>日本</p>")
+        let p = try XCTUnwrap(doc.body()?.getChildNodes().first as? Element)
+        let attrs = try XCTUnwrap(p.getAttributes())
+        let before = p.sourceRangeDirty
+        for _ in 0..<4 {
+            XCTAssertEqual(try p.attr("missing"), "")
+            XCTAssertFalse(p.hasAttr("missing"))
+        }
+        XCTAssertEqual(p.sourceRangeDirty, before)
+        for _ in 0..<2 { XCTAssertEqual(try doc.select("[missing]").size(), 0) }
+        try attrs.put("missing", "present")
+        XCTAssertTrue(try doc.select("[missing=present]").first() === p)
+    }
+    func testNegativeLookupBeforeFragmentedValueRead() throws {
+        var item = pending(["title"]).pendingAttributes![0]
+        item.value = .slices([ByteSlice.fromArray([0xE6]), ByteSlice.fromArray([0x97, 0xA5])], 3)
+        for kind in 0..<4 {
+            let attrs = Attributes(pendingAttributes: [item])
+            switch kind {
+            case 0: XCTAssertEqual(attrs.get(key: "missing"), "")
+            case 1: XCTAssertEqual(try attrs.getIgnoreCase(key: "MISSING"), "")
+            case 2: XCTAssertFalse(attrs.hasKeyIgnoreCase(key: "missing"))
+            default: XCTAssertTrue(try attrs.getIgnoreCaseSlice(key: Array("missing".utf8)).isEmpty)
+            }
+            XCTAssertTrue(attrs.attributes.isEmpty)
+            XCTAssertEqual(try attrs.getIgnoreCaseSlice(key: Array("TITLE".utf8)).toArray(), Array("日".utf8))
+            XCTAssertTrue(attrs.attributes.isEmpty)
+            XCTAssertEqual(attrs.asList().first?.getValue(), "日")
+        }
+    }
+
+    func testGeneratedMixedNameStorageAndEveryPositionDuplicate() throws {
+        // Exercise the prefilter limit and the set fallback with mixed storage.
+        for count in [1, 2, 7, 8, 9, 31, 32, 63, 64, 65, 127, 128, 129] {
+            for seed in 0..<8 {
+                let keys = (0..<count).map { "日本-\(seed)-\($0)-e\u{301}" }
+                var items = pending(keys).pendingAttributes!
+                for index in items.indices where index.isMultiple(of: 2) {
+                    items[index].nameBytes = Array(keys[index].utf8)
+                    items[index].nameSlice = ByteSlice.fromArray(Array("ignored-\(index)".utf8))
+                }
+                let attrs = Attributes(pendingAttributes: items)
+                XCTAssertEqual(attrs.get(key: "missing"), "")
+                XCTAssertTrue(attrs.attributes.isEmpty)
+                for (index, key) in keys.enumerated() {
+                    XCTAssertEqual(attrs.get(key: key), "v\(index)")
+                }
+                XCTAssertTrue(attrs.attributes.isEmpty)
+                if count > 1 {
+                    let duplicate = (seed * 13) % (count - 1)
+                    items[count - 1].nameBytes = Array(keys[duplicate].utf8)
+                    let repeated = Attributes(pendingAttributes: items)
+                    XCTAssertEqual(repeated.get(key: keys[duplicate]), "v\(count - 1)")
+                    XCTAssertEqual(repeated.size(), count - 1)
+                }
+            }
+        }
+    }
+
+    func testEmptyPendingBatchCanBeReadThenAppended() throws {
+        let attrs = Attributes(pendingAttributes: [])
+        XCTAssertEqual(attrs.get(key: "none"), "")
+        XCTAssertEqual(try attrs.getIgnoreCase(key: "NONE"), "")
+        XCTAssertFalse(attrs.hasKeyIgnoreCase(key: "none"))
+        for item in pending(["id", "id"]).pendingAttributes! { attrs.appendPending(item) }
+        XCTAssertEqual(attrs.get(key: "id"), "v1")
+        XCTAssertEqual(attrs.size(), 1)
+    }
+
+    func testNegativeReadThenSharedMutationStillNotifiesBothOwners() throws {
+        let attrs = pending(["id", "class"])
+        XCTAssertFalse(attrs.hasKey(key: "missing"))
+        let a = try SwiftSoup.parse("<p></p>")
+        let b = try SwiftSoup.parse("<p></p>")
+        let pa = try XCTUnwrap(a.select("p").first())
+        let pb = try XCTUnwrap(b.select("p").first())
+        pa.getAttributes()!.addAll(incoming: attrs)
+        pb.getAttributes()!.addAll(incoming: attrs)
+        for doc in [a, b] { XCTAssertEqual(try doc.select("#v0").size(), 1) }
+        let id = try XCTUnwrap(attrs.asList().first { $0.getKey() == "id" })
+        id.setValue(value: Array("updated".utf8))
+        for doc in [a, b] {
+            XCTAssertEqual(try doc.select("#v0").size(), 0)
+            XCTAssertEqual(try doc.select("#updated").size(), 1)
+        }
+    }
+
+}

--- a/Tests/SwiftSoupTests/ElementSiblingPositionTest.swift
+++ b/Tests/SwiftSoupTests/ElementSiblingPositionTest.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import SwiftSoup
+
+private final class PositionProjectedElements: Elements {
+    var view: [Element] = []
+    var arrayReads = 0
+    override func array() -> [Element] {
+        arrayReads += 1
+        return view
+    }
+}
+
+private final class PositionProjectedParent: Element {
+    let projection = PositionProjectedElements()
+    var childrenReads = 0
+    override func children() -> Elements {
+        childrenReads += 1
+        return projection
+    }
+}
+
+private final class PositionParentProbe: Element {
+    var responses: [Element?] = []
+    var parentReads = 0
+    override func parent() -> Element? {
+        let i = min(parentReads, max(0, responses.count - 1))
+        parentReads += 1
+        return responses.isEmpty ? nil : responses[i]
+    }
+}
+
+final class ElementSiblingPositionTest: XCTestCase {
+    private func check(_ parent: Element, file: StaticString = #filePath, line: UInt = #line) throws {
+        // Independent reference: the public filtered view, not siblingIndex.
+        let expected = parent.children().array()
+        for (index, element) in expected.enumerated() {
+            XCTAssertEqual(try element.elementSiblingIndex(), index, file: file, line: line)
+        }
+    }
+
+    func testMixedNodePositionsAcrossWidths() throws {
+        for width in [0, 1, 2, 3, 8, 32, 64, 255] {
+            let parent = try Element(Tag.valueOf("main"), "")
+            for i in 0..<width {
+                try parent.appendChild(TextNode("text\(i)", ""))
+                try parent.appendChild(Comment(Array("comment".utf8), []))
+                try parent.appendChild(Element(Tag.valueOf(i % 2 == 0 ? "p" : "span"), ""))
+            }
+            try parent.appendChild(TextNode("tail", ""))
+            try check(parent)
+        }
+    }
+
+    func testStalePublicSiblingIndexDoesNotChangePosition() throws {
+        let document = try SwiftSoup.parse("<main>text<p>a</p><!--gap--><i>b</i>text<p>c</p></main>")
+        let parent = try XCTUnwrap(document.select("main").first())
+        for element in parent.children() {
+            let original = element.siblingIndex
+            for stale in [Int.min, -1, 0, 1, 99, Int.max] {
+                element.setSiblingIndex(stale)
+                try check(parent)
+            }
+            element.setSiblingIndex(original)
+        }
+    }
+
+    func testDetachedAndMissingMembershipKeepZero() throws {
+        let element = try Element(Tag.valueOf("i"), "")
+        XCTAssertEqual(try element.elementSiblingIndex(), 0)
+        let parent = try Element(Tag.valueOf("main"), "")
+        try parent.append("<p>one</p><p>two</p>")
+        element.parentNode = parent
+        XCTAssertEqual(try element.elementSiblingIndex(), 0)
+        let raw = Node([])
+        element.parentNode = raw
+        XCTAssertEqual(try element.elementSiblingIndex(), 0)
+        withExtendedLifetime((parent, raw)) {}
+    }
+
+    func testDocumentAndFormParents() throws {
+        let document = Document("")
+        try document.appendChild(Comment(Array("before".utf8), []))
+        try document.appendChild(Element(Tag.valueOf("html"), ""))
+        try document.appendChild(Element(Tag.valueOf("extra"), ""))
+        try check(document)
+        let form = try FormElement(Tag.valueOf("form"), [])
+        try form.append("text<input><span>x</span><!--gap--><input>")
+        try check(form)
+    }
+
+    func testCustomChildrenAndArrayProjectionAreRespected() throws {
+        let parent = try PositionProjectedParent(Tag.valueOf("main"), "")
+        let first = try Element(Tag.valueOf("p"), "")
+        let second = try Element(Tag.valueOf("p"), "")
+        try parent.appendChild(first)
+        try parent.appendChild(second)
+        parent.projection.view = [second, first]
+        XCTAssertEqual(try first.elementSiblingIndex(), 1)
+        XCTAssertEqual(try second.elementSiblingIndex(), 0)
+        XCTAssertEqual(parent.childrenReads, 2)
+        XCTAssertEqual(parent.projection.arrayReads, 2)
+        parent.projection.view = [second]
+        XCTAssertEqual(try first.elementSiblingIndex(), 0)
+    }
+
+    func testParentOverrideCallCountAndNilSecondResult() throws {
+        let parent = try Element(Tag.valueOf("main"), "")
+        let child = try PositionParentProbe(Tag.valueOf("p"), "")
+        child.responses = [nil, parent]
+        XCTAssertEqual(try child.elementSiblingIndex(), 0)
+        XCTAssertEqual(child.parentReads, 1)
+        child.parentReads = 0
+        child.responses = [parent, nil]
+        XCTAssertThrowsError(try child.elementSiblingIndex()) { error in
+            guard case Exception.Error(let type, let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(type, .IllegalArgumentException)
+            XCTAssertEqual(message, "Object must not be null")
+        }
+        XCTAssertEqual(child.parentReads, 2)
+    }
+
+    func testParentOverrideCanRedirectSecondRead() throws {
+        let first = try Element(Tag.valueOf("div"), "")
+        let second = try Element(Tag.valueOf("main"), "")
+        let child = try PositionParentProbe(Tag.valueOf("p"), "")
+        try second.appendChild(Element(Tag.valueOf("i"), ""))
+        try second.appendChild(child)
+        child.parentReads = 0
+        child.responses = [first, second]
+        XCTAssertEqual(try child.elementSiblingIndex(), 1)
+        XCTAssertEqual(child.parentReads, 2)
+    }
+
+    func testMutationAndDeepCopyPositions() throws {
+        let document = try SwiftSoup.parse("<main><p>a</p>t<p>b</p><!--c--><p>c</p></main><aside><b>d</b></aside>")
+        let main = try XCTUnwrap(document.select("main").first())
+        let aside = try XCTUnwrap(document.select("aside").first())
+        for iteration in 0..<96 {
+            if iteration % 3 == 0, let last = main.children().last() {
+                try main.prependChild(last)
+            } else if iteration % 3 == 1 {
+                try main.appendChild(Element(Tag.valueOf("em"), ""))
+            } else if let first = main.children().first() {
+                try aside.appendChild(first)
+            }
+            try check(main)
+            try check(aside)
+        }
+        let copy = document.copy() as! Document
+        for parent in try copy.select("main, aside") { try check(parent) }
+    }
+
+    func testPositionalSelectorsBeforeAndAfterMutation() throws {
+        let document = try SwiftSoup.parse("<main>t<p>A</p><!--gap--><p>B</p><span>C</span>t<p>D</p></main>")
+        let root = try XCTUnwrap(document.select("main").first())
+        for _ in 0..<8 {
+            let children = root.children().array()
+            for (query, predicate) in [
+                (":first-child", { (i: Int) in i == 0 }),
+                (":nth-child(2n)", { (i: Int) in (i + 1) % 2 == 0 }),
+                (":nth-last-child(2)", { (i: Int) in i == children.count - 2 })
+            ] {
+                let expected = children.enumerated().filter { predicate($0.offset) }.map(\.element)
+                for _ in 0..<3 {
+                    let actual = try root.select(query).array().filter { $0 !== root }
+                    XCTAssertEqual(actual.map(ObjectIdentifier.init), expected.map(ObjectIdentifier.init))
+                }
+            }
+            try root.prependChild(children.last!)
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/ElementSiblingTraversalTest.swift
+++ b/Tests/SwiftSoupTests/ElementSiblingTraversalTest.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import SwiftSoup
+
+private final class ReorderedChildrenElement: Element {
+    override func children() -> Elements {
+        return Elements(Array(super.children().array().reversed()))
+    }
+}
+
+private final class RedirectedParentElement: Element {
+    weak var visibleParent: Element?
+    override func parent() -> Element? { visibleParent }
+}
+
+final class ElementSiblingTraversalTest: XCTestCase {
+    private func assertSiblings(_ parent: Element, file: StaticString = #filePath, line: UInt = #line) throws {
+        let elements = parent.children().array()
+        for (index, element) in elements.enumerated() {
+            let previous = try element.previousElementSibling()
+            let next = try element.nextElementSibling()
+            if index == 0 { XCTAssertNil(previous, file: file, line: line) }
+            else { XCTAssertTrue(previous === elements[index - 1], file: file, line: line) }
+            if index + 1 == elements.count { XCTAssertNil(next, file: file, line: line) }
+            else { XCTAssertTrue(next === elements[index + 1], file: file, line: line) }
+        }
+    }
+
+    func testMixedNodesBothDirectionsAndDetachedElement() throws {
+        let doc = try SwiftSoup.parse("<main>start<!--before--><p>one</p>between<!--gap--><span>two</span>text<p>three</p><!--end-->last</main>")
+        let root = try XCTUnwrap(doc.getElementsByTag("main").first())
+        try assertSiblings(root)
+        let detached = try XCTUnwrap(root.children().first())
+        try detached.remove()
+        XCTAssertNil(try detached.previousElementSibling())
+        XCTAssertNil(try detached.nextElementSibling())
+        try assertSiblings(root)
+    }
+
+    func testPubliclyChangedSiblingIndexFallsBackToIdentitySearch() throws {
+        let doc = try SwiftSoup.parse("<main>text<p>a</p><!--gap--><span>b</span><p>c</p>tail</main>")
+        let root = try XCTUnwrap(doc.getElementsByTag("main").first())
+        for element in root.children() {
+            let realIndex = element.siblingIndex
+            for stale in [Int.min, -1, 0, 1, 2, Int.max] {
+                element.setSiblingIndex(stale)
+                try assertSiblings(root)
+            }
+            element.setSiblingIndex(realIndex)
+        }
+    }
+
+    func testReorderingInsertionReplacementAndCrossParentMove() throws {
+        let doc = try SwiftSoup.parse("<main><p>a</p>gap<p>b</p><!--c--><p>c</p></main><aside><span>x</span></aside>")
+        let root = try XCTUnwrap(doc.getElementsByTag("main").first())
+        let aside = try XCTUnwrap(doc.getElementsByTag("aside").first())
+        let first = try XCTUnwrap(root.children().first())
+        let last = try XCTUnwrap(root.children().last())
+        try root.prependChild(last)
+        try assertSiblings(root)
+        try first.before("text<em>new</em><!--comment-->")
+        try assertSiblings(root)
+        try first.after("<strong>after</strong>")
+        try assertSiblings(root)
+        try aside.appendChild(first)
+        try assertSiblings(root)
+        try assertSiblings(aside)
+        let replaced = try XCTUnwrap(root.children().first())
+        try replaced.replaceWith(Element(Tag.valueOf("em"), ""))
+        try assertSiblings(root)
+        let clone = root.copy() as! Element
+        try assertSiblings(clone)
+    }
+
+    func testAdjacentGeneralAndLastChildSelectorsSkipNonElements() throws {
+        let doc = try SwiftSoup.parse("<main>t<p id='a'></p><!--gap-->t<p id='b'></p><span id='c'></span>t<p id='d'></p>tail<!--end--></main>")
+        let root = try XCTUnwrap(doc.getElementsByTag("main").first())
+        func ids(_ query: String) throws -> [String] {
+            try Collector.collect(QueryParser.parse(query), root).map { try $0.attr("id") }
+        }
+        XCTAssertEqual(try ids("p + p"), ["b"])
+        XCTAssertEqual(try ids("p ~ p"), ["b", "d"])
+        XCTAssertEqual(try ids("span + p"), ["d"])
+        XCTAssertEqual(try ids("p:last-child"), ["d"])
+        XCTAssertEqual(try ids("q ~ p"), [])
+    }
+
+    func testCustomChildrenAndParentOverridesPreserveSiblingView() throws {
+        let parent = try ReorderedChildrenElement(Tag.valueOf("main"), "")
+        try parent.append("<p>a</p>text<span>b</span><!--gap--><em>c</em>")
+        try assertSiblings(parent)
+
+        let redirected = try RedirectedParentElement(Tag.valueOf("span"), "")
+        let actualParent = try Element(Tag.valueOf("div"), "")
+        try actualParent.appendChild(redirected)
+        // A parent override returning nil used to throw, not silently detach.
+        XCTAssertThrowsError(try redirected.nextElementSibling())
+        XCTAssertThrowsError(try redirected.previousElementSibling())
+        redirected.visibleParent = parent
+        // The overridden parent does not contain this node.
+        XCTAssertThrowsError(try redirected.nextElementSibling())
+        XCTAssertThrowsError(try redirected.previousElementSibling())
+        redirected.visibleParent = actualParent
+        XCTAssertNil(try redirected.nextElementSibling())
+        XCTAssertNil(try redirected.previousElementSibling())
+    }
+
+    func testInvalidParentOrMissingMembershipStillThrows() throws {
+        let element = try Element(Tag.valueOf("span"), "")
+        let rawParent = Node([])
+        element.parentNode = rawParent
+        try withExtendedLifetime(rawParent) {
+            XCTAssertThrowsError(try element.nextElementSibling())
+            XCTAssertThrowsError(try element.previousElementSibling())
+        }
+        let parent = try Element(Tag.valueOf("div"), "")
+        element.parentNode = parent
+        try withExtendedLifetime(parent) {
+            XCTAssertThrowsError(try element.nextElementSibling())
+            XCTAssertThrowsError(try element.previousElementSibling())
+        }
+        element.parentNode = nil
+        XCTAssertNil(try element.nextElementSibling())
+        XCTAssertNil(try element.previousElementSibling())
+    }
+}

--- a/Tests/SwiftSoupTests/FormattingStackLookupTest.swift
+++ b/Tests/SwiftSoupTests/FormattingStackLookupTest.swift
@@ -1,0 +1,74 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class FormattingStackLookupTest: XCTestCase {
+    func testMembershipMatchesIdentityForEmptyAndDeepStacks() throws {
+        let builder = HtmlTreeBuilder()
+        let tag = try Tag.valueOf("b")
+        let nodes = (0..<257).map { _ in Element(tag, "") }
+        let absent = Element(tag, "")
+        for count in [0, 1, 2, 8, 32, 128, 257] {
+            builder.stack = Array(nodes.prefix(count))
+            let snapshot = builder.stack
+            for node in nodes + [absent] {
+                XCTAssertEqual(builder.onStack(node), snapshot.contains { $0 === node })
+            }
+            XCTAssertEqual(builder.stack.map(ObjectIdentifier.init), snapshot.map(ObjectIdentifier.init))
+        }
+    }
+
+    func testPublicStackReplacementAndDuplicateReferencesAreObserved() throws {
+        let builder = HtmlTreeBuilder()
+        let first = try Element(Tag.valueOf("b"), "")
+        let second = try Element(Tag.valueOf("b"), "")
+        let third = try Element(Tag.valueOf("i"), "")
+        builder.stack = [first, second, first]
+        XCTAssertTrue(builder.onStack(first))
+        XCTAssertTrue(builder.onStack(second))
+        XCTAssertFalse(builder.onStack(third))
+        XCTAssertTrue(builder.aboveOnStack(first) === second)
+        builder.stack.removeLast()
+        XCTAssertTrue(builder.onStack(first))
+        XCTAssertNil(builder.aboveOnStack(first))
+        builder.stack = [third]
+        XCTAssertFalse(builder.onStack(first))
+        XCTAssertFalse(builder.onStack(second))
+        XCTAssertTrue(builder.onStack(third))
+        builder.stack.removeAll()
+        XCTAssertFalse(builder.onStack(third))
+    }
+
+    func testRenamedOrReparentedMembersRemainMembers() throws {
+        let builder = HtmlTreeBuilder()
+        let document = try SwiftSoup.parse("<main><b>one</b></main><aside></aside>")
+        let member = try XCTUnwrap(document.getElementsByTag("b").first())
+        let absent = member.copy() as! Element
+        builder.stack = [member]
+        try member.tagName("em")
+        try member.attr("class", "changed")
+        try document.getElementsByTag("aside").first()!.appendChild(member)
+        XCTAssertTrue(builder.onStack(member))
+        XCTAssertFalse(builder.onStack(absent))
+        try member.remove()
+        XCTAssertTrue(builder.onStack(member))
+    }
+
+    func testFormattingMarkersAndStackMembershipStayIndependent() throws {
+        let builder = HtmlTreeBuilder()
+        let element = try Element(Tag.valueOf("b"), "")
+        builder.pushActiveFormattingElements(element)
+        XCTAssertTrue(builder.isInActiveFormattingElements(element))
+        XCTAssertFalse(builder.onStack(element))
+        builder.stack = [element]
+        XCTAssertTrue(builder.onStack(element))
+        builder.insertMarkerToFormattingElements()
+        XCTAssertNil(builder.lastFormattingElement())
+        XCTAssertTrue(builder.onStack(element))
+        builder.clearFormattingElementsToLastMarker()
+        XCTAssertTrue(builder.lastFormattingElement() === element)
+        builder.removeFromActiveFormattingElements(element)
+        XCTAssertFalse(builder.isInActiveFormattingElements(element))
+        XCTAssertTrue(builder.onStack(element))
+    }
+}

--- a/Tests/SwiftSoupTests/FragmentAppendBenchmarkTest.swift
+++ b/Tests/SwiftSoupTests/FragmentAppendBenchmarkTest.swift
@@ -1,0 +1,78 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+/// Opt in with SWIFTSOUP_FRAGMENT_BENCHMARK=1 in a release test build.
+/// Use identical test sources/counts/iterations on both revisions and alternate
+/// execution order. Inputs here are synthetic, not a production distribution.
+final class FragmentAppendBenchmarkTest: XCTestCase {
+    private func benchmark(_ kind: String) throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["SWIFTSOUP_FRAGMENT_BENCHMARK"] == "1" else {
+            throw XCTSkip("Set SWIFTSOUP_FRAGMENT_BENCHMARK=1 to run")
+        }
+        let count = Int(env["SWIFTSOUP_FRAGMENT_COUNT"] ?? "256") ?? 0
+        let iterations = Int(env["SWIFTSOUP_FRAGMENT_ITERATIONS"] ?? "100") ?? 0
+        guard (1...8192).contains(count), (1...1_000_000).contains(iterations) else {
+            throw NSError(domain: "FragmentAppendBenchmark", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid count or iterations"])
+        }
+        let parts = (0..<count).map { i in Array(["日本", "&", "語\t", "😀"][i % 4].utf8) }
+        let slices = parts.map(ByteSlice.fromArray)
+        let flat = parts.flatMap { $0 }
+        let encoded = String(repeating: "日&amp;本&#x8a9e;", count: count)
+        let decoded = Array(String(repeating: "日&本語", count: count).utf8)
+        let markup = kind == "parse-attribute" ? "<p title='\(encoded)'>text</p>" : "<p>\(encoded)</p>"
+        let scriptText = String(repeating: "if(a<b){s='<x';}<!--c-->\n", count: count)
+        let script = "<script>\(scriptText)</script>"
+        let interrupted = "<p>" + String(repeating: "日本</discarded-end>語", count: count) + "</p>"
+        func operation() throws -> [UInt8] {
+            switch kind {
+            case "text":
+                let text = TextNode(slice: .empty, baseUri: nil)
+                for slice in slices { text.appendSlice(slice) }
+                return text.getWholeTextUTF8()
+            case "data":
+                let data = DataNode(slice: .empty, baseUri: [])
+                for slice in slices { data.appendSlice(slice) }
+                return data.getWholeDataUTF8()
+            case "attribute":
+                let attr = try Attribute(key: "x", value: "")
+                for slice in slices { attr.appendValueSlice(slice) }
+                return attr.getValueUTF8()
+            case "parse-coalesced", "parse-discarded":
+                let parser = Parser.htmlParser().settings(ParseSettings(false, false, kind != "parse-coalesced"))
+                return try parser.parseInput(interrupted, "").textUTF8()
+            case "parse-text":
+                return try SwiftSoup.parse(markup).textUTF8()
+            case "parse-attribute":
+                let doc = try SwiftSoup.parse(markup)
+                doc.materializeAttributesRecursively()
+                return try doc.getElementsByTag("p").first()!.attr(Array("title".utf8))
+            default:
+                return Array(try SwiftSoup.parse(script).getElementsByTag("script").first()!.data().utf8)
+            }
+        }
+        let expected = ["parse-coalesced", "parse-discarded"].contains(kind)
+            ? Array(String(repeating: "日本語", count: count).utf8)
+            : kind == "parse-script" ? Array(scriptText.utf8) : kind.hasPrefix("parse-") ? decoded : flat
+        XCTAssertEqual(try operation(), expected)
+        var checksum: UInt64 = 0
+        for _ in 0..<3 { checksum &+= UInt64(try operation().count) }
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations { checksum &+= UInt64(try operation().count) }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        XCTAssertEqual(checksum, UInt64(iterations + 3) * UInt64(expected.count))
+        let result: [String: Any] = ["operation":kind,"fragments":count,"iterations":iterations,
+            "warmups":3,"elapsed_ms":Double(elapsed)/1_000_000,"checksum":String(checksum)]
+        print("SWIFTSOUP_FRAGMENT_RESULT " + String(decoding: try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]), as: UTF8.self))
+    }
+    func testParsingCoalescedTextWithoutSourceRanges() throws { try benchmark("parse-coalesced") }
+    func testParsingDiscardedTagsWithSourceRanges() throws { try benchmark("parse-discarded") }
+    func testTextAppend() throws { try benchmark("text") }
+    func testDataAppend() throws { try benchmark("data") }
+    func testAttributeAppend() throws { try benchmark("attribute") }
+    func testEntityTextParsing() throws { try benchmark("parse-text") }
+    func testEntityAttributeParsing() throws { try benchmark("parse-attribute") }
+    func testScriptParsing() throws { try benchmark("parse-script") }
+}

--- a/Tests/SwiftSoupTests/FragmentAppendTest.swift
+++ b/Tests/SwiftSoupTests/FragmentAppendTest.swift
@@ -1,0 +1,164 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class FragmentAppendTest: XCTestCase {
+    private func chunks(_ count: Int) -> [[UInt8]] {
+        (0..<count).map { i in
+            [Array("日本😀".utf8), [], [0,255,192,175], Array("\t &<>\" ".utf8), Array("é\u{00a0}".utf8), [UInt8(i % 256)]][i % 6]
+        }
+    }
+    private func slice(_ bytes: [UInt8], data: Bool) -> ByteSlice {
+        let padded = [UInt8(250)] + bytes + [251]
+        let storage = data ? ByteStorage(data: Data([249] + padded).dropFirst()) : ByteStorage(array: padded)
+        return ByteSlice(storage: storage, start: 1, end: bytes.count + 1)
+    }
+    func testTextGrowthBoundariesAndBackings() {
+        for count in [0,1,2,3,15,16,17,128,1024] {
+            for data in [false,true] {
+                let node = TextNode(slice: .empty, baseUri: nil)
+                let input = chunks(count)
+                for bytes in input { node.appendSlice(slice(bytes, data: data)) }
+                XCTAssertEqual(node.getWholeTextUTF8(), input.flatMap { $0 })
+                XCTAssertEqual(node.getWholeText(), String(decoding: input.flatMap { $0 }, as: UTF8.self))
+            }
+        }
+    }
+    func testDataGrowthBoundariesAndBackings() {
+        for count in [0,1,2,3,15,16,17,128,1024] {
+            for data in [false,true] {
+                let node = DataNode(slice: .empty, baseUri: [])
+                let input = chunks(count)
+                for bytes in input { node.appendSlice(slice(bytes, data: data)) }
+                XCTAssertEqual(node.getWholeDataUTF8(), input.flatMap { $0 }, "count=\(count)")
+                XCTAssertEqual(node.getWholeData(), String(decoding: input.flatMap { $0 }, as: UTF8.self))
+            }
+        }
+    }
+    func testAttributeGrowthBoundariesAndBackings() throws {
+        for count in [0,1,2,3,15,16,17,128,1024] {
+            for data in [false,true] {
+                let attribute = try Attribute(key: "data-test", value: "prefix")
+                let input = chunks(count)
+                for bytes in input { attribute.appendValueSlice(slice(bytes, data: data)) }
+                XCTAssertEqual(attribute.getValueUTF8(), Array("prefix".utf8) + input.flatMap { $0 })
+            }
+        }
+    }
+    func testTextMaterializationSnapshotsAndReset() {
+        let node = TextNode(slice: .fromArray(Array("prefix".utf8)), baseUri: [])
+        var expected = Array("prefix".utf8)
+        var snapshots: [([UInt8],[UInt8])] = []
+        for (i,bytes) in chunks(80).enumerated() {
+            node.appendSlice(slice(bytes, data: i.isMultiple(of: 2)))
+            expected.append(contentsOf: bytes)
+            if i.isMultiple(of: 7) { snapshots.append((node.getWholeTextUTF8(), expected)) }
+        }
+        XCTAssertEqual(node.getWholeTextUTF8(), expected)
+        for (value,snapshot) in snapshots { XCTAssertEqual(value, snapshot) }
+        node.text("reset").appendBytes(Array("追加".utf8))
+        XCTAssertEqual(node.getWholeText(), "reset追加")
+    }
+    func testDataMaterializationSnapshotsAndReset() {
+        let node = DataNode(slice: .fromArray(Array("prefix".utf8)), baseUri: [])
+        var expected = Array("prefix".utf8)
+        var snapshots: [([UInt8],[UInt8])] = []
+        for (i,bytes) in chunks(80).enumerated() {
+            node.appendSlice(slice(bytes, data: true))
+            expected.append(contentsOf: bytes)
+            if i.isMultiple(of: 7) { snapshots.append((node.getWholeDataUTF8(), expected)) }
+        }
+        XCTAssertEqual(node.getWholeDataUTF8(), expected)
+        for (value,snapshot) in snapshots { XCTAssertEqual(value, snapshot) }
+        node.setWholeData("reset").appendBytes(Array("追加".utf8))
+        XCTAssertEqual(node.getWholeData(), "reset追加")
+    }
+    func testAttributeRetainedSliceArrayAndValueSnapshots() throws {
+        let attribute = try Attribute(key: "x", value: "a")
+        attribute.appendValueSlice(.fromArray(Array("b".utf8)))
+        let retained = try XCTUnwrap(attribute.valueSlices)
+        let retainedValues = retained.map { $0.toArray() }
+        for _ in 0..<50 { attribute.appendValueSlice(.fromArray(Array("c".utf8))) }
+        XCTAssertEqual(retained.map { $0.toArray() }, retainedValues)
+        XCTAssertEqual(retained.count, 2)
+        let snapshot = attribute.getValueUTF8()
+        let sliceSnapshot = attribute.valueSliceMaterialized()
+        attribute.appendValueSlice(.fromArray(Array("tail".utf8)))
+        XCTAssertEqual(snapshot, Array(("ab" + String(repeating: "c", count: 50)).utf8))
+        XCTAssertEqual(sliceSnapshot.toArray(), snapshot)
+        XCTAssertEqual(attribute.getValueUTF8(), snapshot + Array("tail".utf8))
+    }
+    func testAttributeNormalizationCachesInvalidate() throws {
+        let attribute = try Attribute(key: "x", value: " BEFORE ")
+        XCTAssertEqual(String(decoding: attribute.lowerValueSlice(), as: UTF8.self), " before ")
+        XCTAssertEqual(String(decoding: attribute.lowerTrimmedValueSlice(), as: UTF8.self), "before")
+        for value in ["AFTER", " NEXT", " END "] { attribute.appendValueSlice(.fromArray(Array(value.utf8))) }
+        XCTAssertEqual(String(decoding: attribute.lowerValueSlice(), as: UTF8.self), " before after next end ")
+        XCTAssertEqual(String(decoding: attribute.lowerTrimmedValueSlice(), as: UTF8.self), "before after next end")
+    }
+    func testTextAttributeBackedPathAndMutationToken() throws {
+        let doc = try SwiftSoup.parse("<p>initial</p>")
+        let p = try XCTUnwrap(doc.getElementsByTag("p").first())
+        let text = try XCTUnwrap(p.childNode(0) as? TextNode)
+        _ = text.getAttributes()
+        let version = doc.textMutationVersionToken()
+        for _ in 0..<4 { XCTAssertEqual(try doc.select("p:contains(tail)").size(), 0) }
+        text.appendSlice(.fromArray(Array("tail".utf8)))
+        // Attribute ownership notifications can legitimately add an increment.
+        // The public contract is invalidation, not the exact internal count.
+        XCTAssertNotEqual(doc.textMutationVersionToken(), version)
+        XCTAssertEqual(text.getWholeText(), "initialtail")
+        XCTAssertEqual(try doc.select("p:contains(tail)").size(), 1)
+        doc.outputSettings().prettyPrint(pretty: false)
+        XCTAssertTrue(try doc.outerHtml().contains("initialtail"))
+    }
+    func testPublicHTMLAndXMLCharacterReferences() throws {
+        for count in [1,17,256,1024] {
+            let encoded = String(repeating: "日&amp;本&#x8a9e;&#32;", count: count)
+            let decoded = String(repeating: "日&本語 ", count: count)
+            for parser in [Parser.htmlParser(), Parser.xmlParser()] {
+                let doc = try parser.parseInput("<root><p title='\(encoded)'>\(encoded)</p></root>", "")
+                let p = try XCTUnwrap(doc.getElementsByTag("p").first())
+                doc.materializeAttributesRecursively()
+                XCTAssertEqual(try p.attr("title"), decoded)
+                XCTAssertEqual(try p.text(trimAndNormaliseWhitespace: false), decoded)
+            }
+        }
+    }
+    func testBorrowedBufferAppends() throws {
+        let bytes = Array("日本語😀".utf8)
+        try bytes.withUnsafeBufferPointer { buffer in
+            let storage = ByteStorage(buffer: buffer.baseAddress!, count: buffer.count, owner: nil)
+            let part = ByteSlice(storage: storage, start: 0, end: bytes.count)
+            let text = TextNode(slice: .empty, baseUri: [])
+            let data = DataNode(slice: .empty, baseUri: [])
+            let attribute = try Attribute(key: "x", value: "")
+            for _ in 0..<64 { text.appendSlice(part); data.appendSlice(part); attribute.appendValueSlice(part) }
+            let expected = Array(String(repeating: "日本語😀", count: 64).utf8)
+            XCTAssertEqual(text.getWholeTextUTF8(), expected)
+            XCTAssertEqual(data.getWholeDataUTF8(), expected)
+            XCTAssertEqual(attribute.getValueUTF8(), expected)
+        }
+    }
+    func testCoalescingWithoutSourceRangesPreservesTextAndClones() throws {
+        for count in [1, 2, 17, 256, 2048] {
+            let html = "<p>" + String(repeating: "日本</discarded-end>語", count: count) + "</p>"
+            let parser = Parser.htmlParser().settings(ParseSettings(false, false, false))
+            let doc = try parser.parseInput(html, "")
+            let expected = String(repeating: "日本語", count: count)
+            XCTAssertEqual(try doc.text(), expected)
+            let p = try XCTUnwrap(doc.getElementsByTag("p").first())
+            XCTAssertEqual(p.childNodeSize(), 1)
+            let clone = doc.copy() as! Document
+            XCTAssertEqual(try clone.text(), expected)
+            doc.outputSettings().prettyPrint(pretty: false)
+            clone.outputSettings().prettyPrint(pretty: false)
+            XCTAssertEqual(try clone.outerHtml(), try doc.outerHtml())
+            let text = try XCTUnwrap(p.childNode(0) as? TextNode)
+            text.appendBytes(Array("末尾".utf8))
+            XCTAssertEqual(try p.text(), expected + "末尾")
+            XCTAssertEqual(try clone.text(), expected)
+        }
+    }
+
+}

--- a/Tests/SwiftSoupTests/FragmentConstructionBenchmarkTest.swift
+++ b/Tests/SwiftSoupTests/FragmentConstructionBenchmarkTest.swift
@@ -1,0 +1,90 @@
+import Foundation
+import XCTest
+import SwiftSoup
+
+/// Opt-in release measurements. Each invocation prints one JSON timing record.
+/// Use identical test source and environment on both revisions, alternating order.
+final class FragmentConstructionBenchmarkTest: XCTestCase {
+    private struct Fixture {
+        let article: String
+        let injected: String
+    }
+
+    private func fixture(_ count: Int) -> Fixture {
+        let article = (0..<count).map { index in
+            "<p id='p\(index)' class='entry'>日本語の文章です。<b>重要</b>な言葉と<a href='/\(index)'>説明</a>。</p>"
+        }.joined(separator: "\n")
+        let injected = (0..<count).map { index in
+            "<p id='p\(index)' class='entry'><m-s><m-m data-id='\(index)'><m-t>日本語</m-t></m-m>の文章です。<b>重要</b>な言葉と<a href='/\(index)'>説明</a>。</m-s></p>"
+        }.joined(separator: "\n")
+        return Fixture(article: "<html><head><title>Reader</title></head><body>\(article)</body></html>",
+                       injected: injected)
+    }
+
+    private struct Result {
+        let html: [UInt8]
+        let originalBodyBytes: Int
+        var count: Int { html.count + originalBodyBytes }
+    }
+
+    private func operation(_ name: String, _ fixture: Fixture) throws -> Result {
+        if name == "fragment" {
+            let document = try SwiftSoup.parseBodyFragment(fixture.injected)
+            document.outputSettings().prettyPrint(pretty: false)
+            return try Result(html: document.outerHtmlUTF8WithoutSourceReuse(), originalBodyBytes: 0)
+        }
+        let document = try SwiftSoup.parse(fixture.article)
+        document.outputSettings().prettyPrint(pretty: false)
+        if name == "injection" {
+            let root = document.body()!
+            let original = try root.html()
+            let stage = root.copy() as! Element
+            try stage.html(fixture.injected)
+            let staged = stage.getChildNodes().map { $0.copy() as! Node }
+            let rollback = root.getChildNodes().map { $0.copy() as! Node }
+            root.empty()
+            try root.insertChildren(0, staged)
+            let output = try document.outerHtmlUTF8ReusingSourceOutsideBody()
+            withExtendedLifetime(rollback) {}
+            // Consume both serialization results, as the caller passes the original
+            // body to its separate language-processing stage (not measured here).
+            return Result(html: output, originalBodyBytes: original.utf8.count)
+        }
+        return try Result(html: document.outerHtmlUTF8WithoutSourceReuse(), originalBodyBytes: 0)
+    }
+
+    private func benchmark(_ name: String) throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["SWIFTSOUP_CONSTRUCTION_BENCHMARK"] == "1" else {
+            throw XCTSkip("Set SWIFTSOUP_CONSTRUCTION_BENCHMARK=1 to run release measurements")
+        }
+        let count = Int(env["SWIFTSOUP_CONSTRUCTION_PARAGRAPHS"] ?? "64") ?? 0
+        let iterations = Int(env["SWIFTSOUP_CONSTRUCTION_ITERATIONS"] ?? "100") ?? 0
+        guard (1...4096).contains(count), (1...100_000).contains(iterations) else {
+            throw NSError(domain: "FragmentConstructionBenchmark", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Invalid paragraph or iteration count"])
+        }
+        let input = fixture(count)
+        let expected = try operation(name, input)
+        var checksum: UInt64 = 0
+        for _ in 0..<3 { checksum &+= UInt64(try operation(name, input).count) }
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations { checksum &+= UInt64(try operation(name, input).count) }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        XCTAssertEqual(checksum, UInt64(iterations + 3) * UInt64(expected.count))
+        let actual = try operation(name, input)
+        XCTAssertEqual(actual.html, expected.html)
+        XCTAssertEqual(actual.originalBodyBytes, expected.originalBodyBytes)
+        let checked = try SwiftSoup.parse(expected.html, "", Parser.htmlParser())
+        XCTAssertEqual(try checked.getElementsByTag("p").size(), count)
+        XCTAssertEqual(try checked.getElementsByTag("m-m").size(), name == "document" ? 0 : count)
+        let result: [String: Any] = ["operation": name, "paragraphs": count, "iterations": iterations,
+                                   "warmups": 3, "elapsed_ms": Double(elapsed) / 1_000_000,
+                                   "checksum": String(checksum)]
+        print("SWIFTSOUP_CONSTRUCTION_RESULT " + String(decoding: try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]), as: UTF8.self))
+    }
+
+    func testDocumentConstructionAndSerialization() throws { try benchmark("document") }
+    func testFragmentConstructionAndSerialization() throws { try benchmark("fragment") }
+    func testReaderInjectionReplay() throws { try benchmark("injection") }
+}

--- a/Tests/SwiftSoupTests/FragmentIndexConstructionTest.swift
+++ b/Tests/SwiftSoupTests/FragmentIndexConstructionTest.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import SwiftSoup
+
+final class FragmentIndexConstructionTest: XCTestCase {
+    func testPrivateConstructionKeepsEveryQueryIndexDirtyUntilFirstQuery() throws {
+        let builder = HtmlTreeBuilder()
+        let context = try Element(Tag.valueOf("div"), "")
+        _ = try builder.parseFragment(Array("<p id='one' class='x'>一<b>二</b></p><form><input name='n'></form>".utf8),
+                                      context, [], .noTracking(), .htmlDefault)
+        var stack: [Node] = [builder.doc]
+        while let node = stack.popLast() {
+            if let element = node as? Element {
+                XCTAssertTrue(element.isTagQueryIndexDirty)
+                XCTAssertTrue(element.isClassQueryIndexDirty)
+                XCTAssertTrue(element.isIdQueryIndexDirty)
+                XCTAssertTrue(element.isAttributeQueryIndexDirty)
+                XCTAssertTrue(element.isAttributeValueQueryIndexDirty)
+                XCTAssertNil(element.selectorResultCache)
+                XCTAssertFalse(element.suppressQueryIndexDirty)
+            }
+            for (index, child) in node.getChildNodes().enumerated() {
+                XCTAssertTrue(child.parent() === node)
+                XCTAssertEqual(child.siblingIndex, index)
+                stack.append(child)
+            }
+        }
+        XCTAssertEqual(try builder.doc.select("p.x#one").size(), 1)
+        XCTAssertEqual(try builder.doc.select("input[name=n]").size(), 1)
+    }
+
+    func testManualProcessingAfterFragmentReturnInvalidatesWarmedIndexes() throws {
+        let builder = HtmlTreeBuilder()
+        let context = try Element(Tag.valueOf("div"), "")
+        _ = try builder.parseFragment(Array("<p>before</p>".utf8), context, [], .noTracking(), .htmlDefault)
+        let document = builder.doc
+        let root = try XCTUnwrap(document.children().first())
+        for _ in 0..<4 {
+            XCTAssertEqual(try document.select("span.new").size(), 0)
+            XCTAssertEqual(try root.select("span").size(), 0)
+        }
+        builder.stack = [root]
+        builder.transition(.InBody)
+        let attributes = Attributes()
+        try attributes.put("class", "new")
+        try builder.processStartTag("span", attributes)
+        XCTAssertEqual(try document.select("span.new").size(), 1)
+        XCTAssertEqual(try root.select("span").size(), 1)
+        let span = try XCTUnwrap(root.getElementsByTag("span").first())
+        XCTAssertTrue(span.parent() === root)
+        XCTAssertTrue(span.ownerDocument() === document)
+    }
+
+    func testFragmentConstructionDoesNotModifyWarmedContextDocument() throws {
+        let document = try SwiftSoup.parse("<form id='f'><div id='context'><p class='before'>original</p></div></form>")
+        let context = try XCTUnwrap(document.getElementById("context"))
+        for _ in 0..<4 { _ = try document.select(".before"); _ = try context.select("p") }
+        let before = try document.outerHtmlUTF8WithoutSourceReuse()
+        let version = document.textMutationVersionToken()
+        let nodes = try Parser.parseFragment("<p class='after'>new</p><input name='n'>", context, [])
+        XCTAssertEqual(try document.outerHtmlUTF8WithoutSourceReuse(), before)
+        XCTAssertEqual(document.textMutationVersionToken(), version)
+        XCTAssertEqual(try document.select(".before").size(), 1)
+        XCTAssertEqual(try document.select(".after").size(), 0)
+        try context.insertChildren(0, nodes)
+        XCTAssertEqual(try document.select(".after").size(), 1)
+        XCTAssertEqual(try context.select("p").size(), 2)
+    }
+
+    func testNestedFormattingFosterParentingAndRepeatedBuilderUse() throws {
+        for markup in ["<b><i>一</b>二</i>", "<table>text<tr><td>一</td></tr></table>",
+                       "<ruby><rb>漢</rb><rt>かん</rt></ruby>", "<select><option>一<option>二</select>"] {
+            let builder = HtmlTreeBuilder()
+            for _ in 0..<3 {
+                let context = try Element(Tag.valueOf("div"), "")
+                let nodes = try builder.parseFragment(Array(markup.utf8), context, [], .noTracking(), .htmlDefault)
+                let destination = try SwiftSoup.parse("<main></main>")
+                let root = try XCTUnwrap(destination.getElementsByTag("main").first())
+                try root.insertChildren(0, nodes)
+                let copy = destination.copy() as! Document
+                XCTAssertEqual(try destination.outerHtmlUTF8WithoutSourceReuse(), try copy.outerHtmlUTF8WithoutSourceReuse())
+                var stack: [Node] = [destination]
+                while let node = stack.popLast() {
+                    XCTAssertTrue(node.ownerDocument() === destination)
+                    for (index, child) in node.getChildNodes().enumerated() {
+                        XCTAssertTrue(child.parent() === node)
+                        XCTAssertEqual(child.siblingIndex, index)
+                        stack.append(child)
+                    }
+                }
+                try root.append("<p class='added'>追加</p>")
+                XCTAssertEqual(try destination.select("p.added").size(), 1)
+            }
+        }
+    }
+    func testManualProcessingAfterFragmentReturnKeepsForeignOwnerDispatch() throws {
+        final class RedirectedElement: Element {
+            var redirectedOwner: Document?
+            var ownerLookups = 0
+            override func ownerDocument() -> Document? {
+                ownerLookups += 1
+                return redirectedOwner
+            }
+        }
+        let builder = HtmlTreeBuilder()
+        let context = try Element(Tag.valueOf("div"), "")
+        _ = try builder.parseFragment(Array("<p>initial</p>".utf8), context, [], .noTracking(), .htmlDefault)
+        let privateDocument = builder.doc
+        let foreign = try SwiftSoup.parse("<main></main>")
+        let node = try RedirectedElement(Tag.valueOf("p"), "")
+        node.redirectedOwner = foreign
+        let parent = try XCTUnwrap(foreign.body())
+        try parent.appendChild(node)
+        builder.stack = [parent, node]
+        builder.transition(.InBody)
+        privateDocument.sourceRangeDirty = true
+        privateDocument.dirtySourceRoots = [ObjectIdentifier(privateDocument): Weak(privateDocument)]
+        foreign.dirtySourceRoots.removeAll()
+        node.sourceRangeDirty = false
+        node.ownerLookups = 0
+        // Fragment mode survives parseFragment(), but its private construction scope must not.
+        try builder.processEndTag("p")
+        XCTAssertTrue(node.sourceRangeDirty)
+        XCTAssertGreaterThan(node.ownerLookups, 0)
+        XCTAssertTrue(foreign.dirtySourceRoots[ObjectIdentifier(node)]?.value === node)
+        XCTAssertTrue(privateDocument.dirtySourceRoots[ObjectIdentifier(privateDocument)]?.value === privateDocument)
+    }
+
+    func testManualInsertionAfterFragmentReturnKeepsForeignOwnerDispatch() throws {
+        final class RedirectedElement: Element {
+            var redirectedOwner: Document?
+            var ownerLookups = 0
+            override func ownerDocument() -> Document? {
+                ownerLookups += 1
+                return redirectedOwner
+            }
+        }
+        let builder = HtmlTreeBuilder()
+        let context = try Element(Tag.valueOf("div"), "")
+        _ = try builder.parseFragment(Array("<p>initial</p>".utf8), context, [], .noTracking(), .htmlDefault)
+        let privateDocument = builder.doc
+        let foreign = try SwiftSoup.parse("<main></main>")
+        let parent = try RedirectedElement(Tag.valueOf("div"), "")
+        parent.redirectedOwner = foreign
+        try foreign.body()!.appendChild(parent)
+        builder.stack = [parent]
+        builder.transition(.InBody)
+        privateDocument.sourceRangeDirty = true
+        privateDocument.dirtySourceRoots = [ObjectIdentifier(privateDocument): Weak(privateDocument)]
+        foreign.dirtySourceRoots.removeAll()
+        parent.sourceRangeDirty = false
+        parent.ownerLookups = 0
+        try builder.processStartTag("span")
+        XCTAssertGreaterThan(parent.ownerLookups, 0)
+        XCTAssertTrue(foreign.dirtySourceRoots[ObjectIdentifier(parent)]?.value === parent)
+        XCTAssertTrue(privateDocument.dirtySourceRoots[ObjectIdentifier(privateDocument)]?.value === privateDocument)
+        XCTAssertEqual(parent.childNodeSize(), 1)
+        XCTAssertTrue(parent.childNode(0).parent() === parent)
+        XCTAssertTrue(parent.childNode(0).ownerDocument() === foreign)
+    }
+
+    func testManualCharacterInsertionAfterFragmentReturnInvalidatesTextPredicates() throws {
+        let builder = HtmlTreeBuilder()
+        let context = try Element(Tag.valueOf("div"), "")
+        _ = try builder.parseFragment(Array("<section></section>".utf8), context, [], .noTracking(), .htmlDefault)
+        let document = builder.doc
+        let root = try XCTUnwrap(document.children().first())
+        let section = try XCTUnwrap(document.select("section").first())
+        for _ in 0..<4 {
+            XCTAssertEqual(try section.text(), "")
+            XCTAssertEqual(try document.select("section:contains(後)").size(), 0)
+            XCTAssertEqual(try document.select("section:empty").size(), 1)
+        }
+        let version = document.textMutationVersionToken()
+        builder.stack = [root, section]
+        builder.transition(.InBody)
+        XCTAssertTrue(try builder.process(Token.Char().data(Array("後".utf8))))
+        XCTAssertNotEqual(document.textMutationVersionToken(), version)
+        XCTAssertEqual(try section.text(), "後")
+        XCTAssertEqual(try document.select("section:contains(後)").size(), 1)
+        XCTAssertEqual(try document.select("section:empty").size(), 0)
+    }
+
+}

--- a/Tests/SwiftSoupTests/FragmentSourceAppendTest.swift
+++ b/Tests/SwiftSoupTests/FragmentSourceAppendTest.swift
@@ -1,0 +1,230 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class FragmentSourceAppendTest: XCTestCase {
+    private func append(_ node: Node, to parent: Element, builder: HtmlTreeBuilder, fast: Bool) throws {
+        if fast {
+#if BASELINE_APPEND_REFERENCE
+            try parent.appendChild(node)
+#else
+            builder.appendFragmentNode(node, to: parent)
+#endif
+        } else {
+            try parent.appendChild(node)
+        }
+    }
+
+    private func observe(_ doc: Document) throws -> [String] {
+        var nodes: [Node] = []
+        var pending: [Node] = [doc]
+        while let node = pending.popLast() {
+            nodes.append(node)
+            pending.append(contentsOf: node.getChildNodes().reversed())
+        }
+        let positions = Dictionary(uniqueKeysWithValues: nodes.enumerated().map { (ObjectIdentifier($0.element), $0.offset) })
+        var values = ["text-version:\(doc.textMutationVersionToken())"]
+        for node in nodes {
+            let parent = node.parentNode.flatMap { positions[ObjectIdentifier($0)] } ?? -1
+            values.append("\(node.nodeName()):\(parent):\(node.siblingIndex):\(node.sourceRangeDirty):\(node.sourceRangeIsComplete):\(node.sourceRange?.start ?? -1):\(node.sourceRange?.end ?? -1)")
+            if let element = node as? Element {
+                values.append("\(element.isTagQueryIndexDirty):\(element.isClassQueryIndexDirty):\(element.isIdQueryIndexDirty):\(element.isAttributeQueryIndexDirty):\(element.isAttributeValueQueryIndexDirty):\(element.selectorResultCache != nil)")
+            }
+            XCTAssertTrue(node.ownerDocument() === doc)
+            for (index, child) in node.getChildNodes().enumerated() {
+                XCTAssertTrue(child.parentNode === node)
+                XCTAssertEqual(child.siblingIndex, index)
+            }
+        }
+        values += doc.dirtySourceRoots.values.map {
+            $0.value.flatMap { positions[ObjectIdentifier($0)] }.map(String.init) ?? "expired"
+        }.sorted()
+        values += [try doc.outerHtml(), String(decoding: try doc.outerHtmlUTF8(), as: UTF8.self),
+                   String(decoding: try doc.outerHtmlUTF8WithoutSourceReuse(), as: UTF8.self), try doc.text()]
+        for query in ["p", "b", "#new", ".new", "[data-x]", "p:contains(追加)"] {
+            values.append(try doc.select(query).outerHtml())
+        }
+        return values
+    }
+
+    private func exercise(fast: Bool, seed: Int, warm: Bool, dirty: Bool) throws -> [String] {
+        let builder = HtmlTreeBuilder()
+        builder.initialiseParse(Array("<main><p>original</p></main>".utf8), [], .noTracking(), .htmlDefault)
+        let doc = builder.doc
+        doc.outputSettings().prettyPrint(pretty: false)
+        let parent = try doc.appendElement("main")
+        try parent.append("<p id='old'>original</p>")
+        if warm {
+            for _ in 0..<4 {
+                _ = try doc.select("p")
+                _ = try doc.select(".new")
+                _ = try parent.select("#new")
+                _ = try parent.text()
+            }
+        }
+        doc.dirtySourceRoots.removeAll()
+        doc.sourceRangeDirty = seed != 2
+        if seed == 1 || seed == 2 { doc.dirtySourceRoots[ObjectIdentifier(doc)] = Weak(doc) }
+        if seed == 3 {
+            parent.sourceRangeDirty = true
+            doc.dirtySourceRoots[ObjectIdentifier(parent)] = Weak(parent)
+        }
+        parent.sourceRangeDirty = dirty
+        let p = try Element(Tag.valueOf("p"), "")
+        try p.attr("id", "new").attr("class", "new").attr("data-x", "1")
+        try p.appendText("追加")
+        let children: [Node] = [p, TextNode("末尾 &", ""), Comment(Array("comment".utf8), []), DataNode(Array("data".utf8), [])]
+        for node in children {
+            node.sourceRangeDirty = dirty
+            node.treeBuilder = builder // insertNode establishes this before appendChild.
+            try append(node, to: parent, builder: builder, fast: fast)
+        }
+        return try observe(doc)
+    }
+
+    func testFreshFragmentAppendMatchesPublicInsertionState() throws {
+        for seed in 0..<4 {
+            for dirty in [false, true] {
+                XCTAssertEqual(try exercise(fast: true, seed: seed, warm: false, dirty: dirty),
+                               try exercise(fast: false, seed: seed, warm: false, dirty: dirty))
+            }
+        }
+    }
+
+    func testWarmedIndexesAndTextCachesStillInvalidate() throws {
+        for seed in 0..<4 {
+            XCTAssertEqual(try exercise(fast: true, seed: seed, warm: true, dirty: false),
+                           try exercise(fast: false, seed: seed, warm: true, dirty: false))
+        }
+    }
+
+    func testFragmentContextsMaintainOrderAndOwnershipAfterMutation() throws {
+        let cases = [
+            ("div", "<p>一 &amp; 二</p><p><b>三</b></p>"),
+            ("table", "<tr><td>一</td><td>二</td></tr>"),
+            ("tbody", "<tr><td>一</td></tr>"),
+            ("select", "<option>一<option>二"),
+            ("ruby", "<rb>漢字</rb><rp>(</rp><rt>かんじ</rt><rp>)</rp>"),
+            ("div", "<b><i>一</b>二</i><table>三<tr><td>四</td></tr></table>")
+        ]
+        for (tag, markup) in cases {
+            let doc = try SwiftSoup.parse("<main></main>")
+            let root = try Element(Tag.valueOf(tag), "")
+            try root.attr("id", "target")
+            try doc.getElementsByTag("main").first()!.appendChild(root)
+            try root.html(markup)
+            doc.outputSettings().prettyPrint(pretty: false)
+            _ = try observe(doc)
+            let before = try doc.outerHtmlUTF8WithoutSourceReuse()
+            let clone = doc.copy() as! Document
+            clone.outputSettings().prettyPrint(pretty: false)
+            XCTAssertEqual(before, try clone.outerHtmlUTF8WithoutSourceReuse())
+            _ = try observe(clone)
+            try root.append("<span>終わり</span>")
+            _ = try observe(doc)
+        }
+    }
+
+    func testSourceBackedFragmentInsertionDoesNotReturnStaleMarkup() throws {
+        let doc = try SwiftSoup.parse("<html><head><title>original</title></head><body><main></main></body></html>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        let main = try XCTUnwrap(doc.getElementsByTag("main").first())
+        try main.html("<p id='new' class='before'>日本&amp;語</p><ruby>漢<rt>かん</rt></ruby>")
+        let p = try XCTUnwrap(doc.getElementById("new"))
+        for _ in 0..<4 { XCTAssertEqual(try doc.select(".before").size(), 1) }
+        try p.attr("class", "after").text("変更後")
+        try doc.select("rt").remove()
+        let html = String(decoding: try doc.outerHtmlUTF8ReusingSourceOutsideBody(), as: UTF8.self)
+        let reparsed = try SwiftSoup.parse(html)
+        XCTAssertEqual(try reparsed.getElementById("new")?.text(), "変更後")
+        XCTAssertEqual(try reparsed.select(".before, rt").size(), 0)
+        XCTAssertEqual(try reparsed.select(".after").size(), 1)
+    }
+    private func structuralObservation(fast: Bool, seed: Int, nodeDirty: Bool,
+                                       parentDirty: Bool, detached: Bool) throws -> [String] {
+        let builder = HtmlTreeBuilder()
+        builder.initialiseParse(Array("<main><p>value</p></main>".utf8), [], .noTracking(), .htmlDefault)
+        let document = builder.doc
+        document.outputSettings().prettyPrint(pretty: false)
+        let parent = try document.appendElement("main")
+        let node = try Element(Tag.valueOf("p"), "")
+        if !detached { try parent.appendChild(node) }
+        builder.stack = [parent, node]
+        document.dirtySourceRoots.removeAll()
+        document.sourceRangeDirty = seed != 2
+        if seed == 1 || seed == 2 {
+            document.dirtySourceRoots[ObjectIdentifier(document)] = Weak(document)
+        }
+        if seed == 3 { document.dirtySourceRoots[ObjectIdentifier(parent)] = Weak(parent) }
+        node.sourceRangeDirty = nodeDirty
+        parent.sourceRangeDirty = parentDirty
+        builder.beginBulkAppend()
+        defer { builder.endBulkAppend() }
+        if fast { builder.markStructuralChange(detached ? node : nil) }
+        else { node.markSourceDirty(force: true) }
+        return try ["node:\(node.sourceRangeDirty)", "parent:\(parent.sourceRangeDirty)"] + observe(document)
+    }
+
+    func testStructuralDirtyingMatchesReferenceAcrossCoverageAndExistingFlags() throws {
+        for seed in 0..<4 {
+            for dirty in [false, true] {
+                for parentDirty in [false, true] {
+                    for detached in [false, true] {
+                        XCTAssertEqual(
+                            try structuralObservation(fast: true, seed: seed, nodeDirty: dirty,
+                                                      parentDirty: parentDirty, detached: detached),
+                            try structuralObservation(fast: false, seed: seed, nodeDirty: dirty,
+                                                      parentDirty: parentDirty, detached: detached),
+                            "seed=\(seed) nodeDirty=\(dirty) parentDirty=\(parentDirty) detached=\(detached)"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    func testStructuralChangeWithEmptyStackIsANoop() throws {
+        let builder = HtmlTreeBuilder()
+        builder.initialiseParse([], [], .noTracking(), .htmlDefault)
+        let document = builder.doc
+        let version = document.textMutationVersionToken()
+        let dirty = document.sourceRangeDirty
+        builder.markStructuralChange()
+        XCTAssertEqual(document.textMutationVersionToken(), version)
+        XCTAssertEqual(document.sourceRangeDirty, dirty)
+        XCTAssertTrue(document.dirtySourceRoots.isEmpty)
+        XCTAssertEqual(try document.outerHtml(), "")
+    }
+
+    func testPublicManualStackEditsKeepForeignOwnerDispatch() throws {
+        final class RedirectedElement: Element {
+            var redirectedOwner: Document?
+            var ownerLookups = 0
+            override func ownerDocument() -> Document? {
+                ownerLookups += 1
+                return redirectedOwner
+            }
+        }
+        let parser = Parser.htmlParser()
+        let document = try parser.parseInput("<p>initial</p>", "")
+        let builder = parser.getTreeBuilder()
+        let foreign = try SwiftSoup.parse("<main></main>")
+        let node = try RedirectedElement(Tag.valueOf("p"), "")
+        node.redirectedOwner = foreign
+        let parent = try XCTUnwrap(foreign.body())
+        try parent.appendChild(node)
+        builder.stack = [parent, node]
+        document.sourceRangeDirty = true
+        document.dirtySourceRoots = [ObjectIdentifier(document): Weak(document)]
+        foreign.dirtySourceRoots.removeAll()
+        node.sourceRangeDirty = false
+        node.ownerLookups = 0
+        // This is a public API operation after replacing the public stack.
+        try builder.processEndTag("p")
+        XCTAssertTrue(node.sourceRangeDirty)
+        XCTAssertGreaterThan(node.ownerLookups, 0)
+        XCTAssertTrue(foreign.dirtySourceRoots[ObjectIdentifier(node)]?.value === node)
+        XCTAssertTrue(document.dirtySourceRoots[ObjectIdentifier(document)]?.value === document)
+    }
+
+}

--- a/Tests/SwiftSoupTests/NoOpTreeMutationTest.swift
+++ b/Tests/SwiftSoupTests/NoOpTreeMutationTest.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import SwiftSoup
+
+final class NoOpTreeMutationTest: XCTestCase {
+    private func fixture(empty: Bool = false) throws -> (Document, Element) {
+        let html = "<html><head></head><body><DIV id = 'target' data-x='keep'>" +
+            (empty ? "" : "<SPAN title = 'nested'>payload</SPAN>") + "</DIV></body></html>"
+        let doc = try SwiftSoup.parse(html)
+        return (doc, try XCTUnwrap(doc.getElementById("target")))
+    }
+
+    private func check(_ doc: Document, _ target: Element, _ operation: () throws -> Void,
+                       file: StaticString = #filePath, line: UInt = #line) throws {
+        for query in ["#target", "div:empty", "div:contains(payload)", "span:first-child", "[data-x=keep]"] {
+            for _ in 0..<3 { _ = try doc.select(query) }
+        }
+        let before = try doc.outerHtmlUTF8()
+        let children = target.getChildNodes()
+        let version = doc.textMutationVersionToken()
+        let flags = [doc.sourceRangeDirty, target.sourceRangeDirty]
+        try operation()
+        XCTAssertEqual(try doc.outerHtmlUTF8(), before, file: file, line: line)
+        XCTAssertEqual(doc.textMutationVersionToken(), version, file: file, line: line)
+        XCTAssertEqual([doc.sourceRangeDirty, target.sourceRangeDirty], flags, file: file, line: line)
+        XCTAssertEqual(target.getChildNodes().map(ObjectIdentifier.init), children.map(ObjectIdentifier.init), file: file, line: line)
+        for (index, child) in children.enumerated() {
+            XCTAssertTrue(child.parent() === target, file: file, line: line)
+            XCTAssertEqual(child.siblingIndex, index, file: file, line: line)
+        }
+    }
+
+    func testEmptyArrayAppendIsARepresentationPreservingNoOp() throws {
+        let (doc, target) = try fixture()
+        try check(doc, target) { try target.addChildren([Node]()) }
+    }
+
+    func testEmptyVariadicAppendIsARepresentationPreservingNoOp() throws {
+        let (doc, target) = try fixture()
+        try check(doc, target) { try target.addChildren() }
+    }
+
+    func testEmptyIndexedInsertPreservesAllValidGaps() throws {
+        for gap in 0...1 {
+            let (doc, target) = try fixture()
+            try check(doc, target) { try target.addChildren(gap, [Node]()) }
+        }
+    }
+
+    func testElementEmptyInsertPreservesNegativeIndexSemantics() throws {
+        for gap in [-2, -1, 0, 1] {
+            let (doc, target) = try fixture()
+            try check(doc, target) { try target.insertChildren(gap, []) }
+        }
+    }
+
+    func testEmptyHTMLAppendAndPrependLeaveSourceUntouched() throws {
+        for prepend in [false, true] {
+            let (doc, target) = try fixture()
+            try check(doc, target) {
+                if prepend { try target.prepend("") } else { try target.append("") }
+            }
+        }
+    }
+
+    func testEmptySiblingHTMLLeavesSourceUntouched() throws {
+        for before in [false, true] {
+            let (doc, target) = try fixture()
+            try check(doc, target) {
+                if before { try target.before("") } else { try target.after("") }
+            }
+        }
+    }
+
+    func testEmptyOnAnAlreadyEmptyElementIsANoOp() throws {
+        let (doc, target) = try fixture(empty: true)
+        try check(doc, target) { target.empty() }
+    }
+
+    func testInvalidEmptyInsertionStillThrowsBeforeMutation() throws {
+        let (doc, target) = try fixture()
+        try check(doc, target) {
+            for index in [Int.min, -3, 2, Int.max] { XCTAssertThrowsError(try target.insertChildren(index, [])) }
+            for index in [Int.min, -1, 2, Int.max] { XCTAssertThrowsError(try target.addChildren(index, [Node]())) }
+        }
+    }
+
+    func testEmptyTextIsARealNodeAndStillInvalidates() throws {
+        let (doc, target) = try fixture(empty: true)
+        _ = try doc.select("div:empty")
+        let version = doc.textMutationVersionToken()
+        try target.appendText("")
+        XCTAssertEqual(target.childNodeSize(), 1)
+        XCTAssertTrue(target.getChildNodes()[0] is TextNode)
+        XCTAssertNotEqual(doc.textMutationVersionToken(), version)
+        target.empty()
+        XCTAssertEqual(target.childNodeSize(), 0)
+    }
+
+    func testRepeatedNoOpsThenRealMutationRefreshesWarmedSelectors() throws {
+        let (doc, target) = try fixture(empty: true)
+        for _ in 0..<64 {
+            XCTAssertTrue(try doc.select("#target:empty").first() === target)
+            try check(doc, target) {
+                try target.addChildren([Node]())
+                try target.insertChildren(-1, [])
+                target.empty()
+            }
+        }
+        try target.appendText("payload")
+        XCTAssertEqual(try doc.select("#target:empty").size(), 0)
+        XCTAssertTrue(try doc.select("#target:contains(payload)").first() === target)
+        XCTAssertEqual(target.childNodeSize(), 1)
+    }
+}

--- a/Tests/SwiftSoupTests/NodeAttributeMutationTest.swift
+++ b/Tests/SwiftSoupTests/NodeAttributeMutationTest.swift
@@ -1,0 +1,206 @@
+import XCTest
+@testable import SwiftSoup
+
+final class NodeAttributeMutationTest: XCTestCase {
+    private func assertSelection(_ root: Element, _ query: String, _ expected: [Element],
+                                 file: StaticString = #filePath, line: UInt = #line) throws {
+        let evaluator = try QueryParser.parse(query)
+        var stack = [root]
+        var scanned: [Element] = []
+        while let element = stack.popLast() {
+            if try evaluator.matches(root, element) { scanned.append(element) }
+            stack.append(contentsOf: element.childNodes.reversed().compactMap { $0 as? Element })
+        }
+        let ids = expected.map(ObjectIdentifier.init)
+        XCTAssertEqual(scanned.map(ObjectIdentifier.init), ids, query, file: file, line: line)
+        for _ in 0..<4 {
+            XCTAssertEqual(try root.select(query).array().map(ObjectIdentifier.init), ids, query, file: file, line: line)
+        }
+    }
+
+    private func script() throws -> (Document, Element, DataNode) {
+        let doc = try SwiftSoup.parse("<html><head><script>before</script></head><body></body></html>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        let script = try XCTUnwrap(doc.select("script").first())
+        let data = try XCTUnwrap(script.getChildNodes().first as? DataNode)
+        return (doc, script, data)
+    }
+
+    func testRawDataAttributeReadMaterializesExistingValue() throws {
+        let (_, _, data) = try script()
+        XCTAssertEqual(try data.attr("data"), "before")
+        XCTAssertTrue(data.hasAttr("data"))
+        XCTAssertEqual(data.getAttributes()?.get(key: "data"), "before")
+    }
+
+    func testRawDataAttributeWriteCannotBeOverwrittenByLaterRead() throws {
+        for bytes in [false, true] {
+            let (doc, script, data) = try script()
+            try assertSelection(doc, "script:containsData(before)", [script])
+            if bytes { try data.attr(Array("data".utf8), Array("after".utf8)) }
+            else { try data.attr("data", "after") }
+            XCTAssertEqual(data.getWholeData(), "after")
+            XCTAssertEqual(data.getWholeData(), "after")
+            try assertSelection(doc, "script:containsData(before)", [])
+            try assertSelection(doc, "script:containsData(after)", [script])
+            XCTAssertTrue(String(decoding: try doc.outerHtmlUTF8(), as: UTF8.self).contains("<script>after</script>"))
+        }
+    }
+
+    func testRemovingRawDataCannotResurrectDeferredContent() throws {
+        let (doc, script, data) = try script()
+        try assertSelection(doc, "script:containsData(before)", [script])
+        try data.removeAttr("data")
+        XCTAssertEqual(data.getWholeData(), "")
+        XCTAssertFalse(data.hasAttr("data"))
+        data.appendSlice(ByteSlice.fromArray(Array("after".utf8)))
+        XCTAssertEqual(data.getWholeData(), "after")
+        try assertSelection(doc, "script:containsData(before)", [])
+        try assertSelection(doc, "script:containsData(after)", [script])
+    }
+
+    func testDeferredDataWriteBeforeAnyContentRead() throws {
+        for bytes in [false, true] {
+            let (_, _, data) = try script()
+            XCTAssertNil(data.attributes, "fixture must still use deferred storage")
+            if bytes { try data.attr(Array("data".utf8), Array("after".utf8)) }
+            else { try data.attr("data", "after") }
+            XCTAssertEqual(data.getWholeData(), "after")
+            XCTAssertEqual(try data.attr("data"), "after")
+        }
+    }
+
+    func testDeferredDataRemovalBeforeAnyContentRead() throws {
+        let (_, _, data) = try script()
+        XCTAssertNil(data.attributes)
+        try data.removeAttr("data")
+        XCTAssertEqual(data.getWholeData(), "")
+        XCTAssertFalse(data.hasAttr("data"))
+        data.appendSlice(ByteSlice.fromArray(Array("new".utf8)))
+        XCTAssertEqual(data.getWholeData(), "new")
+    }
+
+    func testDeferredAppendInvalidatesWithoutMaterialization() throws {
+        let (doc, script, data) = try script()
+        // Do not call :containsData here: it materializes storage on the baseline.
+        _ = try doc.select("script")
+        XCTAssertNil(data.attributes)
+        let version = doc.textMutationVersionToken()
+        data.appendSlice(ByteSlice.fromArray(Array("after".utf8)))
+        XCTAssertNil(data.attributes)
+        XCTAssertNotEqual(doc.textMutationVersionToken(), version)
+        XCTAssertEqual(data.getWholeData(), "beforeafter")
+        try assertSelection(doc, "script:containsData(beforeafter)", [script])
+    }
+
+    func testDirectRawDataAttributeReferenceIsLive() throws {
+        let (doc, script, data) = try script()
+        let attr = try XCTUnwrap(data.getAttributes()?.first { $0.getKey() == "data" })
+        try assertSelection(doc, "script:containsData(before)", [script])
+        attr.setValue(value: Array("after".utf8))
+        XCTAssertEqual(data.getWholeData(), "after")
+        try assertSelection(doc, "script:containsData(before)", [])
+        try assertSelection(doc, "script:containsData(after)", [script])
+    }
+
+    func testDataMaterializationDoesNotDirtySourceOrTextVersion() throws {
+        let (doc, _, data) = try script()
+        let version = doc.textMutationVersionToken()
+        let dirty = data.sourceRangeDirty
+        XCTAssertEqual(data.getWholeData(), "before")
+        _ = data.getAttributes()
+        XCTAssertEqual(doc.textMutationVersionToken(), version)
+        XCTAssertEqual(data.sourceRangeDirty, dirty)
+    }
+
+    func testTextMaterializationDoesNotDirtySourceOrTextVersion() throws {
+        let doc = try SwiftSoup.parse("<p>one&amp;two</p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let text = try XCTUnwrap(p.getChildNodes().first as? TextNode)
+        let version = doc.textMutationVersionToken()
+        let dirty = text.sourceRangeDirty
+        let attrs = text.getAttributes()
+        XCTAssertEqual(attrs.get(key: "text"), "one&two")
+        XCTAssertEqual(text.getWholeText(), "one&two")
+        XCTAssertEqual(doc.textMutationVersionToken(), version)
+        XCTAssertEqual(text.sourceRangeDirty, dirty)
+    }
+
+    func testFragmentedTextAttributeWriteIsNotLost() throws {
+        let text = TextNode(slice: ByteSlice.fromArray(Array("one".utf8)), baseUri: [])
+        text.appendSlice(ByteSlice.fromArray(Array("two".utf8)))
+        text.appendSlice(ByteSlice.fromArray(Array("three".utf8)))
+        XCTAssertEqual(text.getAttributes().get(key: "text"), "onetwothree")
+        try text.attr("text", "after")
+        XCTAssertEqual(text.getWholeText(), "after")
+        XCTAssertEqual(text.text(), "after")
+    }
+
+    func testTextAttributeMutationInvalidatesWarmedSelectors() throws {
+        let doc = try SwiftSoup.parse("<p>before</p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let text = try XCTUnwrap(p.getChildNodes().first as? TextNode)
+        let attr = try XCTUnwrap(text.getAttributes().first { $0.getKey() == "text" })
+        try assertSelection(doc, "p:contains(before)", [p])
+        try assertSelection(doc, "p:matches(^before$)", [p])
+        attr.setValue(value: Array("after".utf8))
+        try assertSelection(doc, "p:contains(before)", [])
+        try assertSelection(doc, "p:containsOwn(after)", [p])
+        try assertSelection(doc, "p:matches(^before$)", [])
+        try assertSelection(doc, "p:matchesOwn(^after$)", [p])
+    }
+
+    func testTextRemoveThenAppendDoesNotRestoreOldText() throws {
+        let text = TextNode("old", "")
+        try text.attr("text", "before")
+        try text.removeAttr("text")
+        XCTAssertEqual(text.getWholeText(), "")
+        text.appendSlice(ByteSlice.fromArray(Array("after".utf8)))
+        XCTAssertEqual(text.getWholeText(), "after")
+    }
+
+    func testRawDataAppendInvalidatesCachedDataPredicate() throws {
+        let (doc, script, data) = try script()
+        try assertSelection(doc, "script:containsData(after)", [])
+        data.appendSlice(ByteSlice.fromArray(Array("after".utf8)))
+        try assertSelection(doc, "script:containsData(after)", [script])
+        XCTAssertEqual(data.getWholeData(), "beforeafter")
+    }
+
+    func testNonElementAttributeClonesAreIndependent() throws {
+        let nodes: [Node] = [TextNode("before", ""), DataNode(Array("before".utf8), []), Comment(Array("before".utf8), [])]
+        for node in nodes {
+            let attrs = try XCTUnwrap(node.getAttributes())
+            let original = try XCTUnwrap(attrs.first(where: { _ in true }))
+            let copy = node.copy() as! Node
+            let copied = try XCTUnwrap(copy.getAttributes()?.first(where: { _ in true }))
+            copied.setValue(value: Array("after".utf8))
+            XCTAssertEqual(original.getValue(), "before")
+            XCTAssertFalse(original === copied)
+        }
+    }
+
+    func testNoOpAttributeMutationDoesNotInvalidateCaches() throws {
+        let doc = try SwiftSoup.parse("<p class='old'></p>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        let a = try XCTUnwrap(p.getAttributes()?.first(where: { _ in true }))
+        try assertSelection(doc, ".old", [p])
+        a.setValue(value: Array("old".utf8))
+        try a.setKey(key: "class")
+        XCTAssertFalse(doc.isClassQueryIndexDirty)
+        try assertSelection(doc, ".old", [p])
+    }
+
+    func testAttributeMutationChangesAllSerializerModes() throws {
+        let doc = try SwiftSoup.parse("<html><head></head><body><p title='before'>text</p></body></html>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        let p = try XCTUnwrap(doc.select("p").first())
+        let a = try XCTUnwrap(p.getAttributes()?.first(where: { _ in true }))
+        _ = try doc.outerHtmlUTF8()
+        a.setValue(value: Array("after".utf8))
+        for bytes in [try doc.outerHtmlUTF8(), try doc.outerHtmlUTF8WithoutSourceReuse(), try doc.outerHtmlUTF8ReusingSourceOutsideBody()] {
+            let parsed = try SwiftSoup.parse(String(decoding: bytes, as: UTF8.self))
+            XCTAssertEqual(try parsed.select("p").attr("title"), "after")
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/NodeURLBoundaryTest.swift
+++ b/Tests/SwiftSoupTests/NodeURLBoundaryTest.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import SwiftSoup
+
+final class NodeURLBoundaryTest: XCTestCase {
+    func testAbsentBaseURIResolvesAbsoluteAttributeWithoutCrashing() throws {
+        let node = TextNode("text", nil)
+        try node.attr("href", "https://example.test/path")
+        XCTAssertEqual(try node.absUrl("href"), "https://example.test/path")
+        XCTAssertEqual(try node.attr("abs:href"), "https://example.test/path")
+        XCTAssertEqual(try node.absUrl(Array("href".utf8)), Array("https://example.test/path".utf8))
+    }
+    func testAbsentBaseURIDoesNotInventRelativeResolution() throws {
+        let node = TextNode("text", nil)
+        try node.attr("href", "relative")
+        XCTAssertEqual(try node.absUrl("href"), "")
+        XCTAssertEqual(try node.absUrl("missing"), "")
+        XCTAssertThrowsError(try node.absUrl(""))
+    }
+    func testURLResolutionUsesPublicBaseByteProjection() throws {
+        final class ProjectedBase: TextNode {
+            override func getBaseUriUTF8() -> [UInt8] { Array("https://example.test/root/".utf8) }
+        }
+        let node = ProjectedBase("text", "https://backing.invalid/")
+        try node.attr("href", "target")
+        XCTAssertEqual(try node.absUrl("href"), "https://example.test/root/target")
+    }
+}

--- a/Tests/SwiftSoupTests/OnlyChildExistenceTest.swift
+++ b/Tests/SwiftSoupTests/OnlyChildExistenceTest.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import SwiftSoup
+
+private final class OnlyChildTrace {
+    var events: [String] = []
+}
+
+private final class OnlyChildProjectedElements: Elements {
+    let trace: OnlyChildTrace
+    var view: [Element] = []
+    init(_ trace: OnlyChildTrace) { self.trace = trace; super.init() }
+    override func array() -> [Element] {
+        trace.events.append("array")
+        return view
+    }
+}
+
+private final class OnlyChildProjectedParent: Element {
+    var projection: OnlyChildProjectedElements!
+    override func children() -> Elements {
+        projection.trace.events.append("children")
+        return projection
+    }
+}
+
+private final class OnlyChildParentProbe: Element {
+    let trace = OnlyChildTrace()
+    var responses: [Element?] = []
+    var reads = 0
+    override func parent() -> Element? {
+        trace.events.append("parent:\(reads)")
+        let index = min(reads, max(0, responses.count - 1))
+        reads += 1
+        return responses.isEmpty ? nil : responses[index]
+    }
+}
+
+final class OnlyChildExistenceTest: XCTestCase {
+    private let evaluator = Evaluator.IsOnlyChild()
+    private func make(_ tag: String = "section") throws -> Element {
+        try Element(Tag.valueOf(tag), "")
+    }
+
+    func testMixedSiblingsAgainstIndependentMembershipModel() throws {
+        for width in [0, 1, 2, 3, 8, 32, 64, 257] {
+            for mixed in [false, true] {
+                let parent = try make()
+                var elements: [Element] = []
+                for i in 0..<width {
+                    if mixed {
+                        try parent.appendChild(TextNode("日\(i)", ""))
+                        try parent.appendChild(Comment([120], []))
+                        try parent.appendChild(DataNode([100], []))
+                    }
+                    let child = try make(i.isMultiple(of: 2) ? "p" : "em")
+                    try parent.appendChild(child)
+                    elements.append(child)
+                }
+                for child in elements {
+                    XCTAssertEqual(try evaluator.matches(parent, child), elements.count == 1)
+                }
+            }
+        }
+    }
+
+    func testDetachedDocumentAndFormPoliciesAreUnchanged() throws {
+        let detached = try make()
+        XCTAssertFalse(try evaluator.matches(detached, detached))
+        let document = Document("")
+        try document.appendChild(detached)
+        XCTAssertFalse(try evaluator.matches(document, detached))
+        let form = try FormElement(Tag.valueOf("form"), [])
+        try form.appendChild(detached)
+        XCTAssertTrue(try evaluator.matches(form, detached))
+        // Matching the supplied root is permitted when it has an ordinary parent.
+        XCTAssertTrue(try evaluator.matches(detached, detached))
+        try form.appendChild(make("input"))
+        XCTAssertFalse(try evaluator.matches(form, detached))
+    }
+
+    func testProjectedChildrenAndArrayAndDuplicateSelfArePreserved() throws {
+        let trace = OnlyChildTrace()
+        let parent = try OnlyChildProjectedParent(Tag.valueOf("main"), "")
+        parent.projection = OnlyChildProjectedElements(trace)
+        let child = try make("p"), other = try make("p")
+        try parent.appendChild(child)
+        try parent.appendChild(other)
+        for (view, expected) in [([], true), ([child], true),
+                                 ([child, child], true), ([other], false),
+                                 ([other, child], false)] {
+            parent.projection.view = view
+            trace.events = []
+            XCTAssertEqual(try evaluator.matches(parent, child), expected)
+            XCTAssertEqual(trace.events, ["children", "array"])
+        }
+    }
+
+    func testStatefulParentDispatchAndStoredParentGateArePreserved() throws {
+        let one = try make(), many = try make()
+        try many.appendChild(make())
+        let child = try OnlyChildParentProbe(Tag.valueOf("p"), "")
+        // A projected parent without a stored owner still produces an empty
+        // siblingElements() result, regardless of that projected parent's children.
+        child.responses = [many]
+        XCTAssertTrue(try evaluator.matches(one, child))
+        XCTAssertEqual(child.reads, 1)
+        try one.appendChild(child)
+        for (responses, expected, reads) in [
+            ([one, many] as [Element?], false, 2),
+            ([many, one], true, 2),
+            ([one, nil], true, 2),
+            ([nil, many], false, 1),
+            ([Document(""), one], false, 1)
+        ] {
+            child.responses = responses
+            child.reads = 0
+            child.trace.events = []
+            XCTAssertEqual(try evaluator.matches(one, child), expected)
+            XCTAssertEqual(child.reads, reads)
+            XCTAssertEqual(child.trace.events, (0..<reads).map { "parent:\($0)" })
+        }
+    }
+
+    func testStaleIndicesAndMissingMembershipRemainIdentityBased() throws {
+        let parent = try make(), child = try make()
+        try parent.appendChild(child)
+        for stale in [Int.min, -1, 0, 9, Int.max] {
+            child.setSiblingIndex(stale)
+            XCTAssertTrue(try evaluator.matches(parent, child))
+        }
+        child.setSiblingIndex(0)
+        let absent = try make()
+        absent.parentNode = parent
+        XCTAssertFalse(try evaluator.matches(parent, absent))
+        parent.empty()
+        XCTAssertTrue(try evaluator.matches(parent, absent))
+        absent.parentNode = nil
+    }
+
+    func testSeededMutationAndWarmedPublicQueries() throws {
+        let document = try SwiftSoup.parse("<main><section><p>日</p></section><aside></aside></main>")
+        let root = try XCTUnwrap(document.select("main").first())
+        let left = try XCTUnwrap(document.select("section").first())
+        let right = try XCTUnwrap(document.select("aside").first())
+        for i in 0..<128 {
+            let parents = [left, right]
+            let target = parents[i % 2]
+            if i % 5 == 0 { target.empty() }
+            else if i % 3 == 0, let child = parents[1-i%2].children().last() {
+                try target.appendChild(child)
+            } else { try target.appendChild(make(i % 2 == 0 ? "p" : "em")) }
+            // Independent structural oracle, not siblingElements() or this evaluator.
+            var expected: [Element] = []
+            for parent in [root, left, right] {
+                let children = parent.getChildNodes().compactMap { $0 as? Element }
+                if children.count == 1 { expected.append(children[0]) }
+            }
+            let expectedIDs = Set(expected.map(ObjectIdentifier.init))
+            for _ in 0..<3 {
+                let actual = try root.select(":only-child").array()
+                XCTAssertEqual(Set(actual.filter { $0 !== root }.map(ObjectIdentifier.init)), expectedIDs)
+                for parent in [left, right] {
+                    let children = parent.getChildNodes().compactMap { $0 as? Element }
+                    for child in children {
+                        XCTAssertEqual(try evaluator.matches(root, child), children.count == 1)
+                    }
+                }
+            }
+        }
+    }
+
+    func testDeepCopiesAndReadsDoNotMutateSource() throws {
+        let document = try SwiftSoup.parse("<main><section>t<p>日</p><!--c--></section><aside><i>a</i><b>b</b></aside></main>")
+        let copy = document.copy() as! Document
+        for doc in [document, copy] {
+            let before = try doc.outerHtml().utf8.map { $0 }
+            let all = try doc.select("*").array()
+            for _ in 0..<16 {
+                for element in all { _ = try evaluator.matches(doc, element) }
+            }
+            XCTAssertEqual(try doc.outerHtml().utf8.map { $0 }, before)
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/OwnerDocumentLookupTest.swift
+++ b/Tests/SwiftSoupTests/OwnerDocumentLookupTest.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import SwiftSoup
+
+final class OwnerDocumentLookupTest: XCTestCase {
+    func testLookupFollowsReparentingAndDetachment() throws {
+        let first = try SwiftSoup.parse("<main><p>one</p></main>")
+        let second = try SwiftSoup.parse("<section></section>")
+        let paragraph = try XCTUnwrap(first.getElementsByTag("p").first())
+        let text = paragraph.childNode(0)
+        XCTAssertTrue(first.ownerDocument() === first)
+        XCTAssertTrue(text.ownerDocument() === first)
+        try XCTUnwrap(second.body()).appendChild(paragraph)
+        XCTAssertTrue(paragraph.ownerDocument() === second)
+        XCTAssertTrue(text.ownerDocument() === second)
+        try paragraph.remove()
+        XCTAssertNil(paragraph.ownerDocument())
+        XCTAssertNil(text.ownerDocument())
+    }
+
+    func testAncestorOverrideIsNotBypassed() throws {
+        let physical = Document("")
+        let logical = Document("")
+        let ancestor = RedirectElement(try Tag.valueOf("section"), "")
+        ancestor.redirect = logical
+        try physical.appendChild(ancestor)
+        let paragraph = try ancestor.appendElement("p")
+        try paragraph.text("value")
+        XCTAssertTrue(paragraph.ownerDocument() === logical)
+        XCTAssertTrue(paragraph.childNode(0).ownerDocument() === logical)
+        XCTAssertTrue(paragraph.getOutputSettings() === logical.outputSettings())
+        ancestor.redirect = nil
+        XCTAssertNil(paragraph.ownerDocument())
+        XCTAssertNil(paragraph.childNode(0).ownerDocument())
+    }
+
+    func testDocumentOverrideIsNotBypassedFromChild() throws {
+        let logical = Document("")
+        let physical = RedirectDocument("")
+        physical.redirect = logical
+        let child = try physical.appendElement("div")
+        XCTAssertTrue(child.ownerDocument() === logical)
+        XCTAssertTrue(child.getOutputSettings() === logical.outputSettings())
+    }
+
+    func testOutputSettingsRemainLiveAndClonesUseTheirOwnDocument() throws {
+        let doc = try SwiftSoup.parse("<div><p>text</p></div>")
+        let paragraph = try XCTUnwrap(doc.getElementsByTag("p").first())
+        XCTAssertTrue(paragraph.getOutputSettings() === doc.outputSettings())
+        let replacement = OutputSettings().prettyPrint(pretty: false).syntax(syntax: .xml)
+        doc.outputSettings(replacement)
+        XCTAssertTrue(paragraph.getOutputSettings() === replacement)
+        let clone = doc.copy() as! Document
+        let cloned = try XCTUnwrap(clone.getElementsByTag("p").first())
+        XCTAssertTrue(cloned.ownerDocument() === clone)
+        XCTAssertTrue(cloned.getOutputSettings() === clone.outputSettings())
+        XCTAssertFalse(cloned.getOutputSettings() === replacement)
+        XCTAssertEqual(try paragraph.outerHtml(), try cloned.outerHtml())
+    }
+
+    func testDetachedDefaultsAreFreshAndMatchDocumentDefaults() throws {
+        let detached = try Element(Tag.valueOf("p"), "")
+        let first = detached.getOutputSettings()
+        let second = detached.getOutputSettings()
+        let reference = Document("").outputSettings()
+        XCTAssertFalse(first === second)
+        XCTAssertEqual(first.prettyPrint(), reference.prettyPrint())
+        XCTAssertEqual(first.syntax(), reference.syntax())
+        XCTAssertEqual(first.indentAmount(), reference.indentAmount())
+        XCTAssertEqual(first.charset(), reference.charset())
+        first.prettyPrint(pretty: !reference.prettyPrint())
+        XCTAssertEqual(detached.getOutputSettings().prettyPrint(), reference.prettyPrint())
+    }
+
+    private final class RedirectElement: Element {
+        var redirect: Document?
+        override func ownerDocument() -> Document? { redirect }
+    }
+
+    private final class RedirectDocument: Document {
+        var redirect: Document?
+        override func ownerDocument() -> Document? { redirect }
+    }
+}

--- a/Tests/SwiftSoupTests/PendingAttributesTransferTest.swift
+++ b/Tests/SwiftSoupTests/PendingAttributesTransferTest.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import SwiftSoup
+
+final class PendingAttributesTransferTest: XCTestCase {
+    private func add(_ token: Token.StartTag, _ name: String, _ value: String? = nil) throws {
+        token.appendAttributeName(Array(name.utf8))
+        if let value {
+            if value.isEmpty {
+                token.setEmptyAttributeValue()
+            } else {
+                token.appendAttributeValue(ByteSlice.fromArray(Array(value.utf8)))
+            }
+        }
+        try token.newAttribute()
+    }
+
+    func testTokenResetDoesNotClearTransferredAttributes() throws {
+        let token = Token.StartTag()
+        try add(token, "data-first", "one")
+        try add(token, "checked")
+        let first = token.getAttributes()
+        token.reset()
+        try add(token, "data-second", "two")
+        let second = token.getAttributes()
+
+        XCTAssertFalse(first === second)
+        XCTAssertEqual(first.get(key: "data-first"), "one")
+        XCTAssertTrue(first.hasKey(key: "checked"))
+        XCTAssertFalse(first.hasKey(key: "data-second"))
+        XCTAssertEqual(second.get(key: "data-second"), "two")
+        XCTAssertFalse(second.hasKey(key: "data-first"))
+    }
+
+    func testExistingMaterializedAttributesKeepIdentityAndInvalidateSelectors() throws {
+        let doc = try SwiftSoup.parse("<div class='before' data-keep='value'></div>")
+        let element = try XCTUnwrap(doc.select(".before").first())
+        let attributes = try XCTUnwrap(element.getAttributes())
+        _ = attributes.size()
+        let token = Token.StartTag()
+        token._attributes = attributes
+        try add(token, "class", "after")
+        try add(token, "data-new", "added")
+
+        XCTAssertTrue(token.getAttributes() === attributes)
+        XCTAssertEqual(attributes.get(key: "data-keep"), "value")
+        XCTAssertEqual(attributes.get(key: "data-new"), "added")
+        XCTAssertEqual(try doc.select(".before").size(), 0)
+        XCTAssertTrue(try doc.select(".after").first() === element)
+    }
+
+    func testExistingDeferredAttributesAreAppendedNotReplaced() throws {
+        let first = Token.StartTag()
+        try add(first, "data-keep", "one")
+        try add(first, "data-replace", "before")
+        let attributes = first.getAttributes()
+        let next = Token.StartTag()
+        next._attributes = attributes
+        try add(next, "data-replace", "after")
+        try add(next, "data-new", "two")
+
+        XCTAssertTrue(next.getAttributes() === attributes)
+        XCTAssertEqual(attributes.size(), 3)
+        XCTAssertEqual(attributes.get(key: "data-keep"), "one")
+        XCTAssertEqual(attributes.get(key: "data-replace"), "after")
+        XCTAssertEqual(attributes.get(key: "data-new"), "two")
+    }
+
+    func testUppercaseMetadataComesFromPendingNames() throws {
+        let token = Token.StartTag()
+        try add(token, "DATA-X", "one")
+        try add(token, "Class", "before")
+        // Do not infer Attributes.hasUppercaseKeys from this separate token flag.
+        token.setAttributesNormalized(true)
+        let attributes = token.getAttributes()
+        XCTAssertTrue(attributes.hasUppercaseKeys)
+        attributes.lowercaseAllKeys()
+        XCTAssertEqual(attributes.get(key: "data-x"), "one")
+        XCTAssertEqual(attributes.get(key: "class"), "before")
+        XCTAssertFalse(attributes.hasKey(key: "DATA-X"))
+    }
+
+    func testBooleanEmptyDuplicateAndMalformedNames() throws {
+        let token = Token.StartTag()
+        try add(token, "checked")
+        try add(token, "empty", "")
+        try add(token, "duplicate", "before")
+        try add(token, "duplicate", "after")
+        try add(token, " \t", "invalid")
+        let attributes = token.getAttributes()
+        XCTAssertEqual(attributes.size(), 3)
+        XCTAssertTrue(Array(attributes).first { $0.getKey() == "checked" } is BooleanAttribute)
+        XCTAssertFalse(Array(attributes).first { $0.getKey() == "empty" } is BooleanAttribute)
+        XCTAssertEqual(attributes.get(key: "duplicate"), "after")
+    }
+
+    func testMultipleValueSlicesSurviveTokenReuse() throws {
+        let token = Token.StartTag()
+        token.appendAttributeName(Array("title".utf8))
+        token.appendAttributeValue(ByteSlice.fromArray(Array("日本語".utf8)))
+        token.appendAttributeValue(ByteSlice.fromArray(Array(" & text".utf8)))
+        try token.newAttribute()
+        let attributes = token.getAttributes()
+        token.reset()
+        try add(token, "title", "replacement")
+        _ = token.getAttributes()
+        XCTAssertEqual(attributes.get(key: "title"), "日本語 & text")
+    }
+
+    func testXMLPreservesCaseAndDistinctKeysAcrossElements() throws {
+        let doc = try SwiftSoup.parse("<root><item A='one' a='two'/><item A='three'/></root>", "", Parser.xmlParser())
+        let items = try doc.select("item")
+        let first = try XCTUnwrap(items.get(0).getAttributes())
+        let second = try XCTUnwrap(items.get(1).getAttributes())
+        XCTAssertEqual(first.get(key: "A"), "one")
+        XCTAssertEqual(first.get(key: "a"), "two")
+        XCTAssertEqual(second.get(key: "A"), "three")
+    }
+
+    func testNoSourceRangesMaterializesAttributesBeforeInputIsReleased() throws {
+        var bytes = Array("<div DATA-X='one' title='a&amp;b'></div><div data-x='two'></div>".utf8)
+        let parser = Parser.htmlParser()
+        parser.settings(ParseSettings(false, false, false))
+        let doc = try parser.parseInput(bytes, "")
+        bytes = Array(repeating: 0, count: bytes.count)
+        let divs = try doc.select("div")
+        XCTAssertEqual(try divs.get(0).attr("data-x"), "one")
+        XCTAssertEqual(try divs.get(0).attr("title"), "a&b")
+        XCTAssertEqual(try divs.get(1).attr("data-x"), "two")
+    }
+}

--- a/Tests/SwiftSoupTests/PendingNamePrefilterTest.swift
+++ b/Tests/SwiftSoupTests/PendingNamePrefilterTest.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import SwiftSoup
+
+final class PendingNamePrefilterTest: XCTestCase {
+    private func pending(_ names: [String], bytes: Bool) -> Attributes {
+        Attributes(pendingAttributes: names.enumerated().map { i, name in
+            let key = Array(name.utf8)
+            return Attributes.PendingAttribute(nameSlice: bytes ? nil : ByteSlice.fromArray(key), nameBytes: bytes ? key : nil,
+                hasUppercase: Attributes.containsAsciiUppercase(key), value: .bytes(Array("v\(i)".utf8)))
+        })
+    }
+    func testAllSmallBatchSizesRemainDeferredForUniqueNames() throws {
+        for bytes in [false,true] {
+            for n in 1...32 {
+                let attrs = pending((0..<n).map { "data-k\($0)" }, bytes: bytes)
+                XCTAssertEqual(attrs.get(key: "data-k0"), "v0")
+                XCTAssertTrue(attrs.attributes.isEmpty, "\(bytes) \(n)")
+                XCTAssertEqual(try attrs.getIgnoreCase(key: "DATA-K\(n-1)"), "v\(n-1)")
+                XCTAssertTrue(attrs.attributes.isEmpty)
+            }
+        }
+    }
+    func testPrefilterCollisionsDoNotMergeDistinctNames() throws {
+        // Same length, first byte and final two bytes: all hit the same prefilter bit.
+        for bytes in [false,true] {
+            for n in [8,31,32,33,64] {
+                let names = (0..<n).map { "a\(String(format: "%03d", $0))zz" }
+                let attrs = pending(names, bytes: bytes)
+                for (i,key) in names.enumerated() { XCTAssertEqual(attrs.get(key: key), "v\(i)") }
+                XCTAssertTrue(attrs.attributes.isEmpty)
+                XCTAssertEqual(attrs.size(), n)
+            }
+        }
+    }
+    func testDuplicatesAtEverySmallBatchPositionUseLastValue() throws {
+        for bytes in [false,true] {
+            for n in [2,8,16,32,33] {
+                for duplicate in 0..<(n-1) {
+                    var names = (0..<n).map { "data-k\($0)" }; names[n-1] = names[duplicate]
+                    let attrs = pending(names, bytes: bytes)
+                    XCTAssertEqual(attrs.get(key: names[duplicate]), "v\(n-1)")
+                    XCTAssertEqual(attrs.size(), n-1)
+                }
+            }
+        }
+    }
+    func testValidationResetsAcrossThresholdAndRawReplacement() throws {
+        let attrs = pending((0..<32).map { "k\($0)" }, bytes: false)
+        XCTAssertEqual(attrs.get(key: "k0"), "v0")
+        var last = try XCTUnwrap(attrs.pendingAttributes?.first)
+        last.value = .bytes(Array("replacement".utf8))
+        attrs.appendPending(last)
+        XCTAssertEqual(attrs.get(key: "k0"), "replacement")
+        XCTAssertEqual(attrs.size(), 32)
+    }
+    func testInvalidAndPaddedNamesAtThresholdMatchMaterializer() throws {
+        for n in [8,32,33,128] {
+            for bytes in [false,true] {
+                let names = (0..<n).map { "k\($0)" } + [" k0 ", "\t", "\r", "\u{B}"]
+                let attrs = pending(names, bytes: bytes)
+                XCTAssertEqual(attrs.get(key: "k0"), "v\(n)")
+                XCTAssertEqual(attrs.size(), n)
+                XCTAssertFalse(attrs.hasKey(key: "\t"))
+            }
+        }
+    }
+    func testUnicodeByteDistinctKeysAndMixedCaseRemainDistinct() throws {
+        for bytes in [false,true] {
+            let names = ["é", "e\u{301}", "日本", "ID", "id"] + (0..<28).map { "x\($0)" }
+            let attrs = pending(names, bytes: bytes)
+            for i in names.indices { XCTAssertEqual(attrs.get(key: names[i]), "v\(i)") }
+            XCTAssertEqual(try attrs.getIgnoreCase(key: "id"), "v3")
+            XCTAssertEqual(attrs.size(), 33)
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/SelectorCacheLifetimeTest.swift
+++ b/Tests/SwiftSoupTests/SelectorCacheLifetimeTest.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import SwiftSoup
+
+final class SelectorCacheLifetimeTest: XCTestCase {
+    private func element() throws -> Element {
+        Element(try Tag.valueOf("span"), [])
+    }
+
+    func testLRUMapClearReleasesLinkedValues() throws {
+        let cache = SelectorResultCache.LRUMap(capacity: 4)
+        weak var first: Element?
+        weak var second: Element?
+        do {
+            let a = try element()
+            let b = try element()
+            first = a
+            second = b
+            _ = cache.set("a", Elements([a]))
+            _ = cache.set("b", Elements([b]))
+        }
+        XCTAssertNotNil(first)
+        XCTAssertNotNil(second)
+        cache.clear()
+        XCTAssertNil(first)
+        XCTAssertNil(second)
+        XCTAssertNil(cache.get("a"))
+    }
+
+    func testLRUMapDestructionReleasesLinkedValues() throws {
+        weak var first: Element?
+        weak var second: Element?
+        do {
+            let cache = SelectorResultCache.LRUMap(capacity: 4)
+            let a = try element()
+            let b = try element()
+            first = a
+            second = b
+            _ = cache.set("a", Elements([a]))
+            _ = cache.set("b", Elements([b]))
+            XCTAssertTrue(cache.get("a")?.first() === a)
+        }
+        XCTAssertNil(first)
+        XCTAssertNil(second)
+    }
+
+    func testDocumentReleaseFreesCachedDescendants() throws {
+        weak var document: Document?
+        weak var paragraph: Element?
+        weak var span: Element?
+        do {
+            let doc = try SwiftSoup.parse("<html><head></head><body><p>one</p><span>two</span></body></html>")
+            document = doc
+            paragraph = doc.body()?.child(0)
+            span = doc.body()?.child(1)
+            for _ in 0..<4 {
+                XCTAssertEqual(try doc.select("p").size(), 1)
+                XCTAssertEqual(try doc.select("span").size(), 1)
+            }
+        }
+        XCTAssertNil(document)
+        XCTAssertNil(paragraph)
+        XCTAssertNil(span)
+    }
+
+    func testLRUMapOrderingAndReuseAfterClear() throws {
+        let cache = SelectorResultCache.LRUMap(capacity: 2)
+        let a = Elements([try element()])
+        let b = Elements([try element()])
+        let c = Elements([try element()])
+        _ = cache.set("a", a)
+        _ = cache.set("b", b)
+        XCTAssertTrue(cache.get("a") === a)
+        XCTAssertEqual(cache.set("c", c)?.key, "b")
+        XCTAssertNil(cache.get("b"))
+        XCTAssertTrue(cache.get("a") === a)
+        cache.clear()
+        cache.clear()
+        _ = cache.set("b", b)
+        _ = cache.set("c", c)
+        XCTAssertEqual(cache.set("a", a)?.key, "b")
+        XCTAssertTrue(cache.get("c") === c)
+    }
+}

--- a/Tests/SwiftSoupTests/SelectorCacheSnapshotTest.swift
+++ b/Tests/SwiftSoupTests/SelectorCacheSnapshotTest.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import SwiftSoup
+
+final class SelectorCacheSnapshotTest: XCTestCase {
+    func testDescendantCacheFollowsMovedAncestor() throws {
+        let destination = try SwiftSoup.parse("<aside></aside>")
+        let root: Element
+        let text: TextNode
+        weak var releasedDocument: Document?
+        do {
+            let original = try SwiftSoup.parse("<main><section><p>before</p></section></main>")
+            releasedDocument = original
+            let moved = try XCTUnwrap(original.select("main").first())
+            root = try XCTUnwrap(moved.select("section").first())
+            let paragraph = try XCTUnwrap(root.select("p").first())
+            text = try XCTUnwrap(paragraph.childNode(0) as? TextNode)
+            // Give the source a nonzero version before warming its cache.
+            text.text("before")
+            for _ in 0..<4 { XCTAssertEqual(try root.select("p:contains(before)").size(), 1) }
+            XCTAssertNotNil(root.cachedSelectorResult("p:contains(before)"))
+            try XCTUnwrap(destination.body()).appendChild(moved)
+        }
+        XCTAssertNil(releasedDocument)
+        // Force an equal version across different roots, independently of how
+        // many correct invalidations append/adoption performs.
+        destination.textMutationVersion = root.selectorResultTextVersion &- 1
+        text.text("after")
+        XCTAssertEqual(root.selectorResultTextVersion, destination.textMutationVersion)
+        XCTAssertEqual(try root.select("p:contains(before)").size(), 0)
+        XCTAssertEqual(try root.select("p:contains(after)").size(), 1)
+    }
+
+    func testDescendantCacheInvalidatesWhenStandaloneRootIsAdopted() throws {
+        let moved = try Element(Tag.valueOf("main"), "")
+        try moved.append("<section><p>before</p></section>")
+        let root = try XCTUnwrap(moved.select("section").first())
+        let paragraph = try XCTUnwrap(root.select("p").first())
+        let text = try XCTUnwrap(paragraph.childNode(0) as? TextNode)
+        let destination = Document("")
+        for _ in 0..<4 { XCTAssertEqual(try root.select("p:contains(before)").size(), 1) }
+        XCTAssertNotNil(root.cachedSelectorResult("p:contains(before)"))
+        try destination.appendChild(moved)
+        // Force an equal version across different roots, independently of how
+        // many correct invalidations append/adoption performs.
+        destination.textMutationVersion = root.selectorResultTextVersion &- 1
+        text.text("after")
+        XCTAssertEqual(root.selectorResultTextVersion, destination.textMutationVersion)
+        XCTAssertEqual(try root.select("p:contains(before)").size(), 0)
+        XCTAssertEqual(try root.select("p:contains(after)").size(), 1)
+    }
+
+    func testSelfMatchingRootCanBeReleased() throws {
+        weak var observed: Element?
+        do {
+            let root = try Element(Tag.valueOf("div"), "")
+            observed = root
+            let child = try root.appendElement("p")
+            for _ in 0..<4 {
+                let all = try root.select("*").array()
+                XCTAssertEqual(all.map(ObjectIdentifier.init), [root, child].map(ObjectIdentifier.init))
+                XCTAssertTrue(try root.select("div").first() === root)
+            }
+        }
+        XCTAssertNil(observed)
+    }
+
+    func testWildcardDocumentCanBeReleased() throws {
+        weak var observed: Document?
+        do {
+            let doc = try SwiftSoup.parse("<p>one</p>")
+            observed = doc
+            for _ in 0..<4 { XCTAssertTrue(try doc.select("*").first() === doc) }
+        }
+        XCTAssertNil(observed)
+    }
+
+    func testMutatingAdmittedMissDoesNotChangeLaterResults() throws {
+        let doc = try SwiftSoup.parse("<p>one</p><span>two</span>")
+        _ = try doc.select("p")
+        let admitted = try doc.select("p")
+        let paragraph = try XCTUnwrap(admitted.first())
+        let span = try XCTUnwrap(doc.getElementsByTag("span").first())
+        admitted.add(span)
+        let later = try doc.select("p")
+        XCTAssertEqual(later.size(), 1)
+        XCTAssertTrue(later.first() === paragraph)
+        XCTAssertEqual(admitted.size(), 2)
+    }
+
+    func testMutatingCacheHitDoesNotPoisonResultsOrRetainOwner() throws {
+        weak var observed: Document?
+        do {
+            let doc = try SwiftSoup.parse("<p>one</p><span>two</span>")
+            observed = doc
+            for _ in 0..<4 { _ = try doc.select("p") }
+            let returned = try doc.select("p")
+            let paragraph = try XCTUnwrap(returned.first())
+            returned.add(0, doc)
+            let later = try doc.select("p")
+            XCTAssertEqual(later.size(), 1)
+            XCTAssertTrue(later.first() === paragraph)
+            XCTAssertEqual(returned.size(), 2)
+        }
+        XCTAssertNil(observed)
+    }
+
+    func testSnapshotsPreserveLiveNodeIdentityAndRetainedCollections() throws {
+        let doc = try SwiftSoup.parse("<p>one</p><p>two</p>")
+        for _ in 0..<4 { _ = try doc.select("p") }
+        let first = try doc.select("p")
+        let second = try doc.select("p")
+        XCTAssertFalse(first === second)
+        XCTAssertEqual(first.array().map(ObjectIdentifier.init), second.array().map(ObjectIdentifier.init))
+        let paragraph = try XCTUnwrap(first.first())
+        try paragraph.text("changed")
+        XCTAssertEqual(try second.first()?.text(), "changed")
+        try paragraph.remove()
+        XCTAssertEqual(first.size(), 2)
+        XCTAssertEqual(second.size(), 2)
+        XCTAssertEqual(try doc.select("p").size(), 1)
+    }
+
+    func testCustomCollectionIsNotReplacedWithPlainCachedElements() throws {
+        let root = try Element(Tag.valueOf("div"), "")
+        let result = CustomElements([try root.appendElement("p")])
+        for _ in 0..<4 { root.storeSelectorResult("custom", result) }
+        XCTAssertNil(root.cachedSelectorResult("custom"))
+        XCTAssertEqual(result.arrayReads, 0)
+    }
+
+    func testSelfMatchingCacheHitsHaveIndependentContainers() throws {
+        let root = try Element(Tag.valueOf("div"), "")
+        let child = try root.appendElement("p")
+        for _ in 0..<4 { _ = try root.select("*") }
+        let first = try XCTUnwrap(root.cachedSelectorResult("*"))
+        let second = try XCTUnwrap(root.cachedSelectorResult("*"))
+        XCTAssertFalse(first === second)
+        XCTAssertEqual(first.array().map(ObjectIdentifier.init), [root, child].map(ObjectIdentifier.init))
+        let extra = try Element(Tag.valueOf("span"), "")
+        first.add(extra)
+        XCTAssertEqual(second.size(), 2)
+        XCTAssertEqual(try root.select("*").size(), 2)
+        XCTAssertEqual(first.size(), 3)
+    }
+
+    func testOwnerOnlyResultsRemainCachedAndInvalidateOnMutation() throws {
+        let root = try Element(Tag.valueOf("div"), "")
+        for _ in 0..<4 { _ = try root.select("div") }
+        let result = try XCTUnwrap(root.cachedSelectorResult("div"))
+        XCTAssertEqual(result.size(), 1)
+        XCTAssertTrue(result.first() === root)
+        try root.tagName("section")
+        XCTAssertNil(root.cachedSelectorResult("div"))
+        XCTAssertEqual(try root.select("div").size(), 0)
+        XCTAssertTrue(result.first() === root)
+    }
+
+    func testNonstandardOwnerPlacementIsNotRetainedByCache() throws {
+        weak var observed: Element?
+        do {
+            let root = try Element(Tag.valueOf("div"), "")
+            observed = root
+            let child = try root.appendElement("p")
+            for elements in [[child, root], [root, child, root]] {
+                for _ in 0..<4 { root.storeSelectorResult("nonstandard", Elements(elements)) }
+                XCTAssertNil(root.cachedSelectorResult("nonstandard"))
+            }
+        }
+        XCTAssertNil(observed)
+    }
+
+    private final class CustomElements: Elements {
+        var arrayReads = 0
+        override func array() -> [Element] {
+            arrayReads += 1
+            return super.array()
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/SiblingEndpointReadTest.swift
+++ b/Tests/SwiftSoupTests/SiblingEndpointReadTest.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import SwiftSoup
+
+final class SiblingEndpointReadTest: XCTestCase {
+    private func check(_ parent: Element, receivers: [Element]? = nil, file: StaticString = #filePath, line: UInt = #line) {
+        let family = parent.children().array()
+        for node in receivers ?? family {
+            XCTAssertTrue(node.firstElementSibling() === (family.count > 1 ? family.first : nil), file: file, line: line)
+            XCTAssertTrue(node.lastElementSibling() === (family.count > 1 ? family.last : nil), file: file, line: line)
+        }
+    }
+
+    func testMixedFamiliesAtEverySmallWidthAndLegacySingletonNil() throws {
+        for count in 0...48 {
+            let parent = try Element(Tag.valueOf("section"), "")
+            try parent.appendChild(TextNode("start", ""))
+            for _ in 0..<count {
+                try parent.appendChild(Comment(Array("c".utf8), []))
+                try parent.appendElement("p")
+                try parent.appendChild(DataNode(Array("data".utf8), []))
+            }
+            try parent.appendChild(TextNode("end", ""))
+            check(parent)
+        }
+        let detached = try Element(Tag.valueOf("p"), "")
+        XCTAssertNil(detached.firstElementSibling()); XCTAssertNil(detached.lastElementSibling())
+    }
+
+    func testDocumentAndFormElementParents() throws {
+        let doc = Document("")
+        try doc.appendElement("p"); try doc.appendElement("span"); check(doc)
+        let form = try FormElement(Tag.valueOf("form"), "", Attributes())
+        try form.appendElement("input"); try form.appendChild(Comment(Array("gap".utf8), [])); try form.appendElement("button")
+        check(form)
+    }
+
+    private final class Log { var events: [String] = [] }
+    private final class View: Elements {
+        let log: Log
+        init(_ values: [Element], _ log: Log) { self.log = log; super.init(values) }
+        override func array() -> [Element] { log.events.append("array"); return super.array() }
+    }
+    private final class Parent: Element, @unchecked Sendable {
+        var view: Elements?
+        var log: Log?
+        override func children() -> Elements { log?.events.append("children"); return view ?? super.children() }
+    }
+    private final class Receiver: Element, @unchecked Sendable {
+        var visible: Element?
+        var log: Log?
+        override func parent() -> Element? { log?.events.append("parent"); return visible }
+    }
+
+    func testCustomParentChildrenArrayProjectionAndExactCallbackOrder() throws {
+        let log = Log(), parent = try Parent(Tag.valueOf("section"), "")
+        let a = try Element(Tag.valueOf("p"), ""), b = try Element(Tag.valueOf("b"), "")
+        let receiver = try Receiver(Tag.valueOf("i"), "")
+        parent.log = log; parent.view = View([b,a],log)
+        receiver.log = log; receiver.visible = parent
+        XCTAssertTrue(receiver.firstElementSibling() === b)
+        XCTAssertEqual(log.events,["parent","children","array"])
+        log.events=[]
+        XCTAssertTrue(receiver.lastElementSibling() === a)
+        XCTAssertEqual(log.events,["parent","children","array"])
+        for values in [[],[a],[a,a]] {
+            parent.view=View(values,log)
+            XCTAssertTrue(receiver.firstElementSibling() === (values.count>1 ? a:nil))
+            XCTAssertTrue(receiver.lastElementSibling() === (values.count>1 ? a:nil))
+        }
+    }
+
+    func testRedirectedParentWithoutStoredMembershipAndNilProjection() throws {
+        let projected = try Element(Tag.valueOf("section"), "")
+        try projected.appendElement("p"); try projected.appendElement("b")
+        let receiver = try Receiver(Tag.valueOf("i"), "")
+        receiver.visible=projected
+        check(projected,receivers:[receiver])
+        receiver.visible=nil
+        XCTAssertNil(receiver.firstElementSibling()); XCTAssertNil(receiver.lastElementSibling())
+    }
+
+    func testStaleSiblingIndicesDoNotChangeEndpointReads() throws {
+        let parent = try Element(Tag.valueOf("section"), "")
+        try parent.append("t<p>a</p><!--b--><b>b</b><em>c</em>t")
+        let nodes=parent.children().array()
+        for node in nodes {
+            let saved=node.siblingIndex
+            for bad in [Int.min,-1,0,1,Int.max] { node.setSiblingIndex(bad); check(parent) }
+            node.setSiblingIndex(saved)
+        }
+    }
+
+    func testBuiltInDuplicateMembershipRetainsCountRatherThanDistinctness() throws {
+        let parent = try Element(Tag.valueOf("section"), "")
+        let a=try parent.appendElement("p")
+        parent.childNodes=[a,a]
+        XCTAssertTrue(a.firstElementSibling() === a); XCTAssertTrue(a.lastElementSibling() === a)
+        parent.childNodes=[a]
+        XCTAssertNil(a.firstElementSibling()); XCTAssertNil(a.lastElementSibling())
+    }
+
+    func testMutationRoundsClonesAndSourceState() throws {
+        let doc=try SwiftSoup.parse("<main><p>a</p>t<b>b</b><!--c--><p>c</p></main><aside><em>x</em></aside>")
+        let main=try XCTUnwrap(doc.select("main").first()), aside=try XCTUnwrap(doc.select("aside").first())
+        let output=try doc.outerHtml(), token=doc.textMutationVersionToken()
+        for _ in 0..<4 { check(main); check(aside) }
+        XCTAssertEqual(try doc.outerHtml(),output); XCTAssertEqual(doc.textMutationVersionToken(),token)
+        var state: UInt64=0x74371
+        for round in 0..<192 {
+            state=state &* 6364136223846793005 &+ 1
+            let source=(state&1)==0 ? main:aside, target=source===main ? aside:main
+            if let last=source.children().last() { try target.prependChild(last) }
+            if round%4==0 { try source.appendElement("span") }
+            if round%7==0 { try target.appendChild(Comment(Array("gap".utf8), [])) }
+            check(main); check(aside)
+        }
+        let copy=doc.copy() as! Document
+        for parent in try copy.select("main,aside") { check(parent) }
+    }
+}

--- a/Tests/SwiftSoupTests/SiblingReindexTest.swift
+++ b/Tests/SwiftSoupTests/SiblingReindexTest.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import SwiftSoup
+
+final class SiblingReindexTest: XCTestCase {
+    func testEveryValidSuffixWithRetainedArraySnapshot() throws {
+        for count in [0, 1, 2, 15, 16, 17, 128] {
+            let root = try Element(Tag.valueOf("main"), "")
+            for index in 0..<count {
+                try root.appendChild(index % 2 == 0 ? TextNode("text", "") : Element(Tag.valueOf("p"), ""))
+            }
+            let snapshot = root.getChildNodes()
+            for start in 0...count {
+                for child in snapshot { child.setSiblingIndex(Int.max) }
+                root.reindexChildren(start)
+                XCTAssertEqual(root.childNodeSize(), count)
+                for index in 0..<count {
+                    XCTAssertTrue(root.childNode(index) === snapshot[index])
+                    XCTAssertTrue(snapshot[index].getParentNode() === root)
+                    XCTAssertEqual(snapshot[index].siblingIndex, index < start ? Int.max : index)
+                }
+            }
+            root.reindexChildren(0)
+        }
+    }
+
+    func testReindexDoesNotInvalidateWarmedReadState() throws {
+        let doc = try SwiftSoup.parse("<main>text<p id='a'>one</p><!--gap--><p id='b'>two</p>tail</main>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        let root = try XCTUnwrap(doc.getElementsByTag("main").first())
+        for _ in 0..<4 { _ = try doc.select("p"); _ = try doc.text() }
+        let before = try doc.outerHtmlUTF8()
+        let version = root.textMutationVersionToken()
+        let tagsDirty = doc.isTagQueryIndexDirty
+        let children = root.getChildNodes()
+        for child in children { child.setSiblingIndex(100) }
+        root.reindexChildren(0)
+        XCTAssertEqual(try doc.outerHtmlUTF8(), before)
+        XCTAssertEqual(root.textMutationVersionToken(), version)
+        XCTAssertEqual(doc.isTagQueryIndexDirty, tagsDirty)
+        XCTAssertEqual(try doc.select("p").array().map { try $0.attr("id") }, ["a", "b"])
+        for (index, child) in children.enumerated() { XCTAssertEqual(child.siblingIndex, index) }
+    }
+
+    func testRepeatedMovesRemovalsAndInsertionsMatchReferenceOrder() throws {
+        let root = try Element(Tag.valueOf("main"), "")
+        let other = try Element(Tag.valueOf("aside"), "")
+        var expected: [Node] = []
+        for index in 0..<64 {
+            let child = TextNode("\(index)", "")
+            try root.appendChild(child)
+            expected.append(child)
+        }
+        for round in 0..<80 {
+            let moved = expected.removeLast()
+            try root.insertChildren(0, [moved])
+            expected.insert(moved, at: 0)
+            if round % 3 == 0 {
+                let middle = expected.remove(at: expected.count / 2)
+                try other.appendChild(middle)
+                try root.appendChild(middle)
+                expected.append(middle)
+            }
+            let snapshot = root.getChildNodes()
+            for (index, child) in expected.enumerated() {
+                XCTAssertTrue(snapshot[index] === child)
+                XCTAssertTrue(child.parent() === root)
+                XCTAssertEqual(child.siblingIndex, index)
+                if index > 0 { XCTAssertTrue(child.previousSibling() === expected[index - 1]) }
+                if index + 1 < expected.count { XCTAssertTrue(child.nextSibling() === expected[index + 1]) }
+            }
+        }
+    }
+
+    func testInsertionPreservesOwnerLookupObservationOrder() throws {
+        final class ObservingDocument: Document {
+            var observedRoot: Element?
+            var counts: [Int] = []
+            override func ownerDocument() -> Document? {
+                if let observedRoot { counts.append(observedRoot.childNodeSize()) }
+                return self
+            }
+        }
+        let document = ObservingDocument("")
+        let root = try document.appendElement("main")
+        document.observedRoot = root
+        let tag = try Tag.valueOf("p")
+        let children = (0..<3).map { _ in Element(tag, "") }
+        document.counts.removeAll()
+        try root.insertChildren(0, children)
+        // Reindexing must not batch or reorder the surrounding mutation callbacks.
+        XCTAssertEqual(document.counts, [1, 2, 3, 3])
+        for (index, child) in children.enumerated() {
+            XCTAssertEqual(child.siblingIndex, index)
+            XCTAssertTrue(child.parent() === root)
+        }
+    }
+
+    func testDeepCopyReindexesWithoutChangingSource() throws {
+        let original = try SwiftSoup.parse("<main><p><b>one</b></p><p>two</p></main>")
+        let copy = original.copy() as! Document
+        let source = try XCTUnwrap(original.getElementsByTag("main").first())
+        let destination = try XCTUnwrap(copy.getElementsByTag("main").first())
+        try destination.insertChildren(0, [TextNode("new", "")])
+        XCTAssertEqual(source.childNodeSize(), 2)
+        XCTAssertEqual(destination.childNodeSize(), 3)
+        XCTAssertEqual(source.childNode(1).siblingIndex, 1)
+        XCTAssertEqual(destination.childNode(2).siblingIndex, 2)
+        XCTAssertTrue(destination.childNode(1).childNode(0).ownerDocument() === copy)
+        XCTAssertTrue(source.childNode(0).childNode(0).ownerDocument() === original)
+    }
+}

--- a/Tests/SwiftSoupTests/SingleTextBufferTest.swift
+++ b/Tests/SwiftSoupTests/SingleTextBufferTest.swift
@@ -1,0 +1,78 @@
+import Foundation
+import XCTest
+@testable import SwiftSoup
+
+final class SingleTextBufferTest: XCTestCase {
+    private func assertReads(_ bytes: [UInt8], slice: ByteSlice,
+                             file: StaticString = #filePath, line: UInt = #line) throws {
+        let root = try Element(Tag.valueOf("p"), "")
+        try root.appendChild(TextNode(slice: slice, baseUri: []))
+        XCTAssertEqual(try root.text(trimAndNormaliseWhitespace: false),
+                       String(decoding: bytes, as: UTF8.self), file: file, line: line)
+        // Reference the general text traversal rather than the single-node fast path.
+        let reference = try Element(Tag.valueOf("p"), "")
+        try reference.appendChild(TextNode(bytes, []))
+        try reference.appendChild(TextNode([], []))
+        XCTAssertEqual(try root.text(), try reference.text(), file: file, line: line)
+        XCTAssertEqual(try root.textUTF8(), try reference.textUTF8(), file: file, line: line)
+        XCTAssertEqual(try root.textUTF8Slice(), try reference.textUTF8Slice(), file: file, line: line)
+    }
+
+    func testAllByteValuesAndMalformedUTF8AcrossBackings() throws {
+        let cases: [[UInt8]] = [[], Array("日本語😀é & text".utf8), Array("a\u{00a0}b\t\r\n c".utf8),
+            [0, 1, 127, 255, 192, 160], Array(0...255)] + (0...255).map { [UInt8($0)] }
+        for bytes in cases {
+            let padded = [UInt8(250)] + bytes + [251]
+            let array = ByteStorage(array: padded)
+            try assertReads(bytes, slice: ByteSlice(storage: array, start: 1, end: bytes.count + 1))
+            let data = ByteStorage(data: Data([249] + padded).dropFirst())
+            try assertReads(bytes, slice: ByteSlice(storage: data, start: 1, end: bytes.count + 1))
+            try padded.withUnsafeBufferPointer { buffer in
+                let borrowed = ByteStorage(buffer: buffer.baseAddress!, count: buffer.count, owner: nil)
+                try assertReads(bytes, slice: ByteSlice(storage: borrowed, start: 1, end: bytes.count + 1))
+            }
+        }
+    }
+
+    func testWhitespaceEntitiesFragmentsAndXML() throws {
+        for content in ["", "\t x \n", "a&nbsp;b", "日本語", "éà", "a&#160;b", "a&#0;b", "😀", " &amp; &lt; "] {
+            for parser in [Parser.htmlParser(), Parser.xmlParser()] {
+                let doc = try parser.parseInput("<root><p>\(content)</p><pre>\(content)</pre></root>", "")
+                for tag in ["p", "pre"] {
+                    let element = try XCTUnwrap(doc.getElementsByTag(tag).first())
+                    let before = try element.text()
+                    let raw = try element.text(trimAndNormaliseWhitespace: false)
+                    guard let node = element.getChildNodes().first as? TextNode else {
+                        XCTAssertEqual(raw, "")
+                        continue
+                    }
+                    _ = node.getWholeTextUTF8() // Materialize backing.
+                    XCTAssertEqual(try element.text(), before)
+                    XCTAssertEqual(try element.text(trimAndNormaliseWhitespace: false), raw)
+                }
+            }
+        }
+    }
+
+    func testAttributeBackedTextMutationAndSelectorCaches() throws {
+        let doc = try SwiftSoup.parse("<p>日本語</p>")
+        let p = try XCTUnwrap(doc.getElementsByTag("p").first())
+        let text = p.childNode(0) as! TextNode
+        _ = text.getAttributes()
+        for _ in 0..<4 { _ = try doc.select("p:contains(日本語)") }
+        text.text("変更\t後")
+        XCTAssertEqual(try p.text(), "変更 後")
+        XCTAssertEqual(try p.text(trimAndNormaliseWhitespace: false), "変更\t後")
+        XCTAssertEqual(try doc.select("p:contains(日本語)").size(), 0)
+        XCTAssertEqual(try doc.select("p:contains(変更)").size(), 1)
+    }
+
+    func testLongSingleTextSlicesWithLateWhitespace() throws {
+        for count in [1, 7, 15, 16, 31, 32, 255, 4096] {
+            for suffix in ["語", "\t", "\u{00a0}", " ", "é"] {
+                let bytes = Array((String(repeating: "日", count: count) + suffix).utf8)
+                try assertReads(bytes, slice: .fromArray(bytes))
+            }
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/TextAttributePresenceTest.swift
+++ b/Tests/SwiftSoupTests/TextAttributePresenceTest.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import SwiftSoup
+
+final class TextAttributePresenceTest: XCTestCase {
+    func testFreshByteQueriesAgreeWithStringQueries() throws {
+        for value in ["", "text", "日本", "e\u{301}", "👩🏽‍💻"] {
+            for key in ["text", "TEXT", "TeXt", "missing", ""] {
+                let bytesNode = TextNode(value, nil)
+                let stringNode = TextNode(value, nil)
+                XCTAssertEqual(bytesNode.hasAttr(Array(key.utf8)), stringNode.hasAttr(key), key)
+            }
+        }
+    }
+
+    func testByteQueriesThroughNodeReferenceDoNotDirtyParsedSource() throws {
+        let doc = try SwiftSoup.parse("<p>日本 &amp; text</p>")
+        let text = try XCTUnwrap(doc.select("p").first()?.textNodes().first)
+        let node: Node = text
+        let version = doc.textMutationVersionToken()
+        let dirty = text.sourceRangeDirty
+        let before = try doc.outerHtmlUTF8()
+        XCTAssertTrue(node.hasAttr(Array("text".utf8)))
+        XCTAssertTrue(node.hasAttr(Array("TEXT".utf8)))
+        XCTAssertEqual(doc.textMutationVersionToken(), version)
+        XCTAssertEqual(text.sourceRangeDirty, dirty)
+        XCTAssertEqual(try doc.outerHtmlUTF8(), before)
+    }
+
+    func testReadThenRemoveDoesNotRestoreDeferredText() throws {
+        let node = TextNode("pending", nil)
+        XCTAssertTrue(node.hasAttr(Array("text".utf8)))
+        try node.removeAttr(Array("text".utf8))
+        for _ in 0..<4 {
+            XCTAssertFalse(node.hasAttr(Array("text".utf8)))
+            XCTAssertFalse(node.hasAttr("text"))
+            XCTAssertEqual(node.getWholeTextUTF8(), [])
+        }
+    }
+
+    func testPresenceQueryUsesCurrentSharedAttributeState() throws {
+        let node = TextNode("original", nil)
+        XCTAssertTrue(node.hasAttr(Array("text".utf8)))
+        let attribute = try XCTUnwrap(node.getAttributes().asList().first)
+        let other = TextNode("other", nil)
+        other.getAttributes().put(attribute: attribute)
+        try attribute.setKey(key: "renamed")
+        for node in [node, other] {
+            XCTAssertFalse(node.hasAttr(Array("text".utf8)))
+            XCTAssertTrue(node.hasAttr(Array("RENAMED".utf8)))
+            XCTAssertEqual(node.getWholeTextUTF8(), [])
+        }
+    }
+}

--- a/Tests/SwiftSoupTests/TextSplitBoundaryTest.swift
+++ b/Tests/SwiftSoupTests/TextSplitBoundaryTest.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import SwiftSoup
+
+final class TextSplitBoundaryTest: XCTestCase {
+    func testCharacterOffsetsUseCharactersRatherThanBytes() throws {
+        for value in ["日本語", "A🇯🇵e\u{301}👨‍👩‍👧‍👦Z", "a\r\nb", "éé"] {
+            let characters = Array(value)
+            for offset in 0...characters.count {
+                let node = TextNode(value, "https://example.test/")
+                let tail = try node.splitText(offset)
+                XCTAssertEqual(Array(node.getWholeTextUTF8()), Array(String(characters[..<offset]).utf8))
+                XCTAssertEqual(Array(tail.getWholeTextUTF8()), Array(String(characters[offset...]).utf8))
+                XCTAssertEqual(tail.getBaseUri(), "https://example.test/")
+                XCTAssertNil(tail.parent())
+            }
+        }
+    }
+    func testCharacterOffsetsBetweenCharacterCountAndByteCountThrow() throws {
+        for value in ["日本", "🇯🇵", "e\u{301}"] {
+            let node = TextNode(value, "")
+            let version = node.textMutationVersionToken()
+            for offset in (value.count + 1)..<value.utf8.count {
+                XCTAssertThrowsError(try node.splitText(offset), "\(value) @ \(offset)")
+                XCTAssertEqual(Array(node.getWholeTextUTF8()), Array(value.utf8))
+                XCTAssertEqual(version, node.textMutationVersionToken())
+            }
+        }
+    }
+    func testEndAndEmptyCharacterOffsetsAreValid() throws {
+        for value in ["", "abc", "日本", "🇯🇵"] {
+            let node = TextNode(value, "")
+            let tail = try node.splitText(value.count)
+            XCTAssertEqual(node.getWholeText(), value)
+            XCTAssertEqual(tail.getWholeText(), "")
+        }
+    }
+    func testByteOffsetsAtEveryScalarBoundaryAreExact() throws {
+        for value in ["日本語", "e\u{301}x", "🇯🇵!", "👨‍👩‍👧‍👦x", "a\r\nb", "a\u{0}b"] {
+            var offsets = [0]
+            for scalar in value.unicodeScalars { offsets.append(offsets.last! + String(scalar).utf8.count) }
+            let bytes = Array(value.utf8)
+            for offset in offsets {
+                let node = TextNode(value, "")
+                let tail = try node.splitText(utf8Offset: offset)
+                XCTAssertEqual(node.getWholeTextUTF8(), Array(bytes[..<offset]), "\(value) @ \(offset)")
+                XCTAssertEqual(tail.getWholeTextUTF8(), Array(bytes[offset...]), "\(value) @ \(offset)")
+            }
+        }
+    }
+    func testByteOffsetsInsideScalarsThrowWithoutMutation() throws {
+        for value in ["日本", "é", "🇯🇵", "a👩‍🔬b"] {
+            let bytes = Array(value.utf8)
+            for offset in bytes.indices where bytes[offset] & 0xC0 == 0x80 {
+                let node = TextNode(value, "")
+                let version = node.textMutationVersionToken()
+                XCTAssertThrowsError(try node.splitText(utf8Offset: offset))
+                XCTAssertEqual(node.getWholeTextUTF8(), bytes)
+                XCTAssertEqual(node.textMutationVersionToken(), version)
+            }
+        }
+    }
+    func testEndAndEmptyByteOffsetsAreValid() throws {
+        for value in ["", "abc", "日本", "e\u{301}"] {
+            let node = TextNode(value, "")
+            let tail = try node.splitText(utf8Offset: value.utf8.count)
+            XCTAssertEqual(node.getWholeTextUTF8(), Array(value.utf8))
+            XCTAssertEqual(tail.getWholeTextUTF8(), [])
+        }
+    }
+    func testInvalidBoundsAreAtomicInAttachedNodes() throws {
+        for byteOffset in [false,true] {
+            for offset in [-1, Int.min, 100, Int.max] {
+                let doc = try SwiftSoup.parse("<p>日本語</p>")
+                let parent = try XCTUnwrap(doc.select("p").first())
+                let node = try XCTUnwrap(parent.textNodes().first)
+                let before = try doc.outerHtml()
+                let version = doc.textMutationVersionToken()
+                if byteOffset { XCTAssertThrowsError(try node.splitText(utf8Offset: offset)) }
+                else { XCTAssertThrowsError(try node.splitText(offset)) }
+                XCTAssertEqual(try doc.outerHtml(), before)
+                XCTAssertEqual(doc.textMutationVersionToken(), version)
+                XCTAssertEqual(parent.childNodeSize(), 1)
+                XCTAssertTrue(node.parent() === parent)
+            }
+        }
+    }
+    func testSplitKeepsSiblingIdentityOrderAndWarmedSelectionCurrent() throws {
+        let doc = try SwiftSoup.parse("<p>日本語<i>suffix</i></p>")
+        let parent = try XCTUnwrap(doc.select("p").first())
+        let node = try XCTUnwrap(parent.textNodes().first)
+        let suffix = parent.childNode(1)
+        for _ in 0..<3 { XCTAssertTrue(try doc.select("p:contains(日本語)").first() === parent) }
+        let tail = try node.splitText(utf8Offset: 3)
+        XCTAssertTrue(parent.childNode(0) === node)
+        XCTAssertTrue(parent.childNode(1) === tail)
+        XCTAssertTrue(parent.childNode(2) === suffix)
+        XCTAssertEqual(tail.siblingIndex, 1)
+        XCTAssertEqual(suffix.siblingIndex, 2)
+        tail.text("別")
+        XCTAssertEqual(try doc.select("p:contains(日本語)").size(), 0)
+        XCTAssertTrue(try doc.select("p:contains(日別)").first() === parent)
+        XCTAssertTrue(try parent.html().contains("日別"))
+    }
+    func testScalarSplitInsideGraphemeRemainsExactAfterRecombining() throws {
+        for value in ["e\u{301}", "🇯🇵", "👩‍🔬", "\r\n"] {
+            let first = String(value.unicodeScalars.first!)
+            let parent = Element(try Tag.valueOf("span"), "")
+            let node = TextNode(value, "")
+            try parent.appendChild(node)
+            let tail = try node.splitText(utf8Offset: first.utf8.count)
+            XCTAssertEqual(node.getWholeTextUTF8() + tail.getWholeTextUTF8(), Array(value.utf8))
+            XCTAssertEqual(Array(try parent.text(trimAndNormaliseWhitespace: false).utf8), Array(value.utf8))
+        }
+    }
+    func testByteSplitRejectsInvalidStoredUTF8WithoutRepairingIt() throws {
+        for bytes: [UInt8] in [[0xFF,0x41], [0xE3,0x81], [0xC0,0xAF,0x41]] {
+            let node = TextNode(bytes, [])
+            XCTAssertThrowsError(try node.splitText(utf8Offset: 1))
+            XCTAssertEqual(node.getWholeTextUTF8(), bytes)
+        }
+    }
+    func testSplitDeferredFragmentedAndMaterializedText() throws {
+        for materialized in [false,true] {
+            let node = TextNode(slice: ByteSlice.fromArray(Array("e".utf8)), baseUri: [])
+            node.appendSlice(ByteSlice.fromArray(Array("\u{301}x".utf8)))
+            if materialized { _ = node.getAttributes().size() }
+            let tail = try node.splitText(utf8Offset: 1)
+            XCTAssertEqual(node.getWholeTextUTF8(), Array("e".utf8))
+            XCTAssertEqual(tail.getWholeTextUTF8(), Array("\u{301}x".utf8))
+            XCTAssertEqual(try node.attr("text"), "e")
+        }
+    }
+    func testCharacterSplitReadsPublicTextProjectionOnce() throws {
+        final class Projected: TextNode {
+            var reads = 0
+            override func getWholeText() -> String {
+                reads += 1
+                return reads == 1 ? "日本語" : "changed"
+            }
+        }
+        let node = Projected("backing", "")
+        let tail = try node.splitText(1)
+        XCTAssertEqual(node.reads, 1)
+        XCTAssertEqual(node.getWholeTextUTF8(), Array("日".utf8))
+        XCTAssertEqual(tail.getWholeTextUTF8(), Array("本語".utf8))
+    }
+    func testTailRetainsExactBaseURIBytes() throws {
+        let base: [UInt8] = [0x2f, 0xff, 0x80, 0x61]
+        for useBytes in [false, true] {
+            let node = TextNode(Array("abc".utf8), base)
+            let tail = try useBytes ? node.splitText(utf8Offset: 1) : node.splitText(1)
+            XCTAssertEqual(tail.getBaseUriUTF8(), base)
+        }
+    }
+    func testByteSplitReadsProjectionOnceAndDoesNotDelegateToCharacterOffset() throws {
+        final class Projected: TextNode {
+            var reads = 0
+            override func getWholeTextUTF8() -> [UInt8] {
+                reads += 1
+                return Array((reads == 1 ? "e\u{301}x" : "other").utf8)
+            }
+            override func splitText(_ offset: Int) throws -> TextNode {
+                XCTFail("A byte offset must not be reinterpreted as a Character offset")
+                return self
+            }
+        }
+        let node = Projected("backing", "")
+        let tail = try node.splitText(utf8Offset: 1)
+        XCTAssertEqual(node.reads, 1)
+        XCTAssertEqual(tail.getWholeTextUTF8(), Array("\u{301}x".utf8))
+    }
+
+    func testGeneratedUnicodeSplitsAgainstIndependentByteAndCharacterModels() throws {
+        let scalars: [UnicodeScalar] = ["A", "é", "日", "\u{301}", "\u{200D}", "\u{1F1EF}", "\u{1F1F5}", "\u{1F469}", "\u{1F3FD}", "\u{1F52C}", "\r", "\n", "\u{0}"]
+        var state: UInt64 = 0xAB931E
+        for iteration in 0..<256 {
+            var value = ""
+            for _ in 0..<(iteration % 7 + 1) {
+                state = state &* 6364136223846793005 &+ 1
+                value.unicodeScalars.append(scalars[Int((state >> 32) % UInt64(scalars.count))])
+            }
+            let bytes = Array(value.utf8)
+            for offset in 0...bytes.count {
+                let node = TextNode(value, "")
+                if offset < bytes.count && bytes[offset] & 0xC0 == 0x80 {
+                    XCTAssertThrowsError(try node.splitText(utf8Offset: offset))
+                    XCTAssertEqual(node.getWholeTextUTF8(), bytes)
+                } else {
+                    let tail = try node.splitText(utf8Offset: offset)
+                    XCTAssertEqual(node.getWholeTextUTF8(), Array(bytes[..<offset]))
+                    XCTAssertEqual(tail.getWholeTextUTF8(), Array(bytes[offset...]))
+                }
+            }
+            let characters = Array(value)
+            for offset in 0...characters.count {
+                let node = TextNode(value, "")
+                let tail = try node.splitText(offset)
+                XCTAssertEqual(node.getWholeTextUTF8(), Array(String(characters[..<offset]).utf8))
+                XCTAssertEqual(tail.getWholeTextUTF8(), Array(String(characters[offset...]).utf8))
+            }
+        }
+    }
+
+}

--- a/Tests/SwiftSoupTests/TextSplitRefinementCompatibilityTest.swift
+++ b/Tests/SwiftSoupTests/TextSplitRefinementCompatibilityTest.swift
@@ -1,0 +1,229 @@
+import XCTest
+@testable import SwiftSoup
+
+final class TextSplitRefinementCompatibilityTest: XCTestCase {
+    func testGraphemeOffsetsPreserveUnicodeBytes() throws {
+        for text in ["日本語", "e\u{301}x", "👩🏽‍💻Z", "🇯🇵x", "\r\nx", "a\0b"] {
+            for offset in 0..<text.count {
+                let node = TextNode(text, "")
+                let tail = try node.splitText(offset)
+                XCTAssertEqual(node.getWholeTextUTF8(), Array(String(text.prefix(offset)).utf8))
+                XCTAssertEqual(tail.getWholeTextUTF8(), Array(String(text.dropFirst(offset)).utf8))
+            }
+        }
+    }
+
+    func testGraphemeEndOffsetIsAllowed() throws {
+        for text in ["hello", "日本", "e\u{301}", ""] {
+            let node = TextNode(text, nil)
+            let tail = try node.splitText(text.count)
+            XCTAssertEqual(node.getWholeTextUTF8(), Array(text.utf8))
+            XCTAssertEqual(tail.getWholeText(), "")
+        }
+    }
+
+    func testInvalidGraphemeOffsetThrowsWithoutMutation() throws {
+        // The previous implementation validates a character offset against UTF-8 byte count.
+        // Run separately when reproducing the old trap so it cannot mask other regressions.
+        let node = TextNode("日", "")
+        XCTAssertThrowsError(try node.splitText(2))
+        XCTAssertEqual(node.getWholeText(), "日")
+        XCTAssertThrowsError(try node.splitText(-1))
+        XCTAssertThrowsError(try node.splitText(Int.max))
+    }
+
+    func testUtf8OffsetsAreExactAtScalarBoundaries() throws {
+        for text in ["日本語", "e\u{301}x", "👩🏽‍💻Z", "🇯🇵x", "\r\nx", "a\0b"] {
+            let bytes = Array(text.utf8)
+            var offset = 0
+            for scalar in text.unicodeScalars {
+                let node = TextNode(text, "")
+                let tail = try node.splitText(utf8Offset: offset)
+                XCTAssertEqual(node.getWholeTextUTF8(), Array(bytes[..<offset]))
+                XCTAssertEqual(tail.getWholeTextUTF8(), Array(bytes[offset...]))
+                offset += scalar.utf8.count
+            }
+        }
+    }
+
+    func testUtf8EndOffsetIsAllowed() throws {
+        for text in ["hello", "日本", "e\u{301}", ""] {
+            let node = TextNode(text, "")
+            let tail = try node.splitText(utf8Offset: text.utf8.count)
+            XCTAssertEqual(node.getWholeTextUTF8(), Array(text.utf8))
+            XCTAssertEqual(tail.getWholeText(), "")
+        }
+    }
+
+    func testUtf8ContinuationOffsetsThrowWithoutChangingTree() throws {
+        for text in ["日本", "éx", "👩🏽‍💻Z"] {
+            for offset in 0..<text.utf8.count where Array(text.utf8)[offset] & 0xC0 == 0x80 {
+                let doc = try SwiftSoup.parse("<p>\(text)</p>")
+                let p = try XCTUnwrap(doc.select("p").first())
+                let node = try XCTUnwrap(p.childNode(0) as? TextNode)
+                let source = try p.outerHtml()
+                XCTAssertThrowsError(try node.splitText(utf8Offset: offset))
+                XCTAssertEqual(node.getWholeText(), text)
+                XCTAssertEqual(p.getChildNodes().count, 1)
+                XCTAssertEqual(try p.outerHtml(), source)
+            }
+        }
+    }
+
+    func testOutOfRangeUtf8OffsetsThrow() throws {
+        let node = TextNode("日本", "")
+        for offset in [-1, 7, Int.max] { XCTAssertThrowsError(try node.splitText(utf8Offset: offset)) }
+        XCTAssertEqual(node.getWholeText(), "日本")
+    }
+
+    func testMalformedUtf8IsNotSilentlyRepairedByByteSplit() throws {
+        for bytes: [UInt8] in [[0xFF, 0x61], [0xC3, 0x61], [0x61, 0x80], [0xF0, 0x9F]] {
+            let node = TextNode(bytes, [])
+            XCTAssertThrowsError(try node.splitText(utf8Offset: 1))
+            XCTAssertEqual(node.getWholeTextUTF8(), bytes)
+        }
+    }
+
+    func testSplitUpdatesSiblingOrderAndWarmedText() throws {
+        let doc = try SwiftSoup.parse("<p>A<span>日本語</span>Z</p>")
+        let span = try XCTUnwrap(doc.select("span").first())
+        let node = try XCTUnwrap(span.childNode(0) as? TextNode)
+        _ = try doc.text()
+        for _ in 0..<2 { XCTAssertEqual(try doc.select("span:contains(日本語)").size(), 1) }
+        let tail = try node.splitText(utf8Offset: 3)
+        XCTAssertTrue(span.childNode(0) === node)
+        XCTAssertTrue(span.childNode(1) === tail)
+        XCTAssertEqual(tail.siblingIndex, 1)
+        XCTAssertTrue(tail.parent() === span)
+        tail.text("語")
+        XCTAssertEqual(try doc.select("span:contains(日本語)").size(), 0)
+        XCTAssertEqual(try doc.select("span:contains(日語)").size(), 1)
+        XCTAssertEqual(try doc.text(), "A日語Z")
+    }
+
+    func testSplitAfterDirectAttributeEditUsesCurrentContents() throws {
+        let node = TextNode("old", "https://example.test/")
+        let attr = try XCTUnwrap(node.getAttributes().asList().first)
+        attr.setValue(value: Array("日本".utf8))
+        let tail = try node.splitText(utf8Offset: 3)
+        XCTAssertEqual(node.getWholeText(), "日")
+        XCTAssertEqual(tail.getWholeText(), "本")
+        XCTAssertEqual(tail.getBaseUri(), "https://example.test/")
+    }
+
+    func testSplitFragmentedStoragePreservesBytes() throws {
+        let node = TextNode(slice: ByteSlice.fromArray([0xE6]), baseUri: nil)
+        node.appendSlice(ByteSlice.fromArray([0x97, 0xA5, 0xE6]))
+        node.appendSlice(ByteSlice.fromArray([0x9C, 0xAC]))
+        let tail = try node.splitText(utf8Offset: 3)
+        XCTAssertEqual(node.getWholeText(), "日")
+        XCTAssertEqual(tail.getWholeText(), "本")
+    }
+
+    func testTextGetterIsReadOnceForCharacterSplit() throws {
+        final class ProjectedText: TextNode {
+            var reads = 0
+            override func getWholeText() -> String { reads += 1; return "日本語" }
+        }
+        let node = ProjectedText("backing bytes", "")
+        let tail = try node.splitText(1)
+        XCTAssertEqual(node.reads, 1)
+        XCTAssertEqual(node.getWholeTextUTF8(), Array("日".utf8))
+        XCTAssertEqual(tail.getWholeText(), "本語")
+    }
+    func testGeneratedUtf8AndGraphemeBoundaryMatrix() throws {
+        let fragments = ["日本", "e\u{301}", "👩🏽‍💻", "🇯🇵", "\r\n", "a\0b", "\u{600}x", "क्‍ष", "\u{10FFFF}"]
+        for seed in 0..<256 {
+            let text = fragments[seed % fragments.count] + fragments[(seed * 7 + 3) % fragments.count] + String(seed)
+            let bytes = Array(text.utf8)
+            var boundaries: Set<Int> = [0]
+            var position = 0
+            for scalar in text.unicodeScalars {
+                position += scalar.utf8.count
+                boundaries.insert(position)
+            }
+            for offset in 0...bytes.count {
+                let node = TextNode(bytes, nil)
+                if boundaries.contains(offset) {
+                    let tail = try node.splitText(utf8Offset: offset)
+                    XCTAssertEqual(node.getWholeTextUTF8(), Array(bytes.prefix(offset)), "seed \(seed), byte \(offset)")
+                    XCTAssertEqual(tail.getWholeTextUTF8(), Array(bytes.dropFirst(offset)))
+                } else {
+                    XCTAssertThrowsError(try node.splitText(utf8Offset: offset))
+                    XCTAssertEqual(node.getWholeTextUTF8(), bytes)
+                }
+            }
+            for offset in 0...text.count {
+                let node = TextNode(text, nil)
+                let tail = try node.splitText(offset)
+                XCTAssertEqual(node.getWholeTextUTF8(), Array(String(text.prefix(offset)).utf8))
+                XCTAssertEqual(tail.getWholeTextUTF8(), Array(String(text.dropFirst(offset)).utf8))
+            }
+        }
+    }
+
+    func testRepeatedSplitsReconstructAttachedTextAndSource() throws {
+        let text = "日本e\u{301}👩🏽‍💻\r\nZ"
+        let doc = try SwiftSoup.parse("<p></p>")
+        doc.outputSettings().prettyPrint(pretty: false)
+        let parent = try XCTUnwrap(doc.select("p").first())
+        var cursor = TextNode(text, nil)
+        try parent.appendChild(cursor)
+        _ = try parent.text()
+        for scalar in text.unicodeScalars {
+            cursor = try cursor.splitText(utf8Offset: scalar.utf8.count)
+        }
+        let nodes = parent.getChildNodes().compactMap { $0 as? TextNode }
+        XCTAssertEqual(nodes.count, text.unicodeScalars.count + 1)
+        XCTAssertEqual(nodes.flatMap { $0.getWholeTextUTF8() }, Array(text.utf8))
+        XCTAssertEqual(Array(try parent.html().utf8), Array(text.utf8))
+        for (index, node) in nodes.enumerated() {
+            XCTAssertEqual(node.siblingIndex, index)
+            XCTAssertTrue(node.parent() === parent)
+        }
+        let copy = try XCTUnwrap(parent.copy() as? Element)
+        // An element clone is detached; supply the same output settings through
+        // its new document instead of comparing against default pretty printing.
+        let copiedDoc = try SwiftSoup.parse("")
+        copiedDoc.outputSettings().prettyPrint(pretty: false)
+        try copiedDoc.body()!.appendChild(copy)
+        XCTAssertEqual(Array(try copy.html().utf8), Array(text.utf8))
+        cursor.text("added")
+        XCTAssertFalse(try copy.text().contains("added"))
+        XCTAssertTrue(try parent.text().contains("added"))
+    }
+
+    func testByteGetterSnapshotAndBaseUriOverrideArePreserved() throws {
+        final class ProjectedBytes: TextNode {
+            var reads = 0
+            override func getWholeTextUTF8() -> [UInt8] { reads += 1; return Array("日本".utf8) }
+            override func getBaseUriUTF8() -> [UInt8] { Array("https://example.test/raw".utf8) }
+            override func getBaseUri() -> String { "https://example.test/string-projection" }
+        }
+        let node = ProjectedBytes("underlying", nil)
+        let tail = try node.splitText(utf8Offset: 3)
+        XCTAssertEqual(node.reads, 1)
+        XCTAssertEqual(tail.getWholeText(), "本")
+        XCTAssertEqual(tail.getBaseUri(), "https://example.test/raw")
+    }
+
+    func testInvalidSplitKeepsMaterializedAttributeReferenceAndWarmCaches() throws {
+        let doc = try SwiftSoup.parse("<p>日本</p>")
+        let parent = try XCTUnwrap(doc.select("p").first())
+        let node = try XCTUnwrap(parent.childNode(0) as? TextNode)
+        let attr = try XCTUnwrap(node.getAttributes().asList().first)
+        _ = try parent.text()
+        _ = try doc.select("p:contains(日本)")
+        let source = try parent.outerHtml()
+        for offset in [1, 2, 4, 5, 7, Int.max] {
+            XCTAssertThrowsError(try node.splitText(utf8Offset: offset))
+            XCTAssertTrue(node.getAttributes().asList().first === attr)
+            XCTAssertEqual(try parent.outerHtml(), source)
+            XCTAssertTrue(try doc.select("p:contains(日本)").first() === parent)
+        }
+        attr.setValue(value: Array("変更".utf8))
+        XCTAssertEqual(try doc.select("p:contains(日本)").size(), 0)
+        XCTAssertEqual(try parent.text(), "変更")
+    }
+
+}

--- a/Tests/SwiftSoupTests/TreeMutationBoundaryTest.swift
+++ b/Tests/SwiftSoupTests/TreeMutationBoundaryTest.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import SwiftSoup
+
+final class TreeMutationBoundaryTest: XCTestCase {
+    private func fixture() throws -> (Document, Element, Element, Element, Element) {
+        let doc = try SwiftSoup.parse("<main><div id='left'><i id='a'>a</i><i id='b'>b</i><i id='c'>c</i></div><div id='right'></div></main>")
+        let left = try XCTUnwrap(doc.getElementById("left"))
+        return (doc, left, try XCTUnwrap(doc.getElementById("a")), try XCTUnwrap(doc.getElementById("b")), try XCTUnwrap(doc.getElementById("c")))
+    }
+    private func assertChildren(_ parent: Element, _ nodes: [Node], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(parent.childNodeSize(), nodes.count, file: file, line: line)
+        for (i, node) in nodes.enumerated() {
+            guard i < parent.childNodeSize() else { continue }
+            XCTAssertTrue(parent.childNode(i) === node, file: file, line: line)
+            XCTAssertTrue(node.parent() === parent, file: file, line: line)
+            XCTAssertEqual(node.siblingIndex, i, file: file, line: line)
+        }
+    }
+    func testAppendTextInvalidatesWarmedSelectorsAndExternalVersion() throws {
+        let doc = try SwiftSoup.parse("<main><p>old</p></main>")
+        let p = try XCTUnwrap(doc.select("p").first())
+        for root in [doc as Element, p] {
+            for _ in 0..<3 {
+                XCTAssertEqual(try root.select("p:contains(new)").size(), 0)
+                XCTAssertEqual(try root.select("p:matches(new)").size(), 0)
+            }
+        }
+        let version = p.textMutationVersionToken()
+        try p.appendText("new")
+        XCTAssertNotEqual(version, p.textMutationVersionToken())
+        for root in [doc as Element, p] {
+            XCTAssertTrue(try root.select("p:contains(new)").first() === p)
+            XCTAssertTrue(try root.select("p:matches(new)").first() === p)
+        }
+        XCTAssertEqual(try p.text(), "oldnew")
+    }
+    func testAppendDataAndCommentInvalidatesWarmedDataSelectors() throws {
+        for comment in [false, true] {
+            let doc = try SwiftSoup.parse("<main></main>")
+            let root = try XCTUnwrap(doc.select("main").first())
+            for _ in 0..<4 { XCTAssertEqual(try root.select(":containsData(added)").size(), 0) }
+            if comment { try root.appendChild(Comment(Array("added".utf8), [])) }
+            else { try root.appendChild(DataNode(Array("added".utf8), [])) }
+            XCTAssertTrue(try root.select(":containsData(added)").first() === root)
+            XCTAssertEqual(root.data(), "added")
+        }
+    }
+    func testAppendToEmptyInvalidatesEmptySelector() throws {
+        let doc = try SwiftSoup.parse("<p></p>")
+        let p = try XCTUnwrap(doc.select("p:empty").first())
+        for _ in 0..<4 { XCTAssertEqual(try p.select(":empty").size(), 1) }
+        try p.appendChild(TextNode("text", ""))
+        XCTAssertEqual(try p.select(":empty").size(), 0)
+    }
+    func testAppendPopulatedElementChangesTextVersion() throws {
+        let (_, left, _, _, _) = try fixture()
+        let child = try Element(Tag.valueOf("strong"), "").text("added")
+        let version = left.textMutationVersionToken()
+        try left.appendChild(child)
+        XCTAssertNotEqual(version, left.textMutationVersionToken())
+        XCTAssertTrue(try left.text().contains("added"))
+    }
+    func testEmptyDetachesRetainedChildrenAndKeepsSubtreesIntact() throws {
+        let (doc, left, a, b, c) = try fixture()
+        let nested = a.childNode(0)
+        _ = try left.select("i")
+        left.empty()
+        assertChildren(left, [])
+        for child in [a, b, c] { XCTAssertNil(child.parent()); XCTAssertNil(child.ownerDocument()) }
+        XCTAssertTrue(nested.parent() === a)
+        XCTAssertEqual(try doc.select("i").size(), 0)
+        XCTAssertTrue(try a.select("#a").first() === a)
+    }
+    func testEmptyChildrenCanBeReinsertedWithoutRemovingUnrelatedSiblings() throws {
+        let (doc, left, a, b, c) = try fixture()
+        left.empty()
+        let right = try XCTUnwrap(doc.getElementById("right"))
+        try right.appendChild(b)
+        try left.appendChild(a)
+        try right.prependChild(c)
+        assertChildren(left, [a]); assertChildren(right, [c, b])
+        XCTAssertEqual(try doc.select("i").array().map { $0.id() }, ["a", "c", "b"])
+    }
+    func testTextAndHtmlReplacementDetachRetainedChildren() throws {
+        for useHTML in [false, true] {
+            let (_, left, a, b, c) = try fixture()
+            if useHTML { try left.html("<em>replacement</em>") } else { try left.text("replacement") }
+            for child in [a, b, c] { XCTAssertNil(child.parent()) }
+        }
+    }
+    func testSelfReplacementIsNoOpAtEveryPosition() throws {
+        let (_, left, a, b, c) = try fixture()
+        for child in [a, b, c] {
+            let version = left.textMutationVersionToken()
+            try child.replaceWith(child)
+            assertChildren(left, [a, b, c])
+            XCTAssertEqual(version, left.textMutationVersionToken())
+        }
+    }
+    func testInsertExistingChildAtEndUsesOriginalGap() throws {
+        let (_, left, a, b, c) = try fixture()
+        try left.insertChildren(-1, [a])
+        assertChildren(left, [b, c, a])
+    }
+    func testInsertMultipleExistingChildrenUsesOriginalGap() throws {
+        let (_, left, a, b, c) = try fixture()
+        try left.insertChildren(3, [a, b])
+        assertChildren(left, [c, a, b])
+    }
+    func testSiblingMovesBeforeAfterAndSelf() throws {
+        let (_, left, a, b, c) = try fixture()
+        try c.after(a)
+        assertChildren(left, [b, c, a])
+        try b.before(a)
+        assertChildren(left, [a, b, c])
+        try a.before(a)
+        try c.after(c)
+        assertChildren(left, [a, b, c])
+    }
+    func testIndexedInsertionRejectsInvalidOffsetWithoutDetachingInput() throws {
+        let (doc, left, a, b, c) = try fixture()
+        let right = try XCTUnwrap(doc.getElementById("right"))
+        for index in [-1, 1, Int.max] {
+            XCTAssertThrowsError(try right.addChildren(index, [a]))
+            assertChildren(left, [a,b,c]); assertChildren(right, [])
+        }
+    }
+    func testRejectSelfAndAncestorBeforeChangingEitherTree() throws {
+        let (_, left, a, b, c) = try fixture()
+        XCTAssertThrowsError(try left.appendChild(left))
+        XCTAssertThrowsError(try a.appendChild(left))
+        assertChildren(left, [a,b,c])
+    }
+    func testReplacementRejectsAncestorBeforeDetachingIt() throws {
+        let (doc, left, a, b, c) = try fixture()
+        let main = try XCTUnwrap(doc.select("main").first())
+        XCTAssertThrowsError(try a.replaceWith(main))
+        XCTAssertTrue(left.parent() === main)
+        assertChildren(left, [a,b,c])
+    }
+    func testBatchRejectsAncestorAtomically() throws {
+        for indexed in [false, true] {
+            let (doc, left, a, b, c) = try fixture()
+            let right = try XCTUnwrap(doc.getElementById("right"))
+            if indexed { XCTAssertThrowsError(try a.addChildren(0, [right, left])) }
+            else { XCTAssertThrowsError(try a.addChildren([right, left])) }
+            XCTAssertTrue(right.parent() === left.parent())
+            assertChildren(left, [a,b,c])
+        }
+    }
+    func testSetParentRejectsCycleBeforeDetaching() throws {
+        let (_, left, a, b, c) = try fixture()
+        XCTAssertThrowsError(try left.setParentNode(a))
+        assertChildren(left, [a,b,c])
+    }
+    func testExistingSiblingReplacementPreservesIdentityOrder() throws {
+        for earlier in [false, true] {
+            let (_, left, a, b, c) = try fixture()
+            if earlier { try c.replaceWith(a); assertChildren(left, [b,a]); XCTAssertNil(c.parent()) }
+            else { try a.replaceWith(c); assertChildren(left, [c,b]); XCTAssertNil(a.parent()) }
+        }
+    }
+    func testRepeatedReferenceInsertionDoesNotDuplicateNodes() throws {
+        let (_, left, a, b, c) = try fixture()
+        try left.insertChildren(-1, [a,b,a])
+        assertChildren(left, [c,a,b])
+    }
+}

--- a/Tests/SwiftSoupTests/TreeMutationModelTest.swift
+++ b/Tests/SwiftSoupTests/TreeMutationModelTest.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import SwiftSoup
+
+final class TreeMutationModelTest: XCTestCase {
+    private func check(_ parent: Element, _ expected: [Node], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(parent.getChildNodes().map(ObjectIdentifier.init), expected.map(ObjectIdentifier.init), file: file, line: line)
+        for (i, child) in expected.enumerated() {
+            XCTAssertTrue(child.parent() === parent, file: file, line: line)
+            XCTAssertEqual(child.siblingIndex, i, file: file, line: line)
+            XCTAssertTrue(child.previousSibling() === (i == 0 ? nil : expected[i - 1]), file: file, line: line)
+            XCTAssertTrue(child.nextSibling() === (i + 1 == expected.count ? nil : expected[i + 1]), file: file, line: line)
+        }
+    }
+
+    func testExhaustiveIndexedMovesAgreeWithOriginalGapModel() throws {
+        var states = 0
+        for count in 0...4 {
+            let width = count + 2 // Include two detached input nodes.
+            for length in 0...3 {
+                let combinations = (0..<length).reduce(1) { value, _ in value * width }
+                for encoded in 0..<combinations {
+                    var remaining = encoded
+                    var sequence: [Int] = []
+                    for _ in 0..<length { sequence.append(remaining % width); remaining /= width }
+                    for gap in 0...count {
+                        let parent = Element(try Tag.valueOf("div"), "")
+                        let nodes = try (0..<width).map { _ in Element(try Tag.valueOf("i"), "") }
+                        for child in nodes.prefix(count) { try parent.appendChild(child) }
+                        var seen = Set<Int>()
+                        let unique = sequence.filter { seen.insert($0).inserted }
+                        let prefix = (0..<gap).filter { !seen.contains($0) }
+                        let suffix = (gap..<count).filter { !seen.contains($0) }
+                        let expected = (prefix + unique + suffix).map { nodes[$0] as Node }
+                        try parent.insertChildren(gap, sequence.map { nodes[$0] })
+                        check(parent, expected)
+                        for index in count..<width where !seen.contains(index) { XCTAssertNil(nodes[index].parent()) }
+                        states += 1
+                    }
+                }
+            }
+        }
+        XCTAssertEqual(states, 2269)
+    }
+
+    private func independentScan(_ root: Element, _ evaluator: Evaluator) throws -> [ObjectIdentifier] {
+        var stack = [root]
+        var result: [ObjectIdentifier] = []
+        while let node = stack.popLast() {
+            if try evaluator.matches(root, node) { result.append(ObjectIdentifier(node)) }
+            for child in node.getChildNodes().reversed() {
+                if let element = child as? Element { stack.append(element) }
+            }
+        }
+        return result
+    }
+
+    func testMutationSequenceMatchesIndependentParentAndSelectorModels() throws {
+        let doc = try SwiftSoup.parse("<main><section id='a'></section><section id='b'></section></main>")
+        let a = try XCTUnwrap(doc.getElementById("a"))
+        let b = try XCTUnwrap(doc.getElementById("b"))
+        let parents = [a, b]
+        let nodes = try (0..<8).map { index -> Element in
+            let node = Element(try Tag.valueOf("i"), "")
+            try node.attr("id", "n\(index)").attr("class", "item").text("v\(index)")
+            return node
+        }
+        var model: [[Int]] = [[], []]
+        var state: UInt64 = 0x79A3845
+        func next(_ limit: Int) -> Int {
+            state = state &* 6364136223846793005 &+ 1442695040888963407
+            return Int((state >> 32) % UInt64(limit))
+        }
+        let queries = ["i", ".item", "section:empty", "section > i:first-child", "i + i", "i:nth-child(2)", "i:contains(extra)", "section:containsData(data)", "#n3"]
+        for step in 0..<384 {
+            let destination = next(2)
+            let chosen = next(nodes.count)
+            switch next(6) {
+            case 0, 1:
+                let gap = next(model[destination].count + 1)
+                let input = [chosen, next(nodes.count), chosen]
+                var seen = Set<Int>()
+                let unique = input.filter { seen.insert($0).inserted }
+                let prefix = model[destination].prefix(gap).filter { !seen.contains($0) }
+                let suffix = model[destination].dropFirst(gap).filter { !seen.contains($0) }
+                for i in model.indices { model[i].removeAll { seen.contains($0) } }
+                model[destination] = prefix + unique + suffix
+                // Character/data children are appended only to the leaf elements.
+                try parents[destination].insertChildren(gap, input.map { nodes[$0] })
+            case 2:
+                try nodes[chosen].remove()
+                for i in model.indices { model[i].removeAll { $0 == chosen } }
+            case 3:
+                parents[destination].empty()
+                model[destination] = []
+            case 4:
+                try nodes[chosen].appendText("extra")
+            default:
+                try nodes[chosen].appendChild(DataNode(Array("data".utf8), []))
+            }
+            for i in model.indices { check(parents[i], model[i].map { nodes[$0] }) }
+            for i in nodes.indices where !model.joined().contains(i) { XCTAssertNil(nodes[i].parent()) }
+            for root in [doc as Element, a, b, nodes[chosen]] {
+                for query in queries {
+                    let evaluator = try QueryParser.parse(query)
+                    let expected = try independentScan(root, evaluator)
+                    XCTAssertEqual(try Collector.collect(evaluator, root).array().map(ObjectIdentifier.init), expected, "step \(step): \(query)")
+                    for _ in 0..<3 {
+                        XCTAssertEqual(try root.select(query).array().map(ObjectIdentifier.init), expected, "step \(step): \(query)")
+                    }
+                }
+            }
+        }
+    }
+
+    func testCrossDocumentMovesInvalidateOldAndNewRoots() throws {
+        let left = try SwiftSoup.parse("<main><i id='move'>payload</i></main>")
+        let right = try SwiftSoup.parse("<main></main>")
+        let node = try XCTUnwrap(left.getElementById("move"))
+        let roots = [try XCTUnwrap(left.select("main").first()), try XCTUnwrap(right.select("main").first())]
+        for iteration in 0..<64 {
+            for root in [left as Element, right, roots[0], roots[1], node] {
+                for _ in 0..<3 { _ = try root.select("#move:contains(payload)") }
+            }
+            let destination = roots[(iteration + 1) % 2]
+            try destination.appendChild(node)
+            for root in [left as Element, right, roots[0], roots[1], node] {
+                let query = "#move:contains(payload)"
+                XCTAssertEqual(try root.select(query).array().map(ObjectIdentifier.init), try independentScan(root, QueryParser.parse(query)))
+            }
+            XCTAssertTrue(node.ownerDocument() === (iteration % 2 == 0 ? right : left))
+        }
+    }
+
+    func testEmptyDetachesWithoutRetainingFormerDocument() throws {
+        weak var observed: Document?
+        let retained: Element
+        do {
+            let doc = try SwiftSoup.parse("<div><i id='retained'>text</i></div>")
+            observed = doc
+            let div = try XCTUnwrap(doc.select("div").first())
+            retained = try XCTUnwrap(div.select("i").first())
+            for _ in 0..<4 { _ = try retained.select("i:contains(text)") }
+            div.empty()
+            XCTAssertNil(retained.parent())
+        }
+        XCTAssertNil(observed)
+        XCTAssertEqual(try retained.text(), "text")
+    }
+}


### PR DESCRIPTION
Part 6/8 of the SwiftSoup correctness/runtime reconciliation from lake-of-fire/SwiftSoup. Depends on #416. This PR targets that topic branch so its diff is incremental; review/merge the stack in order and retarget to master as prerequisites land.

Reconciles DOM identity hashing, cache ownership/lifetime, shared Attribute mutation notification, lazy/deferred attribute reads, clone isolation, validated tree mutations and text splitting. It also retains reviewed sibling/child traversal and parser-fragment refinements, preserving custom accessors. SelectorQueryKey is included here because Element result-cache storage uses it. Selector parser/index behavior is completed in the next PR; selector-specific cross-layer tests accompany that part. This is the larger coupled ownership/mutation layer, kept together to avoid transient inconsistent owner/index states.

Validation: `swift test -c release --jobs 2` on Apple Swift 6.3.3 / arm64 macOS: Executed 1169 tests, with 17 tests skipped and 0 failures (0 unexpected) in 10.333 (10.423) seconds.

Built on current upstream `35f7e1b0049236edcc351c0f10e7beddd0d4e76c`; upstream PR #411 and its escaped-ID regression coverage are retained. Source is extracted from the reviewed fork tree `a197bd5620a062f210686541dd38499c1913d342` without importing its merge/publication-workflow history. Exact head: `fd2975e5a9e056dfac156ed2f37878ec1bd4c29e`.

No new performance measurements are claimed for this integration under host load. Historical evidence is kept separate in part 8. This submission does not update upstream master or a release branch.

Stack order: #412 → #413 → #414 → #415 → #416 → #417 → #418 → #419.

The empty-value selector integration method from AttributeOwnershipTest is introduced in part 7 with its predicate fixes; other ownership methods stay here. No assertion is weakened.
