### PR TITLE
Add reproducible optimization benchmarks and qualification reports

### DIFF
--- a/Benchmarks/entity-decoding-20260909.md
+++ b/Benchmarks/entity-decoding-20260909.md
@@ -1,0 +1,107 @@
+# Use the existing dictionary for multipoint entity lookup
+
+The ByteSlice fallback scanned every entry in the existing multipoint-entity dictionary, including misses before a long single-scalar lookup. It now uses the dictionary's subscript with the existing `toArraySlice()` conversion. This is **one replacement expression**, not another cache or lookup table. Array-backed names share slice storage; Data/pointer-backed names use a short-lived byte copy, which is included in the end-to-end Data and pointer-input measurements. Common packed-name lookup, case sensitivity, extended/base admission and entity tables are unchanged.
+
+Six new regression methods independently parse all **2,125** names from the declarative entity table, check extended and base admission, unknown/case/truncated names, nonzero array and Data indices, pointer storage, COW snapshots, repeated lookup, semicolon rules, and public String/Data/borrowed-buffer parsing. The dictionary query slice is not retained after lookup.
+
+### Independent confirmation
+
+Target 400 ms timed work per process, fixture size 64. `unescape-multi` uses two-scalar names such as `NotEqualTilde`; `unescape-long` uses long one-scalar names such as `CounterClockwiseContourIntegral`; `unescape-unknown` exercises misses. Parse cases contain 64 paragraphs and include parsing plus `text()` extraction. They are deliberately entity-heavy, not claims about normal web-page prevalence. Both Data and caller-borrowed-pointer input include the temporary conversion cost.
+
+| Workload | Reference ms | Candidate ms | Less time | 95% interval |
+| --- | ---: | ---: | ---: | ---: |
+| unescape-multi | 0.095792 | 0.056377 | +41.15% | +36.40 to +45.54% |
+| unescape-long | 0.124962 | 0.066814 | +46.53% | +45.25 to +47.78% |
+| unescape-unknown | 1.065441 | 0.987711 | +7.30% | +4.84 to +9.69% |
+| unescape-common | 0.026962 | 0.026970 | -0.03% | -1.88 to +1.79% |
+| parse-multi-data | 0.348443 | 0.311125 | +10.71% | +8.12 to +13.22% |
+| parse-long-buffer | 0.373229 | 0.312480 | +16.28% | +14.87 to +17.66% |
+| parse-normal-string | 0.268462 | 0.269777 | -0.49% | -3.65 to +2.57% |
+
+## Scope and exact reference
+
+Independent change on fork master `cb57c9e160da093c7dd87eb91d335b6891d0efb7`. The numerical study instead compares the already-optimized PR #3 at `c9c37c80eb571aabba59a1f3ef31af9b072af4a8` with that exact production tree plus only this change. The reference Sources Git tree is `98e22c134afa5144fe64565f448260239545f90f`. Both revisions have identical original `Entities.swift`, blob `9a8e292e58323cedb86e834cc24c8bf14af89739`.
+
+PRs #1–#7 were audited by scope and changed-file lists; none changes Entities. A later recheck included the new regex PR #8, which changes Pattern, not Entities. No existing PR head, master, dependency pin, source-range setting, or parser default was changed. This does not incorporate or supersede the selector/ownership correctness stack.
+
+The two entity PRs change different helpers and are independently reviewable against master. Their two Tools files are intentionally byte-identical, so they share one portable harness after merging either order.
+
+## Measurement protocol
+
+Swift 6.2.1, Linux x86_64, CPU 0 affinity, `-O -g -whole-module-optimization -swift-version 6` shipping libraries **without `-enable-testing`**. One identical optimized public client dynamically loads each library. Fixture setup, compilation, full-output verification, sanitizer tests and profiling are outside timed intervals. Three in-process warmups precede each timed loop. Hashing is randomized normally; it is not made deterministic for timing.
+
+Confirmation uses 12 balanced ABBA/BAAB blocks: **24 fresh processes per revision per workload**. Each block averages the two log times per revision; the table reports geometric-mean milliseconds per operation and a paired-block Student t 95% interval for the log time ratio, transformed to percent less time. Positive means faster. These are exploratory intervals without multiple-comparison correction, not predictions for another machine or production traffic. Wall and process CPU values, calibrations, all raw process records and exact command/library/client/source hashes are retained. No sample/outlier is deleted.
+
+The initial screen (six blocks, 12 processes per revision per workload) is retained separately rather than pooled selectively into confirmation. Targeted and ASCII A/A controls use eight blocks; Reader A/A uses six. All wall-clock A/A intervals include zero; the multipoint-entity A/A interval is especially wide because randomized dictionary ordering affects the baseline linear scan. This uncertainty is not hidden.
+
+## Reader controls: no general application claim
+
+Both entity changes together were also compared with unchanged PR #3 in eight balanced blocks, 16 fresh processes per revision per workload, target 400 ms per process, retained medium/byte-input Reader fixtures. Proper deep-copy injection is measured; shallow-copy paths are only equality sentinels. These SwiftSoup-side replays exclude morphology, Realm/dictionary I/O, WebKit, and UI.
+
+| Workload | Reference ms | Candidate ms | Less time | 95% interval |
+| --- | ---: | ---: | ---: | ---: |
+| manabi-parse | 3.745240 | 3.801148 | -1.49% | -4.53 to +1.46% |
+| manabi-injection-deep | 23.271460 | 22.932565 | +1.46% | -1.36 to +4.19% |
+| manabi-ruby | 5.326387 | 5.349208 | -0.43% | -1.70 to +0.83% |
+| manabi-inner | 0.018072 | 0.017880 | +1.07% | -0.89 to +2.98% |
+
+Every Reader interval spans zero. No overall Reader speedup, universal parser gain, Apple-device performance result, or iPhone result is claimed. The two successful helper-specific results do not change that conclusion.
+
+## Behavioral verification
+
+On the exact PR #3 build inputs, the unchanged reference plus both new test files passes the native release suite: **818 cases, 801 passed, 17 opt-in benchmarks skipped, zero failures**. Each isolated candidate plus its own six new tests passes **812 cases, 795 passed, 17 skipped, zero failures**. The new tests also pass against unchanged production source: these are behavior-preserving optimizations, not correctness fixes. No existing test was removed or weakened.
+
+All four shipping variants (reference, escaping only, lookup only, both) match **9,408 full DOM records**, **4,608 contextual-fragment records**, and **72 nonempty Reader output sets** byte-for-byte. DOM output SHA-256: `c243b0307f2fbfaeb781bd5786ac51e9e66f659c165b9f33f1590345416b6ca1`; fragment output SHA-256: `1c582c7608ddef757b25c57b270e4e63460a21a871025db35dcb60edf5585a98`.
+
+The inherited Reader parse-only observer emitted an empty array, so six of its nominal 72 sets did not observe a parsed result. A separate verification-only client now records regenerated HTML and text for parse-only (and ruby-parse), rejects empty output, and was run across all variants. **The timed Reader client was not changed.** This correction is evidence tooling, not a change to another worker's production PR or retrospective validation of its historical results.
+
+The combined production candidate also passes the complete native AddressSanitizer release suite: **818 cases, 801 passed, 17 skipped, zero failures**, with `ASAN_OPTIONS=detect_leaks=0`. This is not a leak check.
+
+Native CI for the master-based PR is a separate check, not the source of the above PR #3 integration counts. See the PR's checks for the exact published head. ASan results, when reported, use `detect_leaks=0` and do not establish leak freedom.
+
+## Portable reproduction
+
+The committed public client is the exact source used for final entity confirmation. The committed Python runner applies the same comparison protocol with configurable paths; it is not a copy of the study's machine-specific orchestration paths.
+
+To repeat the exact measured reference, make two detached worktrees at `c9c37c80eb571aabba59a1f3ef31af9b072af4a8`, then apply **only this PR's `Sources/Entities.swift` diff from master** to the candidate. Do not include the other entity change in an isolated comparison. To measure master itself instead, use two master-based worktrees and label that a new experiment.
+
+With `BASE` and `CANDIDATE` pointing to those worktrees, and `OUT` an absolute new build directory:
+
+```sh
+mkdir -p "$OUT/base" "$OUT/candidate"
+ext=so
+[ "$(uname -s)" = Darwin ] && ext=dylib
+for variant in base candidate; do
+  root="$BASE"
+  [ "$variant" = candidate ] && root="$CANDIDATE"
+  swiftc -swift-version 6 -O -g -whole-module-optimization \
+    -emit-library -emit-module -module-name SwiftSoup "$root"/Sources/*.swift \
+    -emit-module-path "$OUT/$variant/SwiftSoup.swiftmodule" \
+    -o "$OUT/$variant/libSwiftSoup.$ext"
+done
+swiftc -O -g -I "$OUT/base" -L "$OUT/base" -lSwiftSoup \
+  Tools/benchmark_entities.swift -o "$OUT/benchmark-entities"
+```
+
+Run the command below, then repeat with `--aa` and a **different** output prefix. The runner pins an allowed CPU on Linux and records lack of affinity on macOS. It compares complete public outputs before timing, checks timed checksums, and refuses to overwrite an existing run. Never time concurrently with compilation, sanitizer runs or a profiler. Host-specific path/binary hashes will necessarily differ from this study.
+
+```sh
+python3 Tools/compare_entity_benchmarks.py \
+  --baseline-library "$OUT/base" --candidate-library "$OUT/candidate" \
+  --client "$OUT/benchmark-entities" --blocks 12 --ms 400 --size 64 \
+  --workloads unescape-multi unescape-long unescape-unknown unescape-common parse-multi-data parse-long-buffer parse-normal-string \
+  --output "$OUT/lookup-ab"
+# Repeat with --aa and --output "$OUT/lookup-aa".
+```
+
+Normal project correctness checks remain `swift test -c release` and, where supported, `ASAN_OPTIONS=detect_leaks=0 swift test -c release --sanitize address`. The benchmark does not change Package.swift or add dependencies.
+
+## Measured artifact identities
+
+- Reference library SHA-256: `97486712c374feabf95d22d9ae8564ee427e80e210388bee7bf963231ada16f9`
+- Candidate library SHA-256: `da8fbbb62f5d243fe7250b6a8b0d114dd3382ca31bd03b0071bbeb2994517b5f`
+- Identical final client SHA-256: `22672ec15224612f36814f41a8ac792c7d24c550f903f66da8c2b15cb9e51154`
+- Candidate Entities Git blob: `61c723bfd79b7bdadf8a6f79e0af6045b4e5de21`
+- Runtime patch SHA-256: `2d67086d42310be5f12a2a04557ed2667309016296975ce619235f3363f44132`
+
+Complete raw screen/confirmation/A/A records, CPU results, calibration records, fixture and source manifests, failed/neutral observations, exact source snapshots, test logs and complete output sets are retained in the companion delivery bundle. Do not substitute an earlier other-worker report for this experiment.

--- a/Benchmarks/entity-escaping-20260909.md
+++ b/Benchmarks/entity-escaping-20260909.md
@@ -1,0 +1,113 @@
+# Batch pass-through Unicode runs during entity escaping
+
+The UTF escaping helper used to invoke the internal buffer writer for every non-ASCII sequence. It now copies adjacent pass-through sequences together. ASCII replacements, NBSP replacements, custom public replacement callbacks and their order are unchanged. It stops at the same byte boundaries and retains the historical permissive lead-byte stepping for malformed/truncated bytes; it does not silently replace that with a validating UTF-8 decoder. No new cache, state, public API, or normalization policy.
+
+Six new regression methods include an independent byte oracle, 2,048 seeded malformed byte strings, every byte lead at truncation boundaries, combining marks and emoji, base/extended/XHTML, UTF-8/UTF-16 output settings, attribute/text contexts, array/offset-array/Data/nonzero-index-Data/pointer storage, builder aliases and retained snapshots, custom append callbacks, normalization controls, and source-less regenerated HTML.
+
+### Independent confirmation
+
+Target 500 ms timed work per process, fixture size 128. `escape-japanese` contains long continuous Japanese runs plus a required escape. `escape-mixed` interleaves Japanese, ASCII, emoji, combining marks, NBSP and markup. `serialize-japanese` regenerates a source-less 128-paragraph document with text and title attributes; it does not reuse original HTML source. These synthetic inputs expose the helper, not a measured traffic distribution.
+
+| Workload | Reference ms | Candidate ms | Less time | 95% interval |
+| --- | ---: | ---: | ---: | ---: |
+| escape-japanese | 0.020657 | 0.011167 | +45.94% | +44.59 to +47.26% |
+| escape-mixed | 0.036759 | 0.030078 | +18.17% | +14.68 to +21.52% |
+| serialize-japanese | 0.242221 | 0.150415 | +37.90% | +36.56 to +39.22% |
+| escape-plain | 0.004125 | 0.004108 | +0.41% | -2.43 to +3.17% |
+
+### Small/ASCII control confirmation
+
+Twelve blocks at target 500 ms; an initial median suggested a small ASCII slowdown, but neither the longer repeat nor its A/A control establishes one. Already-safe strings keep their pre-existing no-escaping fast path.
+
+| Workload | Reference ms | Candidate ms | Less time | 95% interval |
+| --- | ---: | ---: | ---: | ---: |
+| escape-ascii | 0.015277 | 0.015022 | +1.67% | -0.75 to +4.02% |
+| escape-short | 0.000313 | 0.000310 | +1.10% | -0.85 to +3.01% |
+
+## Scope and exact reference
+
+Independent change on fork master `cb57c9e160da093c7dd87eb91d335b6891d0efb7`. The numerical study instead compares the already-optimized PR #3 at `c9c37c80eb571aabba59a1f3ef31af9b072af4a8` with that exact production tree plus only this change. The reference Sources Git tree is `98e22c134afa5144fe64565f448260239545f90f`. Both revisions have identical original `Entities.swift`, blob `9a8e292e58323cedb86e834cc24c8bf14af89739`.
+
+PRs #1–#7 were audited by scope and changed-file lists; none changes Entities. A later recheck included the new regex PR #8, which changes Pattern, not Entities. No existing PR head, master, dependency pin, source-range setting, or parser default was changed. This does not incorporate or supersede the selector/ownership correctness stack.
+
+The two entity PRs change different helpers and are independently reviewable against master. Their two Tools files are intentionally byte-identical, so they share one portable harness after merging either order.
+
+## Measurement protocol
+
+Swift 6.2.1, Linux x86_64, CPU 0 affinity, `-O -g -whole-module-optimization -swift-version 6` shipping libraries **without `-enable-testing`**. One identical optimized public client dynamically loads each library. Fixture setup, compilation, full-output verification, sanitizer tests and profiling are outside timed intervals. Three in-process warmups precede each timed loop. Hashing is randomized normally; it is not made deterministic for timing.
+
+Confirmation uses 12 balanced ABBA/BAAB blocks: **24 fresh processes per revision per workload**. Each block averages the two log times per revision; the table reports geometric-mean milliseconds per operation and a paired-block Student t 95% interval for the log time ratio, transformed to percent less time. Positive means faster. These are exploratory intervals without multiple-comparison correction, not predictions for another machine or production traffic. Wall and process CPU values, calibrations, all raw process records and exact command/library/client/source hashes are retained. No sample/outlier is deleted.
+
+The initial screen (six blocks, 12 processes per revision per workload) is retained separately rather than pooled selectively into confirmation. Targeted and ASCII A/A controls use eight blocks; Reader A/A uses six. All wall-clock A/A intervals include zero; the multipoint-entity A/A interval is especially wide because randomized dictionary ordering affects the baseline linear scan. This uncertainty is not hidden.
+
+## Reader controls: no general application claim
+
+Both entity changes together were also compared with unchanged PR #3 in eight balanced blocks, 16 fresh processes per revision per workload, target 400 ms per process, retained medium/byte-input Reader fixtures. Proper deep-copy injection is measured; shallow-copy paths are only equality sentinels. These SwiftSoup-side replays exclude morphology, Realm/dictionary I/O, WebKit, and UI.
+
+| Workload | Reference ms | Candidate ms | Less time | 95% interval |
+| --- | ---: | ---: | ---: | ---: |
+| manabi-parse | 3.745240 | 3.801148 | -1.49% | -4.53 to +1.46% |
+| manabi-injection-deep | 23.271460 | 22.932565 | +1.46% | -1.36 to +4.19% |
+| manabi-ruby | 5.326387 | 5.349208 | -0.43% | -1.70 to +0.83% |
+| manabi-inner | 0.018072 | 0.017880 | +1.07% | -0.89 to +2.98% |
+
+Every Reader interval spans zero. No overall Reader speedup, universal parser gain, Apple-device performance result, or iPhone result is claimed. The two successful helper-specific results do not change that conclusion.
+
+## Behavioral verification
+
+On the exact PR #3 build inputs, the unchanged reference plus both new test files passes the native release suite: **818 cases, 801 passed, 17 opt-in benchmarks skipped, zero failures**. Each isolated candidate plus its own six new tests passes **812 cases, 795 passed, 17 skipped, zero failures**. The new tests also pass against unchanged production source: these are behavior-preserving optimizations, not correctness fixes. No existing test was removed or weakened.
+
+All four shipping variants (reference, escaping only, lookup only, both) match **9,408 full DOM records**, **4,608 contextual-fragment records**, and **72 nonempty Reader output sets** byte-for-byte. DOM output SHA-256: `c243b0307f2fbfaeb781bd5786ac51e9e66f659c165b9f33f1590345416b6ca1`; fragment output SHA-256: `1c582c7608ddef757b25c57b270e4e63460a21a871025db35dcb60edf5585a98`.
+
+The inherited Reader parse-only observer emitted an empty array, so six of its nominal 72 sets did not observe a parsed result. A separate verification-only client now records regenerated HTML and text for parse-only (and ruby-parse), rejects empty output, and was run across all variants. **The timed Reader client was not changed.** This correction is evidence tooling, not a change to another worker's production PR or retrospective validation of its historical results.
+
+The combined production candidate also passes the complete native AddressSanitizer release suite: **818 cases, 801 passed, 17 skipped, zero failures**, with `ASAN_OPTIONS=detect_leaks=0`. This is not a leak check.
+
+Native CI for the master-based PR is a separate check, not the source of the above PR #3 integration counts. See the PR's checks for the exact published head. ASan results, when reported, use `detect_leaks=0` and do not establish leak freedom.
+
+## Portable reproduction
+
+The committed public client is the exact source used for final entity confirmation. The committed Python runner applies the same comparison protocol with configurable paths; it is not a copy of the study's machine-specific orchestration paths.
+
+To repeat the exact measured reference, make two detached worktrees at `c9c37c80eb571aabba59a1f3ef31af9b072af4a8`, then apply **only this PR's `Sources/Entities.swift` diff from master** to the candidate. Do not include the other entity change in an isolated comparison. To measure master itself instead, use two master-based worktrees and label that a new experiment.
+
+With `BASE` and `CANDIDATE` pointing to those worktrees, and `OUT` an absolute new build directory:
+
+```sh
+mkdir -p "$OUT/base" "$OUT/candidate"
+ext=so
+[ "$(uname -s)" = Darwin ] && ext=dylib
+for variant in base candidate; do
+  root="$BASE"
+  [ "$variant" = candidate ] && root="$CANDIDATE"
+  swiftc -swift-version 6 -O -g -whole-module-optimization \
+    -emit-library -emit-module -module-name SwiftSoup "$root"/Sources/*.swift \
+    -emit-module-path "$OUT/$variant/SwiftSoup.swiftmodule" \
+    -o "$OUT/$variant/libSwiftSoup.$ext"
+done
+swiftc -O -g -I "$OUT/base" -L "$OUT/base" -lSwiftSoup \
+  Tools/benchmark_entities.swift -o "$OUT/benchmark-entities"
+```
+
+Run the command below, then repeat with `--aa` and a **different** output prefix. The runner pins an allowed CPU on Linux and records lack of affinity on macOS. It compares complete public outputs before timing, checks timed checksums, and refuses to overwrite an existing run. Never time concurrently with compilation, sanitizer runs or a profiler. Host-specific path/binary hashes will necessarily differ from this study.
+
+```sh
+python3 Tools/compare_entity_benchmarks.py \
+  --baseline-library "$OUT/base" --candidate-library "$OUT/candidate" \
+  --client "$OUT/benchmark-entities" --blocks 12 --ms 500 --size 128 \
+  --workloads escape-japanese escape-mixed serialize-japanese escape-plain escape-ascii escape-short \
+  --output "$OUT/escape-ab"
+# Repeat with --aa and --output "$OUT/escape-aa".
+```
+
+Normal project correctness checks remain `swift test -c release` and, where supported, `ASAN_OPTIONS=detect_leaks=0 swift test -c release --sanitize address`. The benchmark does not change Package.swift or add dependencies.
+
+## Measured artifact identities
+
+- Reference library SHA-256: `97486712c374feabf95d22d9ae8564ee427e80e210388bee7bf963231ada16f9`
+- Candidate library SHA-256: `8224610433f55df4fa9d408d02a750dcbc5de43f8e0cc503d3826e42aa06c99f`
+- Identical final client SHA-256: `22672ec15224612f36814f41a8ac792c7d24c550f903f66da8c2b15cb9e51154`
+- Candidate Entities Git blob: `8dc30c59cabd7d9156a5bab3e92539e0682ec93d`
+- Runtime patch SHA-256: `e7d0ee7f5df9441a37397ed089ee0bcbc54504b8f061a17a2f519b2c27928e71`
+
+Complete raw screen/confirmation/A/A records, CPU results, calibration records, fixture and source manifests, failed/neutral observations, exact source snapshots, test logs and complete output sets are retained in the companion delivery bundle. Do not substitute an earlier other-worker report for this experiment.

--- a/Benchmarks/fragment-append-confirmation-20260908.md
+++ b/Benchmarks/fragment-append-confirmation-20260908.md
@@ -1,0 +1,112 @@
+# Fragment-append confirmation — September 8, 2026
+
+This is a fresh confirmation of the published changes, not a replacement for the earlier study or a claim that its entire raw archive is reproduced here.
+
+## Exact revisions
+
+- Baseline: `79c79cc99249e45e51f36f574eab28241c40197c` (already contains the preceding DOM primitive optimizations).
+- Upstream-ready candidate: `37f5f85d45e594b96b55fea279b90161a90968a0` on `perf/dom-primitives-upstream-20260908`.
+- Fork integration: `0bd3cb4ad29d79820ffe6c2dbe9d0706359962dc` on `perf/dom-primitives-20260908`, PR #3.
+
+The incremental runtime change is six additions and nine deletions across Attribute, TextNode and DataNode: append directly to the optional fragment array instead of making an additional array value, appending, and assigning it back. Cache invalidation, mutation tokens, accumulated lengths, and materialization order remain unchanged. The fork integration preserves the older runtime stack and upstream's escaped-ID fix. No parser option is changed; in particular, source-range tracking is not disabled by these optimizations.
+
+## Portable A/B repeat
+
+Swift 6.2.1, Linux x86_64; optimized standalone XCTest clients and release libraries (`-O -g -whole-module-optimization -enable-testing` for libraries). CPU affinity pinned to 0. Compilation, behavioral checks and timing were separate. Each operation uses the exact committed FragmentAppendBenchmarkTest source, 256 fragments, 1,000 timed iterations, three warmups, six balanced ABBA/BAAB blocks, and 12 fresh processes per revision. No outliers were removed.
+
+Geometric-mean milliseconds per operation; positive percentages mean less time. Intervals are exploratory paired-block 95% t intervals on log time ratios, without multiple-comparison adjustment. They do not represent other machines or production traffic.
+
+| Operation | Baseline ms | Candidate ms | Less time | 95% interval |
+|---|---:|---:|---:|---:|
+| attribute | 0.260973 | 0.025893 | +90.1% | +89.6 to +90.5% |
+| data | 0.261975 | 0.021965 | +91.6% | +91.2 to +92.0% |
+| parse-attribute | 0.101143 | 0.102085 | -0.9% | -5.7 to +3.7% |
+| parse-coalesced | 0.701111 | 0.419226 | +40.2% | +37.7 to +42.6% |
+| parse-discarded | 0.559111 | 0.553148 | +1.1% | -0.8 to +2.9% |
+| parse-script | 0.212531 | 0.209720 | +1.3% | -4.2 to +6.6% |
+| parse-text | 0.088264 | 0.081062 | +8.2% | +2.6 to +13.4% |
+| text | 0.276857 | 0.029196 | +89.5% | +89.1 to +89.8% |
+
+`text`, `data` and `attribute` measure construction, repeated accumulation and materialization, not a whole parser. `parse-coalesced` is a deliberately interrupted-text parser stress test with source ranges disabled. `parse-discarded` uses the same interrupted input with source ranges enabled. This is not a reason to disable source ranges in Manabi. The other parser cases use entity-rich text, an entity-rich attribute and script content respectively. These synthetic cases do not establish workload prevalence.
+
+## Reader controls, including the negative results
+
+The external deterministic Manabi-style replays exclude morphology, dictionary/Realm I/O, WebKit and UI. Publication uses proper deep copies rather than the application's previously identified shallow-copy behavior. The confirmation and independent control repeat use 12 and 24 fresh process runs per revision respectively.
+
+| Pass | Operation | Baseline ms | Candidate ms | Less time | 95% interval |
+|---|---|---:|---:|---:|---:|
+| initial | manabi-parse | 8.3302 | 8.4541 | -1.5% | -6.1 to +2.9% |
+| initial | manabi-injection-deep | 55.2623 | 54.7782 | +0.9% | -4.3 to +5.7% |
+| initial | manabi-publish-deep | 7.1998 | 7.7678 | -7.9% | -18.0 to +1.4% |
+| initial | manabi-highlight | 2.9011 | 2.7696 | +4.5% | +0.4 to +8.5% |
+| initial | manabi-ruby | 11.0913 | 11.1444 | -0.5% | -2.5 to +1.5% |
+| repeat | manabi-publish-deep | 7.4747 | 7.2548 | +2.9% | -0.2 to +6.0% |
+| repeat | manabi-injection-deep | 57.0095 | 57.2986 | -0.5% | -3.4 to +2.3% |
+| repeat | manabi-highlight | 2.8719 | 2.8845 | -0.4% | -2.9 to +2.0% |
+
+The initial publication slowdown did not reproduce. The initial highlighting improvement also did not reproduce. The defensible conclusion remains **no established general reader-pipeline speedup** from this incremental patch. Both passes are retained rather than selecting whichever estimate looks best. All three unchanged A/A intervals include zero.
+
+The repeat was interrupted by an execution-tool timeout after 80 completed records, exactly at a balanced-block boundary. It resumed with the same recorded iteration counts and remaining schedule. All 144 planned repeat records are retained; none were discarded or duplicated. Together there are 312 external timing/A/A processes plus 24 portable processes containing 192 individual operation measurements.
+
+## Fresh behavioral verification
+
+- All three exact source variants passed the archived standalone suite: 708 passed, 14 opt-in benchmarks skipped, zero failures per variant (722 total). The archived suite does not contain all current upstream/fork tests and is not a full SwiftPM/Xcode run.
+- All 11 newly committed fragment regression tests pass on all three variants. All eight portable fragment benchmarks also pass enabled on baseline and upstream-ready candidate.
+- All 9,408 complete DOM-observation records match across the three variants (1,344 cases × seven parsing configurations).
+- All 72 complete reader replay output sets match across the three variants.
+- The production source trees and both new test-file blob hashes were checked against the published objects. This confirmation did not repeat the previously recorded AddressSanitizer checks. No Apple-device or Instruments measurement is claimed.
+
+Complete DOM-output SHA-256: `c243b0307f2fbfaeb781bd5786ac51e9e66f659c165b9f33f1590345416b6ca1`.
+
+Sources Git tree hashes:
+
+```
+baseline       697f0424d5df9ee2a674c6cfb65c65ec534715ee
+candidate      324d663ff0b1f4451fcaeb812a833dd2ffff78e8
+fork integrated 10b7b422369c40a5679ae9590ec15826975eb329
+```
+
+## Contributor reproduction
+
+Place the identical committed benchmark file in each revision and use the same release toolchain, count and iteration settings. Alternate execution order and run A/A controls. The standard SwiftPM entry point is:
+
+```sh
+SWIFTSOUP_FRAGMENT_BENCHMARK=1 \
+SWIFTSOUP_FRAGMENT_COUNT=256 \
+SWIFTSOUP_FRAGMENT_ITERATIONS=1000 \
+swift test -c release --filter FragmentAppendBenchmarkTest
+```
+
+The reported measurements used standalone XCTest clients, not that full SwiftPM invocation. The companion confirmation bundle includes the actual build/test scripts, source snapshots, fixture data, complete raw timings and commands, test logs and observation manifests. It does not include the unrecovered original 1,196-run raw archive mentioned in the earlier PR description.
+
+## Raw portable batches
+
+Each numeric entry below is the total timed elapsed milliseconds for 1,000 operations. Warmups are excluded. The CSV retains every portable result, including neutral and negative estimates.
+
+```csv
+block,position,variant,attribute,data,parse-attribute,parse-coalesced,parse-discarded,parse-script,parse-text,text
+0,0,baseline,255.411678,275.178052,107.175217,728.168826,560.229020,208.627683,82.587664,262.206516
+0,1,published,25.579163,21.365444,101.130164,413.614961,556.322533,203.740599,79.057976,28.301915
+0,2,published,25.644611,20.979342,96.723614,406.059186,565.558030,214.578360,77.157391,29.627253
+0,3,baseline,289.042623,246.126677,101.098971,658.845932,543.085952,208.748039,81.293368,279.905957
+1,0,published,24.883302,21.160754,100.450664,399.310970,534.994820,206.467113,77.740345,29.729945
+1,1,baseline,251.566747,258.307253,97.242089,703.919597,571.169321,232.412511,85.424644,294.300435
+1,2,baseline,268.804440,261.395035,100.629603,672.653627,558.200816,233.519556,105.852963,280.200172
+1,3,published,26.441173,21.566988,97.776195,434.288291,585.710713,209.278208,85.207817,29.266781
+2,0,baseline,264.216566,255.137535,107.969436,787.111024,580.278386,200.133102,92.523179,280.276366
+2,1,published,25.137188,23.336245,105.524856,460.846221,557.167632,206.959538,85.258122,28.968211
+2,2,published,25.255797,21.607769,102.604941,418.373179,561.411036,209.794466,83.369706,29.363366
+2,3,baseline,267.514963,265.354769,98.689241,684.140524,540.209326,202.845952,81.171710,276.012317
+3,0,published,27.143916,23.656504,104.258134,451.549749,533.544661,211.159182,76.863917,28.390149
+3,1,baseline,255.839353,256.408821,98.505994,673.736603,542.258787,206.778982,79.286809,262.138950
+3,2,baseline,256.300924,250.297928,102.714925,689.346923,579.523664,208.207956,81.701791,280.083016
+3,3,published,26.415296,22.209248,97.398262,422.525679,555.234212,210.426538,78.624652,28.875083
+4,0,baseline,265.393020,267.721289,103.903555,698.540515,549.591108,207.191875,82.143195,271.288905
+4,1,published,25.831877,22.073273,101.341915,404.993149,548.581006,211.146804,80.607280,30.409425
+4,2,published,25.841071,21.943026,99.314581,408.470259,552.156854,210.552480,78.400084,29.967669
+4,3,baseline,250.405694,268.493969,95.348208,698.641974,565.410751,217.872818,101.259105,270.276685
+5,0,published,25.482749,21.348690,99.822770,411.785482,541.486304,207.406126,79.989474,28.336279
+5,1,baseline,252.938428,264.736596,101.550344,710.588512,568.305538,208.021643,101.830145,303.943747
+5,2,baseline,256.615419,276.373265,99.654738,716.039535,552.997105,218.940135,89.365609,264.718292
+5,3,published,27.179504,22.507033,120.702768,403.784745,547.587184,215.412720,91.747703,29.199427
+```

--- a/Benchmarks/independent-css-20260909.md
+++ b/Benchmarks/independent-css-20260909.md
@@ -1,0 +1,89 @@
+# Slash-free inline CSS cleaning
+
+## Scope
+
+Independent master-based change on `5d593583469c49d3c84449f28251b4cf201042a8`. Only `Sources/Whitelist.swift` changes at runtime: three added lines at the start of private stripCSSComments. Existing regex compilation, entity escaping, and whitespace-normalization work is not duplicated. No public API, cache, persistent state, sanitizer policy, dependency pin, or other worker's branch changes.
+
+A CSS comment cannot start without an ASCII slash. When the UTF-8 view contains none, return the existing String rather than rebuilding it Character by Character. Any slash, including a quoted slash or a late slash that is not a comment, retains the entire original quote/escape-aware scanner. Property filtering and unsafe-value checks still run. Unicode slash lookalikes do not become comment delimiters.
+
+Tradeoff: slash-containing input incurs an additional scan up to its first slash. A long late-slash control is included explicitly. This is not a claim that all CSS or all cleaning becomes faster.
+
+## Isolated release confirmation
+
+Reference: already-optimized PR #3 source `c9c37c80eb571aabba59a1f3ef31af9b072af4a8`. Candidate: that exact source plus only this runtime change. These first-table numbers are not measurements against master.
+
+Linux x86_64, Swift 6.2.1; shipping `-O -g -whole-module-optimization` libraries without `-enable-testing`; one identical separately compiled public client per comparison pair. CPU affinity 0, three warmups, fresh processes, randomized workload order, eight balanced ABBA/BAAB blocks: 16 processes per revision per workload. Target 250 ms in the faster revision, using equal iteration counts. Compilation, tests and profiling were excluded from timing. Geometric-mean milliseconds per operation; exploratory paired-block 95% t intervals on log ratios, without multiple-comparison correction. Every observation retained.
+
+| Public workload | Reference ms | Candidate ms | Less time | 95% interval |
+|---|---:|---:|---:|---:|
+| Sanitize 64 short style values | 3.117449 | 2.844915 | 8.74% | 6.59–10.84% |
+| Sanitize 64 long Unicode style values | 18.401358 | 13.572643 | 26.24% | 24.77–27.69% |
+| Long values with a late slash | 12.041063 | 12.105335 | -0.53% | -2.55–1.44% |
+| Actual-comment control | 2.460368 | 2.431834 | 1.16% | -4.63–6.63% |
+| Clean and regenerate 64 styled paragraphs | 4.050292 | 3.720846 | 8.13% | 5.71–10.50% |
+| Parse, clean and regenerate styled document | 4.643244 | 4.359176 | 6.12% | 0.51–11.41% |
+| Clean document without styles | 0.615912 | 0.596120 | 3.21% | -2.34–8.47% |
+
+The earlier independent four-block, 120 ms screen is retained separately, not pooled. Long Unicode strings deliberately expose reconstruction work; their prevalence in production traffic was not measured. Cleanup uses public Cleaner and regenerated HTML, not a private helper-only benchmark or shallow-copy substitution.
+
+## Confirmation against newly advanced master
+
+Reference: `5d593583469c49d3c84449f28251b4cf201042a8`. Candidate: that exact source plus BOTH this patch and the independent sibling-position patch. This is a combined confirmation, not isolated attribution. A new client was compiled once against the current reference, then kept identical for the pair. Same eight-block/250 ms protocol.
+
+| Public workload | Reference ms | Combined ms | Less time | 95% interval |
+|---|---:|---:|---:|---:|
+| Short styles | 3.064962 | 2.827195 | 7.76% | 5.24–10.21% |
+| Long Unicode styles | 18.382911 | 13.342432 | 27.42% | 26.83–28.00% |
+| Late-slash control | 11.672791 | 11.894930 | -1.90% | -6.30–2.31% |
+| Actual-comment control | 2.402561 | 2.392114 | 0.43% | -1.34–2.17% |
+| Clean styled document | 4.004747 | 3.718265 | 7.15% | 5.20–9.06% |
+| Parse and clean styled document | 4.604337 | 4.281462 | 7.01% | 3.88–10.05% |
+| Clean document without styles | 0.633303 | 0.623906 | 1.48% | -3.42–6.16% |
+
+## Noise and limits
+
+The initial six-block, 200 ms A/A matrix had one false positive: identical binaries made style-free cleaning appear 2.89% faster, interval 1.23–4.52%. The independent 12-block, 400 ms recheck gives -0.40%, interval -2.64–1.80%; its late-slash control is -0.83%, interval -2.49–0.80%. All intervals in the separate current-master A/A matrix span zero. All initial and repeat records are retained.
+
+Do not interpret small control differences as speedups. This shared host is noisy and the intervals do not establish device-level precision. No overall Manabi, universal parser, Apple-device, or iPhone performance claim. No allocation counts or profiler-derived timing claim.
+
+## Correctness and publication
+
+Six new regression methods cover unchanged property filtering/normalization, byte-preserved Japanese/combining/emoji/quoted content, slash-free unsafe values, comments and unterminated comments, 512 seeded cases compared with the original scanner forced by a removable comment prefix, and repeated rule changes without input mutation. No existing tests were weakened.
+
+- Original PR #3 release: 806 cases, 17 optional benchmarks skipped, zero failures.
+- Unchanged PR #3 plus both new test files: 821 cases, 17 skipped, zero failures. Combined candidate: the same in local debug and release.
+- Current master plus both test files but unchanged production: native Swift 6.1.3 release, 1,080 cases, 17 skipped, zero failures.
+- This independent master-based production/test tree: native Swift 6.1.3 release, 1,071 cases, 17 skipped, zero failures (1,054 passed).
+- Master plus both runtime patches: local Swift 6.2.1 full DEBUG AddressSanitizer suite, 1,080 cases, 17 skipped, zero failures. `ASAN_OPTIONS=detect_leaks=0`; not leak checking or a release-ASan claim.
+
+Native publication run: https://github.com/lake-of-fire/SwiftSoup/actions/runs/34335351288 . An earlier attempt stopped before testing because the container lacked Python; the successful retry installed it. Runtime/test SHA-256 values were checked before testing and non-force branch publication. All 217 files in the initial published tree were independently checked against local inputs and Git blob hashes. Subsequent additions are only this report and the two already-used benchmark tools.
+
+The old reference, both isolated candidates, old combined candidate, current master and current combined candidate all match 2,108 complete public-observation records byte-for-byte, including CSS results, unchanged inputs, cleaned documents, structural selectors, mutation and regenerated HTML/text. SHA-256: `204a9bfdfa9f50a4789b7ce2f0946be5ae482269a6ec9abec7ec2b7ab853c775`. These records are not independent bugs or browser-equivalence checks.
+
+The complete two-candidate study retains 1,760 timed fresh processes across 11 stages, excluding calibration/correctness launches. Every timed checksum and aggregate was independently recomputed. Aggregate JSON SHA-256: `067a43e72434b422f505444267777a594bb8aa9b66e18f259a798d920915218b`.
+
+## Reproduction
+
+Use `swift test -c release` for native tests. For isolated timing, apply only this runtime diff to the stated PR #3 reference; for current-master confirmation, apply both runtime diffs to the stated master. Keep clients and source revisions matched within each comparison pair.
+
+Example Linux shipping-library build in each separate source directory:
+
+```sh
+mkdir -p shipping
+swiftc -swift-version 6 -O -g -whole-module-optimization \
+  -emit-library -emit-module -module-name SwiftSoup \
+  -emit-module-path shipping/SwiftSoup.swiftmodule \
+  -o shipping/libSwiftSoup.so Sources/*.swift
+```
+
+Compile one client against the reference and compare:
+
+```sh
+swiftc -swift-version 6 -O -I /reference/shipping -L /reference/shipping \
+  -lSwiftSoup Tools/benchmark_independent_hotspots.swift -o /tmp/hotspots
+python3 Tools/compare_independent_hotspots.py --client /tmp/hotspots \
+  --baseline-library /reference/shipping --candidate-library /candidate/shipping \
+  --suite css --output /tmp/new-css-results --blocks 8 --ms 250
+```
+
+Python requires NumPy/SciPy. Repeat with `--aa` into another fresh directory. The runner compares complete nonempty outputs before timing, checks every checksum, controls Linux affinity/library loading, and saves calibration, raw trials, binary identities and intervals. Never compile or profile during timing. Exact sources, patches, raw timing records and test logs accompany the delivery archive.

--- a/Benchmarks/independent-position-20260909.md
+++ b/Benchmarks/independent-position-20260909.md
@@ -1,0 +1,83 @@
+# Element sibling-position lookup
+
+## Scope
+
+Independent master-based change on `5d593583469c49d3c84449f28251b4cf201042a8`. Only `Sources/Element.swift` changes at runtime: 19 additions and one deletion in `elementSiblingIndex()`. This is distinct from the existing adjacent-sibling navigation and sibling reindexing work. No cache, persistent state, public API, parser default, dependency pin, or other worker's branch changes.
+
+Built-in parents previously materialized the complete filtered `Elements` list before finding one element's index. Count directly through their child nodes and stop at the target instead. Exact Element, Document and FormElement parents take this path. Custom parent/children/array projections keep the old path. The original two parent() calls, nil-second-result error, zero for absent membership, and independence from stale public siblingIndex values are preserved.
+
+This remains O(n) for one lookup and O(n²) for all positions in a wide parent. It removes unnecessary allocations and scanning, not the asymptotic cost of every structural selector.
+
+## Isolated release confirmation
+
+Reference: already-optimized PR #3 source `c9c37c80eb571aabba59a1f3ef31af9b072af4a8`. Candidate: that exact source plus only this runtime change. These first-table numbers are not measurements against master.
+
+Linux x86_64, Swift 6.2.1, shipping libraries built with `-O -g -whole-module-optimization`, without `-enable-testing`. One identical separately compiled public client per comparison pair. CPU affinity 0, three warmups, fresh processes, randomized workload order, eight balanced ABBA/BAAB blocks: 16 processes per revision per workload, targeting 250 ms of work in the faster revision with equal iteration counts. No compilation, tests, or profiling during timing. Geometric-mean milliseconds per operation; exploratory paired-block 95% t intervals on log ratios, without multiple-comparison adjustment. No observations discarded.
+
+| Public workload | Reference ms | Candidate ms | Less time | 95% interval |
+|---|---:|---:|---:|---:|
+| All positions of 256 sibling elements | 1.996053 | 0.103813 | 94.80% | 94.49–95.09% |
+| Positions with intervening text/comments | 2.279398 | 0.297094 | 86.97% | 86.51–87.40% |
+| Uncached nth-child selection, 256 paragraphs | 2.452187 | 0.409174 | 83.31% | 82.62–83.98% |
+| Parse 128 paragraphs plus nth-child selection | 1.685411 | 1.153848 | 31.54% | 29.58–33.44% |
+| Custom-parent fallback control | 0.927815 | 0.916840 | 1.18% | -5.01–7.01% |
+| Parse/text control | 1.141513 | 1.128082 | 1.18% | -3.26–5.42% |
+
+An earlier independent four-block, 120 ms screening run is retained separately, not pooled into this confirmation. Selection uses public Collector/evaluator traversal, not warmed string-query results. The parsing row includes parsing, selection and normal lifetime costs; it is not a parser-only gain.
+
+## Confirmation against newly advanced master
+
+Reference: `5d593583469c49d3c84449f28251b4cf201042a8`. Candidate: that exact source plus BOTH this patch and the separate slash-free CSS cleaning patch. This is a combined confirmation, not an isolated attribution. A new public client was compiled once against the current baseline, then held identical across this pair. Same eight-block/250 ms protocol.
+
+| Workload | Reference ms | Combined ms | Less time | 95% interval |
+|---|---:|---:|---:|---:|
+| All positions of 256 sibling elements | 2.111733 | 0.110034 | 94.79% | 93.99–95.49% |
+| Mixed sibling positions | 2.252929 | 0.306312 | 86.40% | 86.07–86.73% |
+| Uncached nth-child selection | 2.375669 | 0.392831 | 83.46% | 82.98–83.93% |
+| Parse plus nth-child selection | 1.794774 | 1.276510 | 28.88% | 25.83–31.80% |
+| Custom-parent fallback control | 0.922212 | 0.913415 | 0.95% | -0.86–2.74% |
+| Parse/text control | 1.240496 | 1.219517 | 1.69% | -3.12–6.28% |
+
+Every interval in both six-block, 200 ms position A/A matrices spans zero. The companion CSS study did have a false-positive identical-binary control; its longer recheck spans zero. This is a noisy shared host. Do not infer device-level precision, a universal parser speedup, or whole-Manabi performance. Fixtures are synthetic, not measured production traffic; no Apple/iPhone performance was measured.
+
+## Correctness and publication
+
+Nine new regression methods cover mixed nodes/widths, stale indexes, detached and missing membership, built-in document/form parents, custom children and array projections, stateful parent callbacks, reparenting/deep copies, and warmed selectors after mutation. They pass against unchanged production as compatibility guards. No existing tests were weakened.
+
+- Original PR #3 release: 806 cases, 17 optional benchmarks skipped, zero failures.
+- Unchanged PR #3 plus both new test files: 821 cases, 17 skipped, zero failures. Combined candidate: the same in local debug and release.
+- Newly advanced master plus both test files but unchanged production: native Swift 6.1.3 release, 1,080 cases, 17 skipped, zero failures.
+- This independent master-based production/test tree: native Swift 6.1.3 release, 1,074 cases, 17 skipped, zero failures (1,057 passed).
+- Master plus both runtime patches: local Swift 6.2.1 full DEBUG AddressSanitizer suite, 1,080 cases, 17 skipped, zero failures. `ASAN_OPTIONS=detect_leaks=0`; not leak checking and not a release-ASan claim.
+
+Native publication run: https://github.com/lake-of-fire/SwiftSoup/actions/runs/34335351288 . Its first attempt stopped before testing because Python was missing from the container; the successful retry installed it. Source preparation verified exact runtime/test SHA-256 values before tests and non-force publication. All 217 files in this initial published tree were independently checked against local inputs and Git blob hashes. Subsequent additions are only this report and the two already-used benchmark tools.
+
+The old reference, its two isolated candidates, its combined candidate, current master and current combined candidate all match 2,108 complete public-observation records byte-for-byte: positions, selections, later mutation, HTML/text, CSS filtering and cleaned-document outputs. SHA-256: `204a9bfdfa9f50a4789b7ce2f0946be5ae482269a6ec9abec7ec2b7ab853c775`. These are records, not 2,108 independent bugs or a claim of browser equivalence.
+
+The full two-candidate study retains 1,760 timed fresh processes across 11 stages, excluding calibration and correctness launches. Every checksum and aggregate was independently recomputed. Aggregate JSON SHA-256: `067a43e72434b422f505444267777a594bb8aa9b66e18f259a798d920915218b`.
+
+## Reproduction
+
+Run native project tests with `swift test -c release`. For the isolated timing study, apply only this runtime diff to the PR #3 reference above. For the current-master confirmation, apply both runtime diffs to the stated current master. Keep source revisions and clients matched within each pair.
+
+Example Linux shipping-library build, executed separately in each source directory:
+
+```sh
+mkdir -p shipping
+swiftc -swift-version 6 -O -g -whole-module-optimization \
+  -emit-library -emit-module -module-name SwiftSoup \
+  -emit-module-path shipping/SwiftSoup.swiftmodule \
+  -o shipping/libSwiftSoup.so Sources/*.swift
+```
+
+Compile one client against the reference library, then compare:
+
+```sh
+swiftc -swift-version 6 -O -I /reference/shipping -L /reference/shipping \
+  -lSwiftSoup Tools/benchmark_independent_hotspots.swift -o /tmp/hotspots
+python3 Tools/compare_independent_hotspots.py --client /tmp/hotspots \
+  --baseline-library /reference/shipping --candidate-library /candidate/shipping \
+  --suite position --output /tmp/new-position-results --blocks 8 --ms 250
+```
+
+Python requires NumPy and SciPy. Repeat with `--aa` and a different output directory. The runner verifies complete nonempty outputs before timing, controls Linux library loading/CPU affinity, checks all timed checksums, and retains calibration, every trial, binary identities and intervals. Never build or profile concurrently. Raw evidence, exact source snapshots, patches and complete test logs accompany the delivery archive.

--- a/Benchmarks/pattern-reuse-audit-20260909.md
+++ b/Benchmarks/pattern-reuse-audit-20260909.md
@@ -1,0 +1,45 @@
+# Pattern reuse: reconciled-source confirmation, September 9, 2026
+
+## Source and scope
+
+Baseline is reviewed master `7d2d58c6cb6dd1d2251eb9563a844b3d01718afe`, not the older optimization baseline. Candidate `9ee782e56aa9cfae51b24c3e0a3da02f8a8832ed` (tree `b4d6f44665f69fef3f4b8104304d96dc59bf0678`) merges the unchanged Pattern runtime/test change with that master. Only Pattern.swift changes at runtime. Portable Swift/Python tools are committed. Original PR #8 ancestry is retained; no forced update.
+
+Pattern construction now compiles and retains its immutable regex/result. Reused matchers and repeated validation avoid recompilation. Invalid patterns still have nonthrowing construction, throwing validation and the old invalid-matcher diagnostic. Every Matcher retains independent eager matches and its own cursor. Ignored legacy options and capture-string semantics are unchanged.
+
+## Native correctness
+
+The source/test-identical predecessor `925a8e2b3848dbfd7ad024807acb8f697ae02b90` passed **1,065 total XCTest cases: 1,048 passed, 17 opt-in benchmarks skipped, zero failures**, in each of debug, release and AddressSanitizer on both Ubuntu and macOS, in run [34330228389](https://github.com/lake-of-fire/SwiftSoup/actions/runs/34330228389). ASan used `detect_leaks=0`; this is not leak checking. The later candidate changes only the benchmark runner, and the corrected workflow explicitly verifies Sources/Tests are identical.
+
+The first run's overall status is red because its benchmark used an invalid library/client pairing. Do not call the whole first run green. Its test logs and failed benchmark are retained.
+
+## Corrected measurement protocol
+
+[Run 34331467924](https://github.com/lake-of-fire/SwiftSoup/actions/runs/34331467924) completed on both runners. Ubuntu uses Swift 6.3.3/x86_64; macOS uses Swift 6.1.2/arm64. Shipping libraries and public clients use optimization; libraries do not enable testing or library evolution. The exact same public client source is compiled **separately against each matching module/library**. Pattern's non-resilient struct layout changed, so loading the new library underneath an old-layout client was invalid. That first harness mistake was fixed, not represented as a product crash or accepted timing.
+
+Each operation covers 256 inputs/patterns, except the parse control (64 paragraphs). Three in-process warmups. For each workload/host: eight alternating same-binary A/A pairs and twelve alternating A/B pairs in fresh processes. Common iteration counts are calibrated using both arms, targeting approximately 150 ms for the faster arm, capped at 4,096 iterations. Unused construction uses eight fixed iterations because its baseline is extremely short. Compilation and correctness suites finish before timing. Linux pins one available CPU; macOS has no affinity. No samples are discarded or pooled across hosts.
+
+Percentages below are medians of within-pair ratios, not ratios of separate duration medians. Negative means less time. Checksums must match every pair. The benchmark checksum checks are narrower than the native behavioral suites and do not replace them.
+
+| Workload | Ubuntu paired change | Faster pairs | macOS paired change | Faster pairs |
+|---|---:|---:|---:|---:|
+| Reused Pattern | -77.01% | 12/12 | -71.56% | 12/12 |
+| Reused Pattern plus repeated validate | -86.64% | 12/12 | -84.28% | 12/12 |
+| Fresh Pattern with one match | +0.46% | 2/12 | -0.17% | 6/12 |
+| Parse/text control | +1.96% | 4/12 | +0.37% | 5/12 |
+
+No general parse, Reader or one-use speedup is established. A/A reused-Pattern medians were +0.32% on Ubuntu and **+7.40% on macOS, 0/8 faster**. Other A/A medians range from -1.75% to +2.25%. The macOS control shows measurable host/order drift; the large reuse improvements exceed it, but these are not precision device estimates or confidence intervals.
+
+### Real construction tradeoff
+
+For 256 patterns constructed only to read their original string, baseline/candidate separate median durations were **0.0142/0.9541 ms on Ubuntu** and **0.0242/0.9759 ms on macOS**. Eager compilation is materially more expensive when never used. These very short baseline timings are not suitable for a precise multiplier claim. The compiled expression also remains alive with its Pattern. This tradeoff is intentional, not a universal optimization guarantee.
+
+## Evidence integrity
+
+Each host retains 210 process records: 200 A/A and A/B records plus ten calibrations; warmup operations are inside each process and excluded from elapsed timing. Across both hosts: 420 retained records. Library and both client SHA-256 values appear in each summary; raw records retain logical A/A role and actual loaded variant separately.
+
+Downloaded artifact ZIP hashes, independently checked:
+
+- `audit-pattern-matched-ubuntu-22.04`: `850f8ca61879faa4482f1836945734e869726b53e0bf647d818ced8de5d144f3`.
+- `audit-pattern-matched-macos-15`: `c9d7d3ab18432c912bd8272238aef8f9552fc8e9fe54362df946a9e6ccd87666`.
+
+Reproduce by building matching baseline/candidate libraries and matching clients from Tools/benchmark_pattern_reuse.swift, then invoking Tools/compare_pattern_reuse.py with --baseline-library, --candidate-library, --baseline-client, --candidate-client and a new --output directory. The driver refuses an existing output directory. Run normal SwiftPM tests separately. Final PR CI is a separate exact-head gate. No iOS device, full Reader, allocation-count or leak-freedom claim.

--- a/Tools/benchmark_attribute_observers.swift
+++ b/Tools/benchmark_attribute_observers.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftSoup
+
+let counts = [16, 128, 1024]
+let exposureCount = 131_072
+var result: [[String: Any]] = []
+for count in counts {
+    let attributes = Attributes()
+    for index in 0..<count { try attributes.put("k\(index)", "v\(index)") }
+    let saved = attributes.asList()
+    let iterations = exposureCount / count
+    var checksum = 0
+    for _ in 0..<max(2, iterations / 10) { checksum &+= attributes.asList().count }
+    let start = DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<iterations { checksum &+= attributes.asList().count }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    let final = attributes.asList()
+    precondition(final.count == count && final.first === saved.first && final.last === saved.last)
+    result.append(["attributes": count, "iterations": iterations, "elapsed_ns": elapsed, "checksum": checksum])
+}
+let data = try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys])
+print(String(decoding: data, as: UTF8.self))

--- a/Tools/benchmark_blank_text.swift
+++ b/Tools/benchmark_blank_text.swift
@@ -1,0 +1,104 @@
+import Foundation
+import SwiftSoup
+
+func reference(_ text: String) -> Bool { text.allSatisfy { StringUtil.isWhitespace($0) } }
+
+func verify() throws -> [[String: Any]] {
+    var records: [[String: Any]] = []
+    // Every Unicode scalar: independently exercise the old Character predicate.
+    var validScalars = 0
+    var whitespaceScalars: [UInt32] = []
+    for value in UInt32(0)...0x10FFFF {
+        guard let scalar = UnicodeScalar(value) else { continue }
+        let text = String(scalar)
+        let expected = reference(text)
+        precondition(StringUtil.isBlank(text) == expected, "scalar \(value)")
+        if expected { whitespaceScalars.append(value) }
+        validScalars += 1
+    }
+    records.append(["scalar_count": validScalars, "whitespace_scalars": whitespaceScalars])
+    let values = ["", " \t\r\n\u{c}", "\u{b}", "\u{a0}", " \u{301}", "e\u{301}", "👩🏽‍💻", "🇯🇵", "日本語", String(repeating: " \r\n", count: 4096)]
+    for value in values {
+        let node = TextNode(value, nil)
+        let result = node.isBlank()
+        precondition(result == reference(value))
+        records.append(["input": Array(value.utf8), "blank": result, "retained": node.getWholeTextUTF8()])
+    }
+    for value in UInt16(0)...255 {
+        let bytes = [UInt8(32), UInt8(value), 13, 10]
+        let node = TextNode(bytes, nil)
+        let result = node.isBlank()
+        precondition(result == reference(String(decoding: bytes, as: UTF8.self)))
+        records.append(["input": bytes, "blank": result, "retained": node.getWholeTextUTF8()])
+    }
+    for shape in 0..<16 {
+        let doc = try SwiftSoup.parse("<main><p> \r\n </p><p>日本 &amp; text</p><p>&nbsp;</p><pre> \r\n </pre></main>")
+        doc.outputSettings().prettyPrint(pretty: shape % 2 == 0)
+        let nodes = try doc.select("p")
+        if shape % 3 == 0 { try nodes.first()!.text(shape % 2 == 0 ? "" : "changed") }
+        records.append(["shape": shape, "hasText": nodes.array().map { $0.hasText() }, "eachText": try nodes.eachText(), "html": try doc.outerHtmlUTF8(), "text": Array(try doc.text().utf8)])
+    }
+    return records
+}
+
+func workload(_ name: String) throws -> () throws -> Int {
+    let whitespace = String(repeating: " \t\r\n\u{c}", count: 1024)
+    let japanese = String(repeating: "日本語の文章", count: 1024)
+    switch name {
+    case "string-blank-long", "string-short", "string-unicode":
+        let text = name == "string-short" ? " \t " : name == "string-unicode" ? japanese : whitespace
+        return { StringUtil.isBlank(text) ? 1 : 2 }
+    case "node-blank-long", "node-short", "node-unicode", "node-late-text":
+        let text = name == "node-short" ? " " : name == "node-unicode" ? japanese : name == "node-late-text" ? whitespace + "日" : whitespace
+        let node = TextNode(text, nil)
+        return { node.isBlank() ? 1 : 2 }
+    case "node-custom":
+        final class Custom: TextNode { override func getWholeText() -> String { " \t " } }
+        let node = Custom("ignored", nil)
+        return { node.isBlank() ? 1 : 2 }
+    case "hastext-blank", "hastext-nonblank", "serialize-pretty":
+        let doc = Document.createShell("")
+        let body = doc.body()!
+        let value = name == "hastext-nonblank" ? japanese : String(repeating: " \t\r\n", count: 128)
+        for _ in 0..<128 {
+            let p = try body.appendElement("p")
+            try p.appendText(value)
+        }
+        if name == "serialize-pretty" {
+            return { try doc.outerHtmlUTF8().count }
+        }
+        return { body.hasText() ? 1 : 2 }
+    case "parse-hastext", "parse-control":
+        let paragraph = name == "parse-control" ? "<p>日本語 &amp; ordinary text <em>強調</em></p>" : "<p> \t\r\n </p>"
+        let html = "<main>" + String(repeating: paragraph, count: 128) + "</main>"
+        return {
+            let doc = try SwiftSoup.parse(html)
+            if name == "parse-hastext" { return try doc.select("p").array().reduce(0) { $0 + ($1.hasText() ? 1 : 2) } }
+            return try doc.select("p").size()
+        }
+    default: fatalError("Unknown workload: \(name)")
+    }
+}
+
+do {
+    let args = CommandLine.arguments
+    if args.count == 2 && args[1] == "--verify" {
+        let data = try JSONSerialization.data(withJSONObject: verify(), options: [.sortedKeys])
+        print(String(decoding: data, as: UTF8.self))
+    } else {
+        guard args.count == 3, let iterations = Int(args[2]), iterations > 0 else { fatalError("workload positive-iterations, or --verify") }
+        let operation = try workload(args[1])
+        let expected = try operation()
+        for _ in 0..<3 { let value = try operation(); precondition(value == expected) }
+        var checksum = 0
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations { checksum += try operation() }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        precondition(checksum == expected * iterations)
+        let data = try JSONSerialization.data(withJSONObject: ["workload": args[1], "iterations": iterations, "expected": expected, "checksum": checksum, "elapsed_ns": elapsed], options: [.sortedKeys])
+        print(String(decoding: data, as: UTF8.self))
+    }
+} catch {
+    FileHandle.standardError.write(Data("\(error)\n".utf8))
+    exit(1)
+}

--- a/Tools/benchmark_character_classification.swift
+++ b/Tools/benchmark_character_classification.swift
@@ -1,0 +1,78 @@
+// Build against the complete shipping SwiftSoup library, not an extracted helper.
+import Foundation
+import SwiftSoup
+
+func originalWord(_ ch: Character) -> Bool {
+    let scalars = String(ch).precomposedStringWithCanonicalMapping.unicodeScalars
+    return scalars.count == 1 && (CharacterSet.letters.contains(scalars.first!) || CharacterSet.decimalDigits.contains(scalars.first!))
+}
+
+func verify() throws {
+    var records = [[String: String]]()
+    var spellings = (UInt32(0)..<128).map { String(UnicodeScalar($0)!) }
+    spellings += ["日本語", "é", "e\u{0301}", "Å", "Å", "K", "١", "２", "𝟡", "Ⅸ", "👩🏽‍💻", "🇯🇵", "\r\n", "\0", "a\u{20E3}", "가"]
+    var seed: UInt64 = 0xc1a551f1
+    for _ in 0..<1024 {
+        seed = seed &* 6364136223846793005 &+ 1442695040888963407
+        if let scalar = UnicodeScalar(UInt32(seed % 0x110000)) { spellings.append(String(scalar)) }
+    }
+    for text in spellings {
+        let q = TokenQueue(text + "!tail")
+        let expected = String(text.prefix { originalWord($0) })
+        let word = q.consumeWord()
+        precondition(Array(word.utf8) == Array(expected.utf8))
+        let remainder = String(text.dropFirst(expected.count)) + "!tail"
+        precondition(Array(q.toString().utf8) == Array(remainder.utf8))
+        records.append(["input": Data(text.utf8).base64EncodedString(), "word": Data(word.utf8).base64EncodedString(), "remainder": Data(q.toString().utf8).base64EncodedString()])
+    }
+    let doc = try SwiftSoup.parse("<main><section class='article'><p id='a'>日本語</p><p id='b'>two</p></section><section><p id='c'>three</p></section></main>")
+    for query in ["main > section.article:nth-child(2n + 1) p:contains(日本語)", "main section p", "p", "main > section > p:nth-child(2)", "section:has(p)"] {
+        records.append(["query": query, "evaluator": try QueryParser.parse(query).toString(), "ids": try doc.select(query).array().map { $0.id() }.joined(separator: ","), "html": try doc.outerHtml()])
+    }
+    print(String(decoding: try JSONSerialization.data(withJSONObject: records, options: [.sortedKeys]), as: UTF8.self))
+}
+
+func workload(_ name: String) throws -> () throws -> Int {
+    switch name {
+    case "ascii-letters", "ascii-mixed", "unicode-mixed", "start-tags":
+        let values: [String]
+        if name == "ascii-mixed" { values = (UInt32(0)..<128).map { String(UnicodeScalar($0)!) } }
+        else if name == "unicode-mixed" { values = ["日", "é", "e\u{0301}", "١", "２", "👩🏽‍💻", "🇯🇵", "\r\n", "a\u{20E3}", "가"] }
+        else { values = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ").map(String.init) }
+        let queues = values.map { TokenQueue((name == "start-tags" ? "<" : "") + $0 + "!") }
+        return { var total = 0; for q in queues { total += (name == "start-tags" ? q.matchesStartTag() : q.matchesWord()) ? 1 : 0 }; return total }
+    case "word-short":
+        return { let q = TokenQueue("article42:tail"); return q.consumeWord().utf8.count + q.toString().utf8.count }
+    case "tag-name":
+        return { let q = TokenQueue("custom-component_12:part!"); return q.consumeTagNameSlice().utf8.count + q.toString().utf8.count }
+    case "word-unicode":
+        return { let q = TokenQueue("日本語éclair２:tail"); return q.consumeWord().utf8.count + q.toString().utf8.count }
+    case "selector-parse", "selector-tags", "selector-unicode":
+        let query = name == "selector-parse" ? "main > section.article:nth-child(2n + 1) p:contains(日本語)" : (name == "selector-tags" ? "main section article header span" : "本 > 節 文章")
+        let doc = try SwiftSoup.parse("<main><section class='article'><p>日本語</p></section></main>")
+        let leaf = try doc.select("p").first()!
+        return { let evaluator = try QueryParser.parse(query); return try evaluator.matches(doc, leaf) ? 1 : 0 }
+    case "parse-control":
+        let html = "<main>" + (0..<128).map { "<section class='article'><p id='p\($0)'>日本語 and English</p></section>" }.joined() + "</main>"
+        return { let doc = try SwiftSoup.parse(html); return try doc.select("p").size() + doc.text().utf8.count }
+    default: fatalError("Unknown workload: \(name)")
+    }
+}
+
+QueryParser.cache = nil
+if CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--verify" {
+    try verify()
+} else {
+    guard CommandLine.arguments.count == 3, let iterations = Int(CommandLine.arguments[2]), iterations > 0 else { fatalError("Usage: client --verify | workload positive-iterations") }
+    let name = CommandLine.arguments[1]
+    let operation = try workload(name)
+    let expected = try operation()
+    for _ in 0..<3 { let result = try operation(); precondition(result == expected) }
+    let start = DispatchTime.now().uptimeNanoseconds
+    var checksum = 0
+    for _ in 0..<iterations { checksum += try operation() }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    precondition(checksum == expected * iterations)
+    let result: [String: Any] = ["workload": name, "iterations": iterations, "elapsed_ns": elapsed, "expected": expected, "checksum": checksum]
+    print(String(decoding: try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]), as: UTF8.self))
+}

--- a/Tools/benchmark_child_reads.swift
+++ b/Tools/benchmark_child_reads.swift
@@ -1,0 +1,143 @@
+// Standalone public-API client. Build against each matching shipping module/library.
+// Do not time compilation, fixture construction (except parse-*), or verification.
+import Foundation
+import SwiftSoup
+
+private final class ProjectedParent: Element {
+    override func children() -> Elements { super.children() }
+}
+
+private struct Fixture {
+    let parent: Element
+    let elements: [Element]
+}
+
+private func fixture(_ count: Int, mixed: Bool = false, custom: Bool = false) throws -> Fixture {
+    let parent: Element = custom
+        ? try ProjectedParent(Tag.valueOf("main"), "")
+        : try Element(Tag.valueOf("main"), "")
+    var elements: [Element] = []
+    for i in 0..<count {
+        if mixed {
+            try parent.appendChild(TextNode("日\(i)", ""))
+            try parent.appendChild(Comment([120], []))
+        }
+        let child = try Element(Tag.valueOf("p"), "")
+        try child.attr("id", "n\(i)")
+        try child.appendText("日本語\(i)")
+        try parent.appendChild(child)
+        elements.append(child)
+    }
+    return Fixture(parent: parent, elements: elements)
+}
+
+private func verification() throws -> Data {
+    var records: [[String: Any]] = []
+    for width in [0, 1, 2, 3, 8, 32, 128] {
+        for mixed in [false, true] {
+            for custom in [false, true] {
+                let f = try fixture(width, mixed: mixed, custom: custom)
+                let eval = Evaluator.IsOnlyChild()
+                var positions: [Int] = []
+                var only: [Bool] = []
+                for i in 0..<width {
+                    let got = f.parent.child(i)
+                    precondition(got === f.elements[i])
+                    positions.append(got.siblingIndex)
+                    let match = try eval.matches(f.parent, got)
+                    precondition(match == (width == 1))
+                    only.append(match)
+                }
+                let before = try f.parent.outerHtml()
+                let selected = try f.parent.select(eval).array().map { $0.id() }
+                if width > 1 {
+                    try f.elements.last!.remove()
+                    for i in 0..<(width-1) { precondition(f.parent.child(i) === f.elements[i]) }
+                }
+                records.append(["width":width, "mixed":mixed, "custom":custom,
+                                "positions":positions, "only":only, "selection":selected,
+                                "before":before, "after":try f.parent.outerHtml()])
+            }
+        }
+    }
+    return try JSONSerialization.data(withJSONObject: records, options: [.sortedKeys])
+}
+
+private func operation(_ name: String) throws -> () throws -> Int {
+    if name == "parse-control" || name == "parse-child" || name == "parse-only" {
+        let html = (0..<128).map { "<section><p id='n\($0)'>日本語\($0)</p><em>text</em></section>" }.joined()
+        let evaluator = Evaluator.IsOnlyChild()
+        return {
+            let document = try SwiftSoup.parse(html)
+            if name == "parse-control" {
+                return try document.text().utf8.count + document.select("p").size()
+            }
+            if name == "parse-only" { return try document.select(evaluator).size() }
+            let body = document.body()!
+            var sum = 0
+            for i in 0..<128 { sum += body.child(i).child(0).siblingIndex + 1 }
+            return sum
+        }
+    }
+    if name == "only-unary-256" {
+        let fixtures = try (0..<256).map { _ in try fixture(1, mixed: true) }
+        let evaluator = Evaluator.IsOnlyChild()
+        return {
+            var sum = 0
+            for f in fixtures { sum += try evaluator.matches(f.parent, f.elements[0]) ? 1 : 0 }
+            return sum
+        }
+    }
+    let parts = name.split(separator: "-")
+    guard let count = Int(parts.last!) else { fatalError("Unknown workload \(name)") }
+    let f = try fixture(count, mixed: name.contains("mixed"), custom: name.contains("custom"))
+    if name.hasPrefix("only-") {
+        let evaluator = Evaluator.IsOnlyChild()
+        if name.contains("select") {
+            return { try f.parent.select(evaluator).size() }
+        }
+        return {
+            var sum = 0
+            for child in f.elements {
+                sum += try evaluator.matches(f.parent, child) ? 1 : 0
+            }
+            return sum
+        }
+    }
+    let indices: [Int]
+    if name.contains("all") { indices = Array(0..<count) }
+    else if name.contains("last") { indices = Array(repeating: count-1, count: 32) }
+    else if name.contains("middle") { indices = Array(repeating: count/2, count: 32) }
+    else { indices = Array(repeating: 0, count: 32) }
+    return {
+        var sum = 0
+        for index in indices { sum += f.parent.child(index).siblingIndex + 1 }
+        return sum
+    }
+}
+
+let args = CommandLine.arguments
+if args.count == 2 && args[1] == "--verify" {
+    FileHandle.standardOutput.write(try verification())
+    print("")
+} else if args.count == 3 && args[1] == "--invalid-child" {
+    let f = try fixture(2)
+    _ = f.parent.child(Int(args[2])!)
+    fatalError("Invalid child unexpectedly returned")
+} else {
+    guard args.count == 3, let iterations = Int(args[2]), iterations > 0 else {
+        fatalError("Usage: client <workload> <positive iterations>, or --verify")
+    }
+    let name = args[1], work = try operation(name)
+    let expected = try work()
+    for _ in 0..<3 { let value = try work(); precondition(value == expected) }
+    var checksum = 0
+    let start = DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<iterations { checksum &+= try work() }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    precondition(checksum == expected * iterations)
+    let record: [String: Any] = ["workload":name, "iterations":iterations,
+                               "elapsed_ns":elapsed, "expected":expected, "checksum":checksum]
+    FileHandle.standardOutput.write(try JSONSerialization.data(withJSONObject:record, options:[.sortedKeys]))
+    print("")
+}

--- a/Tools/benchmark_cursor_moves.swift
+++ b/Tools/benchmark_cursor_moves.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SwiftSoup
+
+// Public-client benchmark. Compile the same file against each matching module.
+// Fixture setup is outside timing unless the workload name starts with parse-.
+QueryParser.cache = nil
+let arguments = CommandLine.arguments
+func verify() throws {
+    var records: [[String: Any]] = []
+    let samples = ["", "Abc", "日本語", "e\u{301}Éx", "👩🏽‍💻🇯🇵\r\nA", "İıΣσς", "a\0b"]
+    for text in samples {
+        for needle in samples {
+            let q = TokenQueue(text)
+            records.append(["source": Array(text.utf8), "needle": Array(needle.utf8),
+                            "cs": q.matchesCS(needle), "ci": q.matches(needle), "after": Array(q.toString().utf8)])
+        }
+    }
+    for n in [1, 2, 8, 32] {
+        for from in 0..<n {
+            for to in 0..<n {
+                let set = OrderedSet(sequence: 0..<n)
+                var model = Array(0..<n)
+                model.insert(model.remove(at: from), at: to)
+                set.moveObject(from, toIndex: to)
+                precondition(Array(set) == model)
+                let positions = model.map { set.index(of: $0)! }
+                precondition(positions == Array(0..<n))
+                records.append(["width": n, "from": from, "to": to, "values": Array(set), "indices": positions])
+            }
+        }
+    }
+    let doc = try SwiftSoup.parse("<main><p class='日本語'>École</p><p>other</p></main>")
+    records.append(["html": try doc.outerHtml(), "text": try doc.text(),
+                    "selected": try doc.select("main > p:nth-child(2n + 1)").array().map { try $0.outerHtml() }])
+    let data = try JSONSerialization.data(withJSONObject: records, options: [.sortedKeys])
+    print(String(decoding: data, as: UTF8.self))
+}
+if arguments.count == 2 && arguments[1] == "--verify" {
+    try verify()
+    exit(0)
+}
+precondition(arguments.count == 3, "Usage: client WORKLOAD ITERATIONS or --verify")
+let name = arguments[1]
+let iterations = Int(arguments[2])!
+precondition(iterations > 0)
+let operation: () throws -> Int
+if name.hasPrefix("region-") || name.hasPrefix("prefix-") {
+    var needle: String
+    var text: String
+    var offsetPrefix = ""
+    switch name {
+    case "region-short": needle = "DIV"; text = "div"
+    case "region-ascii-512": needle = String(repeating: "A", count: 512); text = needle.lowercased() + "tail"
+    case "region-unicode-128": needle = String(repeating: "日", count: 128); text = needle + "tail"
+    case "region-unicode-512", "prefix-unicode-512": needle = String(repeating: "日", count: 512); text = needle + "tail"
+    case "region-long-tail": needle = "div"; text = "DiV" + String(repeating: "日", count: 2048)
+    case "region-offset": needle = String(repeating: "本", count: 128); offsetPrefix = String(repeating: "日", count: 512); text = offsetPrefix + needle + "tail"
+    case "region-miss": needle = "x"; text = String(repeating: "日", count: 2048)
+    case "prefix-short": needle = "div"; text = "div"
+    default: fatalError("unknown workload")
+    }
+    let q = TokenQueue(text)
+    if !offsetPrefix.isEmpty { try q.consume(offsetPrefix) }
+    let cs = name.hasPrefix("prefix-")
+    operation = {
+        var sum = 0
+        for _ in 0..<16 { sum += (cs ? q.matchesCS(needle) : q.matches(needle)) ? 2 : 1 }
+        return sum
+    }
+} else if name.hasPrefix("move-") {
+    let n: Int
+    let from: Int
+    let to: Int
+    switch name {
+    case "move-wide-16": n = 16; from = 0; to = 15
+    case "move-wide-128": n = 128; from = 0; to = 127
+    case "move-wide-1024": n = 1024; from = 0; to = 1023
+    case "move-middle-128": n = 128; from = 32; to = 96
+    case "move-adjacent-4096": n = 4096; from = 2048; to = 2049
+    case "move-noop-128": n = 128; from = 32; to = 32
+    case "move-absent-128": n = 128; from = -1; to = 0
+    default: fatalError("unknown workload")
+    }
+    let set = OrderedSet(sequence: 0..<n)
+    operation = {
+        set.moveObject(from, toIndex: to)
+        let moved = set.index(of: from) ?? -1
+        if from >= 0 { set.moveObject(from, toIndex: from) }
+        return moved + set.count + (set.index(of: from) ?? -1) + 2
+    }
+} else if name == "parse-selector" {
+    // Typical, short ASCII selector grammar with Unicode content. No query cache.
+    let query = "main > section.article:nth-child(2n + 1) p:contains(日本語)"
+    operation = { let parsed = try QueryParser.parse(query); return parsed.toString().utf8.count }
+} else if name == "parse-control" {
+    let html = "<main>" + (0..<128).map { "<section id='n\($0)'><p>日本語の文章 \($0)</p></section>" }.joined() + "</main>"
+    operation = { let doc = try SwiftSoup.parse(html); return try doc.text().utf8.count + doc.select("p").size() }
+} else { fatalError("unknown workload") }
+let expected = try operation()
+for _ in 0..<3 { let value = try operation(); precondition(value == expected) }
+let start = DispatchTime.now().uptimeNanoseconds
+var checksum = 0
+for _ in 0..<iterations { checksum += try operation() }
+let elapsed = DispatchTime.now().uptimeNanoseconds - start
+precondition(checksum == expected * iterations)
+let data = try JSONSerialization.data(withJSONObject: ["workload": name, "iterations": iterations,
+    "elapsed_ns": elapsed, "expected": expected, "checksum": checksum], options: [.sortedKeys])
+print(String(decoding: data, as: UTF8.self))

--- a/Tools/benchmark_entities.swift
+++ b/Tools/benchmark_entities.swift
@@ -1,0 +1,98 @@
+import Foundation
+import SwiftSoup
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+    exit(2)
+}
+let args = Array(CommandLine.arguments.dropFirst())
+func option(_ name: String, _ fallback: String) -> String {
+    guard let i = args.firstIndex(of: name) else { return fallback }
+    guard i + 1 < args.count else { fail("Missing value for \(name)") }
+    return args[i + 1]
+}
+let workload = option("--workload", "escape-japanese")
+guard let iterations = Int(option("--iterations", "100")), iterations > 0,
+      let size = Int(option("--size", "256")), size > 0,
+      let warmups = Int(option("--warmups", "3")), warmups >= 0 else { fail("Invalid count") }
+let settings = OutputSettings().charset(.utf8).prettyPrint(pretty: false)
+let phrase = "吾輩は猫である名前はまだ無い。"
+let escapeInputs: [String]
+switch workload {
+case "escape-japanese": escapeInputs = (0..<8).map { String(repeating: phrase, count: size) + "&\($0)" }
+case "escape-mixed": escapeInputs = (0..<8).map { String(repeating: "日本語を読む & 東京<京都> 👩🏽‍💻 café e\u{301}\u{A0}\n", count: size) + "\($0)" }
+case "escape-ascii": escapeInputs = (0..<8).map { String(repeating: "A readable ASCII phrase & <markup> \"quote\".", count: size) + "\($0)" }
+case "escape-plain": escapeInputs = (0..<8).map { String(repeating: phrase, count: size) + "\($0)" }
+case "escape-short": escapeInputs = ["&猫", "é&", "猫<&", "abc&", "aé&", "👩🏽‍💻&", "\u{A0}&", ""]
+default: escapeInputs = []
+}
+let entityText: String
+switch workload {
+case "unescape-multi", "parse-multi-string", "parse-multi-data", "parse-multi-buffer":
+    entityText = "&NotEqualTilde;&NotGreaterFullEqual;&NotNestedGreaterGreater;&NotSquareSubset;"
+case "unescape-long", "parse-long-string", "parse-long-data", "parse-long-buffer":
+    entityText = "&CounterClockwiseContourIntegral;&ClockwiseContourIntegral;&DoubleLongLeftRightArrow;"
+case "unescape-unknown", "parse-unknown-string":
+    entityText = "&NotARealLongEntity;&AnotherMissingName;&UnknownReference;"
+case "unescape-common", "parse-common-string": entityText = "&amp;&lt;&quot;&nbsp;&#x732b;"
+case "parse-normal-string", "parse-normal-data": entityText = "日本語の記事です。東京と京都の本を読みます。 text &amp; reading."
+default: entityText = ""
+}
+let unescapeInputs = (0..<8).map { String(repeating: entityText, count: size) + "\($0)" }
+let htmlInputs = (0..<8).map { index in
+    "<html><head><title>Article \(index)</title></head><body>" +
+    (0..<size).map { "<p data-seq='\($0)'>\(entityText)</p>" }.joined() + "</body></html>"
+}
+let dataInputs = htmlInputs.map { Data($0.utf8) }
+let byteInputs = htmlInputs.map { Array($0.utf8) }
+let document = Document("")
+document.outputSettings().prettyPrint(pretty: false).charset(.utf8)
+if workload == "serialize-japanese" {
+    let body = try document.appendElement("body")
+    for i in 0..<size {
+        try body.appendElement("p").attr("title", phrase + "&\(i)").text(String(repeating: phrase, count: 8) + " & \(i)")
+    }
+}
+@inline(never)
+func runOne(_ i: Int) throws -> String {
+    let index = i & 7
+    if workload.hasPrefix("escape-") { return Entities.escape(escapeInputs[index], settings) }
+    if workload.hasPrefix("unescape-") { return try Entities.unescape(unescapeInputs[index]) }
+    if workload == "serialize-japanese" { return try document.outerHtml() }
+    if workload.hasPrefix("parse-") {
+        let doc: Document
+        if workload.hasSuffix("-data") {
+            doc = try SwiftSoup.parse(dataInputs[index])
+        } else if workload.hasSuffix("-buffer") {
+            doc = try SwiftSoup.parse(withBytes: { parse in
+                try byteInputs[index].withUnsafeBufferPointer { try parse($0) }
+            })
+        } else {
+            doc = try SwiftSoup.parse(htmlInputs[index])
+        }
+        return try doc.text()
+    }
+    fail("Unknown workload \(workload)")
+}
+if args.contains("--verify") {
+    for i in 0..<8 { print(Data(try runOne(i).utf8).base64EncodedString()) }
+} else {
+    var checksum = 0
+    for i in 0..<warmups { checksum &+= try runOne(i).utf8.count }
+    var cpuStart = timespec()
+    guard clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &cpuStart) == 0 else { fail("CPU clock unavailable") }
+    let start = DispatchTime.now().uptimeNanoseconds
+    for i in 0..<iterations { checksum &+= try runOne(i).utf8.count }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    var cpuEnd = timespec()
+    guard clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &cpuEnd) == 0 else { fail("CPU clock unavailable") }
+    let cpu = (cpuEnd.tv_sec - cpuStart.tv_sec) * 1_000_000_000 + cpuEnd.tv_nsec - cpuStart.tv_nsec
+    let result: [String: Any] = ["workload": workload, "size": size, "iterations": iterations,
+        "warmups": warmups, "nanoseconds": elapsed, "cpu_nanoseconds": cpu, "checksum": checksum]
+    print(String(decoding: try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]), as: UTF8.self))
+}

--- a/Tools/benchmark_exclusion.swift
+++ b/Tools/benchmark_exclusion.swift
@@ -1,0 +1,95 @@
+import Foundation
+import SwiftSoup
+
+private func emit(_ value: Any) throws {
+    let data = try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([10]))
+}
+
+private func markup(_ width: Int, dropEvery: Int = 2, descendants: Int = 0) -> String {
+    "<main>" + (0..<width).map { i in
+        "<section id='n\(i)' class='\(i % dropEvery == 0 ? "drop" : "keep")'>日本語 \(i)" +
+        (0..<descendants).map { j in "<span id='d\(i)-\(j)' class='drop'>text</span>" }.joined() + "</section>"
+    }.joined() + "</main>"
+}
+
+private func verification() throws {
+    var records: [[String: Any]] = []
+    for width in [0, 1, 8, 63, 64, 65, 128, 512] {
+        for descendants in [0, 3] {
+            let document = try SwiftSoup.parse(markup(width, descendants: descendants))
+            let roots = try document.select("section").array()
+            let input = roots + roots.reversed()
+            let list = Elements(input)
+            for round in 0..<4 {
+                if round > 0, let first = roots.first {
+                    try first.attr("class", round % 2 == 0 ? "drop" : "keep")
+                    if round == 2 { try first.remove() }
+                    if round == 3 { try document.body()!.appendChild(first) }
+                }
+                let expected = try input.filter { !$0.hasClass("drop") }.map { try $0.attr("id") }
+                let a = try list.not(".drop").map { try $0.attr("id") }
+                let b = try list.not(Evaluator.Class("drop")).map { try $0.attr("id") }
+                precondition(a == expected && b == expected)
+                records.append(["width": width, "descendants": descendants, "round": round,
+                                "string": a, "evaluator": b, "html": try document.outerHtml(),
+                                "input": try input.map { try $0.attr("id") }])
+            }
+        }
+    }
+    try emit(records)
+}
+
+private func main() throws {
+    let args = CommandLine.arguments
+    if args.count == 2 && args[1] == "--verify" { try verification(); return }
+    guard args.count == 3, let iterations = Int(args[2]), iterations > 0 else {
+        throw NSError(domain: "benchmark", code: 1, userInfo: [NSLocalizedDescriptionKey: "usage: benchmark WORKLOAD ITERATIONS | --verify"])
+    }
+    let name = args[1]
+    let operation: () throws -> UInt64
+    if name == "parse-control" || name == "parse-not" {
+        let html = markup(512)
+        operation = {
+            let document = try SwiftSoup.parse(html)
+            let list = try document.select("section")
+            return UInt64(try (name == "parse-not" ? list.not(".drop").size() : document.text().utf8.count))
+        }
+    } else {
+        let width: Int
+        let dropEvery: Int
+        let descendants: Int
+        switch name {
+        case "not-8": (width, dropEvery, descendants) = (8, 2, 0)
+        case "not-128": (width, dropEvery, descendants) = (128, 2, 0)
+        case "not-512": (width, dropEvery, descendants) = (512, 2, 0)
+        case "not-2048": (width, dropEvery, descendants) = (2048, 2, 0)
+        case "not-8192": (width, dropEvery, descendants) = (8192, 2, 0)
+        case "sparse-control": (width, dropEvery, descendants) = (1024, 128, 0)
+        case "descendant-control": (width, dropEvery, descendants) = (64, 2, 64)
+        default: throw NSError(domain: "benchmark", code: 2, userInfo: [NSLocalizedDescriptionKey: "unknown workload"])
+        }
+        let document = try SwiftSoup.parse(markup(width, dropEvery: dropEvery, descendants: descendants))
+        let list = try document.select("section")
+        let expected = list.array().filter { !$0.hasClass("drop") }
+        let check = try list.not(".drop").array()
+        precondition(check.map(ObjectIdentifier.init) == expected.map(ObjectIdentifier.init))
+        operation = {
+            let result = try list.not(".drop")
+            var sum = UInt64(result.count)
+            for element in result { sum += UInt64(element.siblingIndex + 1) }
+            return withExtendedLifetime(document) { sum }
+        }
+    }
+    let expected = try operation()
+    for _ in 0..<3 { let warm = try operation(); precondition(warm == expected) }
+    var checksum: UInt64 = 0
+    let start = DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<iterations { checksum += try operation() }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    precondition(checksum == expected * UInt64(iterations))
+    try emit(["workload": name, "iterations": iterations, "elapsed_ns": elapsed,
+              "expected": expected, "checksum": checksum])
+}
+try main()

--- a/Tools/benchmark_independent_hotspots.swift
+++ b/Tools/benchmark_independent_hotspots.swift
@@ -1,0 +1,148 @@
+import Foundation
+import SwiftSoup
+
+private final class ReversedBenchmarkParent: Element {
+    override func children() -> Elements {
+        Elements(Array(super.children().array().reversed()))
+    }
+}
+
+private func output(_ object: Any) throws {
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([10]))
+}
+
+private func rules() throws -> Whitelist {
+    try Whitelist.none().addTags("main", "p", "b", "span")
+        .addAttributes(":all", "style")
+        .addCSSProperties(":all", "color", "font-weight", "font-family", "content", "width", "margin", "background-image", "transform")
+}
+
+private func markup(_ count: Int, mixed: Bool = false, style: String? = nil) -> String {
+    "<main>" + (0..<count).map { i in
+        let gap = mixed ? "text<!--gap-->" : ""
+        let attribute = style.map { " style=\"\($0)\"" } ?? ""
+        return "\(gap)<p id='n\(i)'\(attribute)>日本語 \(i)<b>text</b></p>"
+    }.joined() + "</main>"
+}
+
+private func verification() throws {
+    var records = [[String: Any]]()
+    let selectors = [":first-child", ":nth-child(2n)", ":nth-child(3n+1)", ":nth-last-child(2)", ":nth-last-of-type(2)"]
+    for width in [1, 2, 8, 32, 128] {
+        for mixed in [false, true] {
+            let document = try SwiftSoup.parse(markup(width, mixed: mixed))
+            let root = try document.select("main").first()!
+            for round in 0..<4 {
+                let children = root.children().array()
+                var selected = [[String]]()
+                for query in selectors {
+                    selected.append(try root.select(query).map { try $0.attr("id") })
+                }
+                records.append(["kind": "position", "width": width, "mixed": mixed, "round": round,
+                                "positions": try children.map { try $0.elementSiblingIndex() },
+                                "ids": try children.map { try $0.attr("id") }, "selection": selected,
+                                "html": try root.outerHtml(), "text": try root.text()])
+                try root.prependChild(children.last!)
+            }
+        }
+    }
+    let rules = try rules()
+    let element = try Element(Tag.valueOf("p"), "")
+    let values = ["red", "'日本語'", "'cafe\u{301}'", "'👩🏽‍💻'", "'a;b:c'", "url(x)", "exp/*c*/ression(1)", "calc(100% / 2)", "'a/*b*/c'", "'a\\\"b'", "u\u{00A0}rl(x)", "re/**/d", "red/*unterminated", "'unterminated", "\u{301}x", "'∕／⁄'", "'a/\u{301}*b'", "'a*\u{301}/b'", "'a\r\nb'", "'\\/x'"]
+    let keys = ["color", "font-family", "content", "width", "unknown"]
+    var seed: UInt64 = 0x49abc
+    for i in 0..<2048 {
+        seed = seed &* 6364136223846793005 &+ 1
+        let key = keys[Int(seed % UInt64(keys.count))]
+        let value = values[Int((seed >> 12) % UInt64(values.count))]
+        let prefix = i % 3 == 0 ? "/*before*/" : ""
+        let suffix = i % 5 == 0 ? "; color:blue" : ""
+        let style = prefix + key + ":" + value + suffix
+        let attribute = try Attribute(key: "style", value: style)
+        let cleaned = try rules.safeAttribute("p", element, attribute)
+        records.append(["kind": "style", "input": style, "result": cleaned?.getValue() as Any? ?? NSNull(), "original": attribute.getValue()])
+    }
+    let cleaner = Cleaner(headWhitelist: nil, bodyWhitelist: rules)
+    for style in values {
+        let document = try SwiftSoup.parse(markup(8))
+        for p in try document.select("p") { try p.attr("style", "content:" + style + "; color:red") }
+        let before = try document.outerHtml()
+        let clean = try cleaner.clean(document)
+        records.append(["kind": "clean", "input": before, "originalAfter": try document.outerHtml(),
+                        "cleanHTML": try clean.outerHtml(), "cleanText": try clean.text()])
+    }
+    precondition(!records.isEmpty)
+    try output(records)
+}
+
+private func run() throws {
+    let args = CommandLine.arguments
+    if args.count == 2 && args[1] == "--verify" { try verification(); return }
+    guard args.count == 3, let iterations = Int(args[2]), iterations > 0 else {
+        throw NSError(domain: "benchmark", code: 1, userInfo: [NSLocalizedDescriptionKey: "usage: benchmark WORKLOAD ITERATIONS | --verify"])
+    }
+    let name = args[1]
+    let operation: () throws -> UInt64
+    switch name {
+    case "index-wide", "index-mixed":
+        let document = try SwiftSoup.parse(markup(256, mixed: name == "index-mixed"))
+        let root = try document.select("main").first()!
+        let children = root.children().array()
+        operation = { var sum: UInt64 = 0; for e in children { sum &+= UInt64(try e.elementSiblingIndex()) }; return withExtendedLifetime(document) { sum } }
+    case "nth-select":
+        let document = try SwiftSoup.parse(markup(256, mixed: true))
+        let root = try document.select("main").first()!
+        let evaluator = Evaluator.IsNthChild(2, 0)
+        operation = { withExtendedLifetime(document) {}; return UInt64(try Collector.collect(evaluator, root).size()) }
+    case "parse-nth", "parse-control":
+        let html = markup(128, mixed: true)
+        let evaluator = Evaluator.IsNthChild(2, 0)
+        if name == "parse-nth" {
+            operation = { let d = try SwiftSoup.parse(html); return UInt64(try Collector.collect(evaluator, d).size()) }
+        } else {
+            operation = { let d = try SwiftSoup.parse(html); return UInt64(try d.text().utf8.count) }
+        }
+    case "custom-parent":
+        let parent = try ReversedBenchmarkParent(Tag.valueOf("main"), "")
+        try parent.append((0..<128).map { "<p>\($0)</p>" }.joined())
+        let children = parent.children().array()
+        operation = { var sum: UInt64 = 0; for e in children { sum &+= UInt64(try e.elementSiblingIndex()) }; return withExtendedLifetime(parent) { sum } }
+    case "css-short", "css-long", "css-slash", "css-comments":
+        let rules = try rules()
+        let element = try Element(Tag.valueOf("p"), "")
+        let style: String
+        if name == "css-long" { style = "font-family:'" + String(repeating: "日本語名e\u{301}👩🏽‍💻 ", count: 32) + "'; color:red" }
+        else if name == "css-slash" { style = "content:'" + String(repeating: "日本語abcdefgh ", count: 32) + "/'; color:red" }
+        else if name == "css-comments" { style = "/*before*/co/*x*/lor:red; content:'a/*b*/c'; width:calc(100% / 2)" }
+        else { style = "color:navy; font-weight:bold; margin:0 1em; font-family:'日本語'" }
+        let attributes = try (0..<64).map { _ in try Attribute(key: "style", value: style) }
+        operation = { var sum: UInt64 = 0; for a in attributes { sum &+= UInt64(try rules.safeAttribute("p", element, a)?.getValue().utf8.count ?? 0) }; return sum }
+    case "clean-styled", "parse-clean", "clean-plain":
+        let rules = try rules()
+        let cleaner = Cleaner(headWhitelist: nil, bodyWhitelist: rules)
+        let style = name == "clean-plain" ? nil : "color:navy; font-weight:bold; margin:0 1em; font-family:'日本語'"
+        let html = markup(64, style: style)
+        let document = try SwiftSoup.parse(html)
+        if name == "parse-clean" {
+            operation = { let d = try SwiftSoup.parse(html); return UInt64(try cleaner.clean(d).outerHtml().utf8.count) }
+        } else {
+            operation = { UInt64(try cleaner.clean(document).outerHtml().utf8.count) }
+        }
+    default: throw NSError(domain: "benchmark", code: 2, userInfo: [NSLocalizedDescriptionKey: "unknown workload \(name)"])
+    }
+    let expected = try operation()
+    for _ in 0..<3 { let value = try operation(); precondition(value == expected) }
+    var checksum: UInt64 = 0
+    let start = DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<iterations { checksum &+= try operation() }
+    let duration = DispatchTime.now().uptimeNanoseconds - start
+    precondition(checksum == expected &* UInt64(iterations))
+    try output(["workload": name, "iterations": iterations, "elapsed_ns": duration, "checksum": checksum, "expected": expected])
+}
+
+do { try run() } catch {
+    FileHandle.standardError.write(Data("\(error)\n".utf8))
+    exit(1)
+}

--- a/Tools/benchmark_ordered_insertion.swift
+++ b/Tools/benchmark_ordered_insertion.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftSoup
+
+private func emit(_ value: Any) throws {
+    let data = try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([10]))
+}
+
+private func verification() throws {
+    var records: [[String: Any]] = []
+    for width in [0, 1, 8, 16, 63, 64, 128] {
+        for gap in 0...width {
+            let set = OrderedSet(sequence: Array(0..<width))
+            let before = Array(set)
+            var expected = before
+            expected.insert(-1, at: gap)
+            set.insert(-1, at: gap)
+            precondition(Array(set) == expected)
+            let indices = expected.map { set.index(of: $0)! }
+            precondition(indices == Array(expected.indices))
+            // Existing values must not move or replace their representative.
+            set.insert(-1, at: set.count)
+            precondition(Array(set) == expected)
+            records.append(["width": width, "gap": gap, "values": Array(set), "indices": indices])
+            set.remove(-1)
+            precondition(Array(set) == before)
+        }
+    }
+    try emit(records)
+}
+
+private func main() throws {
+    let args = CommandLine.arguments
+    if args.count == 2 && args[1] == "--verify" { try verification(); return }
+    guard args.count == 3, let iterations = Int(args[2]), iterations > 0 else {
+        throw NSError(domain: "benchmark", code: 1, userInfo: [NSLocalizedDescriptionKey: "usage: benchmark WORKLOAD ITERATIONS | --verify"])
+    }
+    let name = args[1]
+    let operation: () throws -> UInt64
+    if name == "parse-control" {
+        let html = "<main>" + (0..<128).map { "<p class='x'>日本語 \($0)</p>" }.joined() + "</main>"
+        operation = {
+            let document = try SwiftSoup.parse(html)
+            return UInt64(try document.select("p.x").count + document.text().utf8.count)
+        }
+    } else {
+        let parts = name.split(separator: "-")
+        guard parts.count == 2, let width = Int(parts[1]), [16, 128, 1024].contains(width),
+              ["head", "middle", "tail", "duplicate"].contains(parts[0]) else {
+            throw NSError(domain: "benchmark", code: 2, userInfo: [NSLocalizedDescriptionKey: "unknown workload"])
+        }
+        let whereTo = String(parts[0])
+        let values = Array(0..<width)
+        let set = OrderedSet(sequence: values)
+        let gap = whereTo == "head" ? 0 : whereTo == "middle" ? width / 2 : width
+        // Full array/index expectations are checked outside the timed loop.
+        if whereTo != "duplicate" {
+            var expected = values
+            expected.insert(-1, at: gap)
+            set.insert(-1, at: gap)
+            precondition(Array(set) == expected)
+            precondition(expected.enumerated().allSatisfy { set.index(of: $0.element) == $0.offset })
+            set.remove(-1)
+        }
+        operation = {
+            if whereTo == "duplicate" {
+                set.insert(width / 2, at: 0)
+                return UInt64(set.index(of: width / 2)! + set.count)
+            }
+            set.insert(-1, at: gap)
+            let checksum = UInt64(set.index(of: -1)! + set.count)
+            set.remove(-1) // restore fixed-sized state; removal is included in timing
+            return checksum
+        }
+        precondition(Array(set) == values)
+    }
+    let expected = try operation()
+    for _ in 0..<3 { let warm = try operation(); precondition(warm == expected) }
+    var checksum: UInt64 = 0
+    let start = DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<iterations { checksum += try operation() }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    precondition(checksum == expected * UInt64(iterations))
+    try emit(["workload": name, "iterations": iterations, "elapsed_ns": elapsed,
+              "expected": expected, "checksum": checksum])
+}
+try main()

--- a/Tools/benchmark_pattern_reuse.swift
+++ b/Tools/benchmark_pattern_reuse.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Dispatch
+import SwiftSoup
+
+func option(_ key: String, _ fallback: String) -> String {
+    guard let i = CommandLine.arguments.firstIndex(of: key), i + 1 < CommandLine.arguments.count else { return fallback }
+    return CommandLine.arguments[i + 1]
+}
+let workload = option("--workload", "reused")
+guard let iterations = Int(option("--iterations", "100")), iterations > 0 else { fatalError("Positive iterations required") }
+let expression = "[0-9]+|日本語"
+let texts = (0..<256).map { "日本語 item\($0)" }
+let pattern = Pattern.compile(expression)
+let markup = "<main>" + texts.prefix(64).map { "<p>\($0)</p>" }.joined() + "</main>"
+@inline(never) func operation() throws -> Int {
+    var result = 0
+    switch workload {
+    case "reused":
+        for text in texts { result += pattern.matcher(in: text).count }
+    case "validated":
+        for text in texts { try pattern.validate(); result += pattern.matcher(in: text).count }
+    case "fresh":
+        for text in texts { result += Pattern.compile(expression).matcher(in: text).count }
+    case "unused":
+        for text in texts { result += Pattern.compile(expression + text).toString().utf8.count }
+    case "parse":
+        result = try SwiftSoup.parse(markup).text().utf8.count
+    default: fatalError("Unknown workload")
+    }
+    return result
+}
+for _ in 0..<3 { _ = try operation() }
+var checksum = 0
+let start = DispatchTime.now().uptimeNanoseconds
+for _ in 0..<iterations { checksum &+= try operation() }
+let elapsed = DispatchTime.now().uptimeNanoseconds - start
+let record: [String: Any] = ["workload": workload, "iterations": iterations, "elapsed_ns": elapsed,
+                           "ns_per_op": Double(elapsed) / Double(iterations), "checksum": checksum]
+print(String(decoding: try JSONSerialization.data(withJSONObject: record, options: [.sortedKeys]), as: UTF8.self))

--- a/Tools/benchmark_sibling_endpoints.swift
+++ b/Tools/benchmark_sibling_endpoints.swift
@@ -1,0 +1,83 @@
+import Foundation
+import SwiftSoup
+
+final class CustomParent: Element, @unchecked Sendable {}
+
+struct Workload {
+    let name: String
+    let parent: Element?
+    let receiver: Element?
+    let html: String?
+    func run() throws -> Int {
+        if let html {
+            let doc=try SwiftSoup.parse(html)
+            let nodes=try doc.select("section").array()
+            if name=="parse-control" { return nodes.count + (try doc.select("p").size()) }
+            return nodes.reduce(0) { result,node in result + (node.firstElementSibling()?.siblingIndex ?? -1) + (node.lastElementSibling()?.siblingIndex ?? -1) }
+        }
+        let node=receiver!
+        var result=0
+        for _ in 0..<32 {
+            let endpoint=name.hasPrefix("last-") ? node.lastElementSibling() : node.firstElementSibling()
+            result += (endpoint?.siblingIndex ?? -1) + 2
+        }
+        // Keep the owning parent live throughout every read, including optimized builds.
+        withExtendedLifetime(parent) {}
+        return result
+    }
+}
+
+func fixture(_ name: String) throws -> Workload {
+    if name.hasPrefix("parse-") {
+        let html="<main>" + (0..<128).map { "<section id='n\($0)'><p>日本語</p><p>文章</p></section>" }.joined() + "</main>"
+        return Workload(name:name,parent:nil,receiver:nil,html:html)
+    }
+    let count: Int
+    if name=="single" { count=1 }
+    else if name=="first-mixed" { count=4 }
+    else if name=="fallback" { count=256 }
+    else { count=Int(name.split(separator:"-").last!)! }
+    let parent:Element = name=="fallback" ? try CustomParent(Tag.valueOf("main"), "") : try Element(Tag.valueOf("main"), "")
+    if name=="first-mixed" { for _ in 0..<256 { try parent.appendChild(TextNode("文字", "")); try parent.appendChild(Comment(Array("c".utf8), [])) } }
+    for i in 0..<count { try parent.appendElement("p").attr("id", "n\(i)") }
+    return Workload(name:name,parent:parent,receiver:parent.children().last()!,html:nil)
+}
+
+func verify() throws {
+    var records=[[String:Any]]()
+    for count in 1...48 {
+        let root=try Element(Tag.valueOf("main"), "")
+        for i in 0..<count {
+            try root.appendChild(TextNode("日本語", ""))
+            try root.appendElement("p").attr("id", "n\(i)")
+            try root.appendChild(Comment(Array("c".utf8), []))
+        }
+        let nodes=root.children().array()
+        for node in nodes {
+            let first=node.firstElementSibling(), last=node.lastElementSibling()
+            precondition(first === (count>1 ? nodes.first:nil))
+            precondition(last === (count>1 ? nodes.last:nil))
+            records.append(["count":count,"node":node.id(),"first":first?.id() ?? "nil","last":last?.id() ?? "nil"])
+        }
+        records.append(["count":count,"html":try root.outerHtml()])
+    }
+    for name in ["single","first-8","first-256","first-2048","last-256","last-2048","first-mixed","fallback","parse-endpoints","parse-control"] {
+        let work=try fixture(name)
+        records.append(["case":name,"expected":try work.run()])
+    }
+    FileHandle.standardOutput.write(try JSONSerialization.data(withJSONObject:records,options:[.sortedKeys]))
+}
+
+let args=CommandLine.arguments
+if args.count==2 && args[1]=="--verify" { try verify() }
+else {
+    guard args.count==3,let n=Int(args[2]),n>0 else { fatalError("Usage: benchmark CASE ITERATIONS | --verify") }
+    let work=try fixture(args[1]), expected=try work.run()
+    for _ in 0..<3 { let observed=try work.run(); precondition(observed==expected) }
+    var checksum=0
+    let start=DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<n { checksum &+= try work.run() }
+    let ns=DispatchTime.now().uptimeNanoseconds-start
+    precondition(checksum==expected*n)
+    FileHandle.standardOutput.write(try JSONSerialization.data(withJSONObject:["case":args[1],"iterations":n,"ns":ns,"expected":expected,"checksum":checksum],options:[.sortedKeys])); print("")
+}

--- a/Tools/benchmark_tokenqueue_search.swift
+++ b/Tools/benchmark_tokenqueue_search.swift
@@ -1,0 +1,87 @@
+// Public-API benchmark. Build with -O against the matching SwiftSoup module.
+// Run <workload> <iterations>, --verify, or --list. Cache disabled explicitly.
+import Foundation
+import SwiftSoup
+
+struct SearchCase {
+    let name: String
+    let input: String
+    let needle: String
+    let prefix: String
+    let skip: String
+}
+let japanese = "日本語文"
+let mixed = "日e\u{301}👩🏽‍💻🇯🇵\r\n"
+let cases: [SearchCase] = [
+    SearchCase(name: "early-ascii", input: "(" + String(repeating: "x", count: 2048), needle: "(", prefix: "", skip: ""),
+    SearchCase(name: "tiny-ascii", input: "li:eq(1)", needle: "(", prefix: "li:eq", skip: ""),
+    SearchCase(name: "late-ascii-2048", input: String(repeating: "x", count: 2048) + ")tail", needle: ")", prefix: String(repeating: "x", count: 2048), skip: ""),
+    SearchCase(name: "late-japanese-128", input: String(repeating: japanese, count: 32) + ")tail", needle: ")", prefix: String(repeating: japanese, count: 32), skip: ""),
+    SearchCase(name: "late-japanese-512", input: String(repeating: japanese, count: 128) + ")tail", needle: ")", prefix: String(repeating: japanese, count: 128), skip: ""),
+    SearchCase(name: "late-japanese-2048", input: String(repeating: japanese, count: 512) + ")tail", needle: ")", prefix: String(repeating: japanese, count: 512), skip: ""),
+    SearchCase(name: "miss-japanese-512", input: String(repeating: japanese, count: 128), needle: ")", prefix: "", skip: ""),
+    SearchCase(name: "mixed-graphemes", input: String(repeating: mixed, count: 128) + ")tail", needle: ")", prefix: String(repeating: mixed, count: 128), skip: ""),
+    SearchCase(name: "offset-japanese", input: "skip" + String(repeating: japanese, count: 128) + ")tail", needle: ")", prefix: String(repeating: japanese, count: 128), skip: "skip"),
+    SearchCase(name: "canonical-match", input: String(repeating: "日", count: 512) + "e\u{301}tail", needle: "é", prefix: String(repeating: "日", count: 512), skip: "")
+]
+let names = cases.map(\.name) + ["numeric-parse-512", "normal-parse-control"]
+QueryParser.cache = nil
+
+func makeOperation(_ name: String) throws -> () throws -> Int {
+    if let fixture = cases.first(where: { $0.name == name }) {
+        return {
+            let q = TokenQueue(fixture.input)
+            if !fixture.skip.isEmpty { try q.consume(fixture.skip) }
+            let consumed = q.consumeTo(fixture.needle)
+            return consumed.utf8.count &+ q.toString().utf8.count
+        }
+    }
+    if name == "numeric-parse-512" {
+        let query = "li:eq(" + String(repeating: "0", count: 512) + "1)"
+        return { try QueryParser.parse(query).toString().utf8.count }
+    }
+    if name == "normal-parse-control" {
+        let html = "<article>" + String(repeating: "<p>日本語の文章 <em>example</em></p>", count: 64) + "</article>"
+        return {
+            let doc = try SwiftSoup.parse(html)
+            return try doc.select("p").size() + doc.text().utf8.count
+        }
+    }
+    throw NSError(domain: "Unknown workload", code: 1)
+}
+func output(_ object: Any) throws {
+    let bytes = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    print(String(decoding: bytes, as: UTF8.self))
+}
+if CommandLine.arguments.count == 2, CommandLine.arguments[1] == "--list" {
+    try output(names)
+} else if CommandLine.arguments.count == 2, CommandLine.arguments[1] == "--verify" {
+    var records: [[String: Any]] = []
+    for fixture in cases {
+        let q = TokenQueue(fixture.input)
+        if !fixture.skip.isEmpty { try q.consume(fixture.skip) }
+        let consumed = q.consumeTo(fixture.needle)
+        precondition(Array(consumed.utf8) == Array(fixture.prefix.utf8))
+        records.append(["name": fixture.name, "prefix": Array(consumed.utf8), "remainder": Array(q.toString().utf8)])
+    }
+    for count in [0, 1, 8, 32, 128] {
+        let html = "<article>" + String(repeating: "<p>日e\u{301}<ruby>語<rt>ご</rt></ruby></p>", count: count) + "</article>"
+        let doc = try SwiftSoup.parse(html)
+        records.append(["html": Array(try doc.outerHtml().utf8), "text": Array(try doc.text().utf8), "count": try doc.select("p").size()])
+    }
+    try output(records)
+} else {
+    guard CommandLine.arguments.count == 3, let iterations = Int(CommandLine.arguments[2]), iterations > 0 else {
+        fatalError("Use --list, --verify, or <workload> <positive iterations>")
+    }
+    let name = CommandLine.arguments[1]
+    let operation = try makeOperation(name)
+    let expected = try operation()
+    for _ in 0..<3 { let value = try operation(); precondition(value == expected) }
+    var checksum = 0
+    let start = DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<iterations { checksum &+= try operation() }
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    precondition(checksum == expected &* iterations)
+    try output(["workload": name, "iterations": iterations, "elapsed_ns": elapsed, "checksum": checksum, "expected": expected])
+}

--- a/Tools/benchmark_whitespace_runs.swift
+++ b/Tools/benchmark_whitespace_runs.swift
@@ -1,0 +1,59 @@
+// Build against a release SwiftSoup library without -enable-testing.
+import Foundation
+import Dispatch
+import SwiftSoup
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+func option(_ name: String, _ fallback: String) -> String {
+    guard let i = CommandLine.arguments.firstIndex(of: name), i + 1 < CommandLine.arguments.count else { return fallback }
+    return CommandLine.arguments[i + 1]
+}
+let workload = option("--workload", "text-japanese")
+guard let iterations = Int(option("--iterations", "100")), iterations > 0,
+      let size = Int(option("--size", "128")), (1...4096).contains(size) else {
+    fatalError("Iterations must be positive; size must be 1...4096")
+}
+let japanese = String(repeating: "日本語の文章を読んで言葉の意味を理解します。", count: 8)
+let pieces: [String]
+switch workload {
+case "text-ascii": pieces = (0..<size).map { "\tArticle \($0) " + String(repeating: "A reader learns words and phrases. ", count: 8) + "\nEnd" }
+case "text-short": pieces = (0..<size).map { "\t日本語\($0)\nです" }
+case "text-mixed": pieces = (0..<size).map { "\t\($0) " + String(repeating: "日本語abc😀e\u{301}文章\u{a0} 次\n", count: 8) }
+case "text-plain": pieces = (0..<size).map { _ in japanese }
+case "text-japanese", "textnode", "owntext", "parse-text", "raw":
+    pieces = (0..<size).map { "\t" + japanese + "\n段落\($0)\u{a0}" + japanese }
+default: fatalError("Unknown workload: \(workload)")
+}
+let html = "<main>" + pieces.map { "<p>\($0)</p>" }.joined() + "</main>"
+let doc = try SwiftSoup.parse(html)
+let root = try doc.select("main").first()!
+let paragraphs = try doc.select("p").array()
+let nodes = pieces.map { TextNode($0, "") }
+let run: () throws -> Int
+switch workload {
+case "textnode": run = { nodes.reduce(0) { $0 &+ $1.text().utf8.count } }
+case "owntext": run = { paragraphs.reduce(0) { $0 &+ $1.ownText().utf8.count } }
+case "parse-text": run = { try SwiftSoup.parse(html).text().utf8.count }
+case "raw": run = { try root.text(trimAndNormaliseWhitespace: false).utf8.count }
+default: run = { try root.text().utf8.count }
+}
+if CommandLine.arguments.contains("--verify") {
+    let outputs: [String: Any] = ["text": try root.text(), "raw": try root.text(trimAndNormaliseWhitespace: false),
+                                "bytes": try root.textUTF8(), "slice": Array(try root.textUTF8Slice()),
+                                "own": paragraphs.map { $0.ownText() }, "nodes": nodes.map { $0.text() },
+                                "html": try doc.outerHtml(), "checksum": try run()]
+    FileHandle.standardOutput.write(try JSONSerialization.data(withJSONObject: outputs, options: [.sortedKeys]))
+    exit(0)
+}
+for _ in 0..<3 { _ = try run() }
+let start = DispatchTime.now().uptimeNanoseconds
+var checksum = 0
+for _ in 0..<iterations { checksum &+= try run() }
+let nanos = DispatchTime.now().uptimeNanoseconds - start
+let result: [String: Any] = ["workload": workload, "size": size, "iterations": iterations,
+                           "elapsed_ns": nanos, "ns_per_op": Double(nanos) / Double(iterations), "checksum": checksum]
+print(String(decoding: try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys]), as: UTF8.self))

--- a/Tools/compare_blank_text.py
+++ b/Tools/compare_blank_text.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and identical
+public client source separately compiled against each matching library. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+import numpy as np
+from scipy.stats import t
+
+WORKLOADS = {
+    "blank": ["string-short", "string-blank-long", "string-unicode", "node-short", "node-blank-long", "node-unicode", "node-late-text", "node-custom", "hastext-blank", "hastext-nonblank", "serialize-pretty", "parse-hastext", "parse-control"]
+}
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--baseline-client',type=Path,required=True)
+    p.add_argument('--candidate-client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    a.output.mkdir(parents=True,exist_ok=False)
+    clients={'A': a.baseline_client.resolve(), 'B': (a.baseline_client if a.aa else a.candidate_client).resolve()}
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(clients[k]),*args],env=variables[k],check=True,capture_output=True,text=True,timeout=120)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    if verify['A'] != verify['B']: raise RuntimeError('Full observable outputs differ; refusing to benchmark')
+    observed=json.loads(verify['A'])
+    if not observed: raise RuntimeError('Empty verification output')
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':{k:hashlib.sha256(v.read_bytes()).hexdigest() for k,v in clients.items()},
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    names=a.workloads or WORKLOADS[a.suite]
+    if any(w not in WORKLOADS[a.suite] for w in names): raise ValueError('Unknown workload')
+    calibration=[]; iterations={}; expected={}
+    for w in names:
+        iterations[w]={}
+        for k in paths:
+            sample=json.loads(launch(k,[w,'4']))
+            calibration.append({'revision':k,**sample})
+            speed=sample['elapsed_ns']/sample['iterations']
+            iterations[w][k]=max(1,min(2_000_000,math.ceil(a.ms*1e6/speed)))
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=json.loads(launch(k,[w,str(iterations[w][k])]))
+                    if data['expected'] != expected[w] or data['checksum'] != expected[w]*iterations[w][k]: raise RuntimeError('Timed checksum changed')
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                assert len(times)==2
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':iterations[w]}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_character_classification.py
+++ b/Tools/compare_character_classification.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and identical
+public client source separately compiled against each matching library. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+
+WORKLOADS = {
+    "classification": ["ascii-letters", "ascii-mixed", "unicode-mixed", "start-tags", "word-short", "tag-name", "word-unicode", "selector-parse", "selector-tags", "selector-unicode", "parse-control"]
+}
+
+
+def validate_sample(sample, workload, iterations, expected=None):
+    """Reject inconsistent records before using their timing denominator."""
+    if not isinstance(sample, dict) or set(sample) != {"workload", "iterations", "elapsed_ns", "expected", "checksum"}:
+        raise ValueError("Unexpected sample schema")
+    if sample['workload'] != workload:
+        raise ValueError("Workload mismatch")
+    for key in ('iterations', 'elapsed_ns', 'expected', 'checksum'):
+        if type(sample[key]) is not int:
+            raise ValueError(f"{key} must be an integer")
+    if sample['iterations'] != iterations or iterations <= 0:
+        raise ValueError("Iteration count mismatch")
+    if sample['elapsed_ns'] <= 0:
+        raise ValueError("Elapsed duration must be positive")
+    if expected is not None and sample['expected'] != expected:
+        raise ValueError("Expected value changed")
+    if sample['checksum'] != sample['expected'] * iterations:
+        raise ValueError("Checksum mismatch")
+    return sample
+
+
+def validate_outputs(first, second):
+    if first != second:
+        raise ValueError("Full observable outputs differ; refusing to benchmark")
+    observed = json.loads(first)
+    if not isinstance(observed, list) or not observed or any(not isinstance(x, dict) or not x for x in observed):
+        raise ValueError("Verification output must be a nonempty array of nonempty records")
+    return observed
+
+
+def validate_workloads(names):
+    if not names or len(set(names)) != len(names):
+        raise ValueError("Workloads must be nonempty and unique")
+    if any(w not in WORKLOADS['classification'] for w in names):
+        raise ValueError("Unknown workload")
+    return names
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--baseline-client',type=Path,required=True)
+    p.add_argument('--candidate-client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    import numpy as np
+    from scipy.stats import t
+    names=validate_workloads(a.workloads or WORKLOADS[a.suite])
+    a.output.mkdir(parents=True,exist_ok=False)
+    clients={'A': a.baseline_client.resolve(), 'B': (a.baseline_client if a.aa else a.candidate_client).resolve()}
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(clients[k]),*args],env=variables[k],check=True,capture_output=True,text=True,timeout=120)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    observed=validate_outputs(verify['A'],verify['B'])
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':{k:hashlib.sha256(v.read_bytes()).hexdigest() for k,v in clients.items()},
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    calibration=[]; iterations={}; expected={}
+    for w in names:
+        iterations[w]={}
+        for k in paths:
+            # Calibrate with measured batches rather than extrapolating four
+            # tiny calls. Retain every calibration attempt separately.
+            count = 16
+            while True:
+                sample=validate_sample(json.loads(launch(k,[w,str(count)])),w,count,expected.get(w))
+                expected[w]=sample['expected']
+                calibration.append({'revision':k,**sample})
+                (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+                if sample['elapsed_ns'] >= max(20, a.ms / 3) * 1e6 or count >= 100_000_000:
+                    break
+                ratio = max(2, min(8, math.ceil(a.ms * 1e6 / max(1, sample['elapsed_ns']))))
+                count = min(100_000_000, count * ratio)
+            speed=sample['elapsed_ns']/sample['iterations']
+            iterations[w][k]=max(1,min(100_000_000,math.ceil(a.ms*1e6/speed)))
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=validate_sample(json.loads(launch(k,[w,str(iterations[w][k])])),w,iterations[w][k],expected[w])
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                if len(times)!=2: raise ValueError('Each block needs two observations per revision')
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':iterations[w], 'batch_ms_min':min(x['elapsed_ns']/1e6 for x in records if x['workload']==w), 'batch_ms_max':max(x['elapsed_ns']/1e6 for x in records if x['workload']==w)}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_child_reads.py
+++ b/Tools/compare_child_reads.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and identical
+public client source separately compiled against each matching library. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+import numpy as np
+from scipy.stats import t
+
+WORKLOADS = {
+    "child": ["child-first-8", "child-first-256", "child-first-2048",
+              "child-middle-256", "child-last-256", "child-all-256",
+              "child-mixed-256", "child-custom-256", "parse-child", "parse-control"],
+    "only": ["only-direct-8", "only-direct-128", "only-direct-512",
+             "only-select-128", "only-select-512", "only-mixed-128",
+             "only-custom-128", "only-unary-256", "parse-only", "parse-control"],
+}
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--baseline-client',type=Path,required=True)
+    p.add_argument('--candidate-client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    a.output.mkdir(parents=True,exist_ok=False)
+    clients={'A': a.baseline_client.resolve(), 'B': (a.baseline_client if a.aa else a.candidate_client).resolve()}
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(clients[k]),*args],env=variables[k],check=True,capture_output=True,text=True,timeout=120)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    if verify['A'] != verify['B']: raise RuntimeError('Full observable outputs differ; refusing to benchmark')
+    observed=json.loads(verify['A'])
+    if not observed: raise RuntimeError('Empty verification output')
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':{k:hashlib.sha256(v.read_bytes()).hexdigest() for k,v in clients.items()},
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    names=a.workloads or WORKLOADS[a.suite]
+    if any(w not in WORKLOADS[a.suite] for w in names): raise ValueError('Unknown workload')
+    calibration=[]; iterations={}; expected={}
+    for w in names:
+        iterations[w]={}
+        for k in paths:
+            sample=json.loads(launch(k,[w,'4']))
+            calibration.append({'revision':k,**sample})
+            speed=sample['elapsed_ns']/sample['iterations']
+            iterations[w][k]=max(1,min(2_000_000,math.ceil(a.ms*1e6/speed)))
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=json.loads(launch(k,[w,str(iterations[w][k])]))
+                    if data['expected'] != expected[w] or data['checksum'] != expected[w]*iterations[w][k]: raise RuntimeError('Timed checksum changed')
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                assert len(times)==2
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':iterations[w]}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_cursor_moves.py
+++ b/Tools/compare_cursor_moves.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and identical
+public client source separately compiled against each matching library. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+import numpy as np
+from scipy.stats import t
+
+WORKLOADS = {
+    "region": ["region-short", "region-ascii-512", "region-unicode-128", "region-unicode-512",
+               "region-long-tail", "region-offset", "region-miss", "prefix-short", "prefix-unicode-512",
+               "parse-selector", "parse-control"],
+    "move": ["move-wide-16", "move-wide-128", "move-wide-1024", "move-middle-128",
+             "move-adjacent-4096", "move-noop-128", "move-absent-128", "parse-control"],
+}
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--baseline-client',type=Path,required=True)
+    p.add_argument('--candidate-client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    a.output.mkdir(parents=True,exist_ok=False)
+    clients={'A': a.baseline_client.resolve(), 'B': (a.baseline_client if a.aa else a.candidate_client).resolve()}
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(clients[k]),*args],env=variables[k],check=True,capture_output=True,text=True,timeout=120)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    if verify['A'] != verify['B']: raise RuntimeError('Full observable outputs differ; refusing to benchmark')
+    observed=json.loads(verify['A'])
+    if not observed: raise RuntimeError('Empty verification output')
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':{k:hashlib.sha256(v.read_bytes()).hexdigest() for k,v in clients.items()},
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    names=a.workloads or WORKLOADS[a.suite]
+    if any(w not in WORKLOADS[a.suite] for w in names): raise ValueError('Unknown workload')
+    calibration=[]; iterations={}; expected={}
+    for w in names:
+        iterations[w]={}
+        for k in paths:
+            sample=json.loads(launch(k,[w,'4']))
+            calibration.append({'revision':k,**sample})
+            speed=sample['elapsed_ns']/sample['iterations']
+            iterations[w][k]=max(1,min(2_000_000,math.ceil(a.ms*1e6/speed)))
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=json.loads(launch(k,[w,str(iterations[w][k])]))
+                    if data['expected'] != expected[w] or data['checksum'] != expected[w]*iterations[w][k]: raise RuntimeError('Timed checksum changed')
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                assert len(times)==2
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':iterations[w]}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_entity_benchmarks.py
+++ b/Tools/compare_entity_benchmarks.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Run identical public clients against two shipping SwiftSoup libraries.
+
+Produces raw fresh-process ABBA/BAAB records and a provenance manifest. Run
+--aa as a separate control. No sample or outlier is removed. See the companion
+Benchmarks reports for compilation commands and interpretation limits.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import time
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--baseline-library', type=Path, required=True)
+    parser.add_argument('--candidate-library', type=Path, required=True)
+    parser.add_argument('--client', type=Path, required=True)
+    parser.add_argument('--workloads', nargs='+', required=True)
+    parser.add_argument('--output', type=Path, required=True, help='New output prefix')
+    parser.add_argument('--blocks', type=int, default=12)
+    parser.add_argument('--ms', type=float, default=500)
+    parser.add_argument('--size', type=int, default=128)
+    parser.add_argument('--aa', action='store_true', help='Use the baseline for BOTH labels')
+    args = parser.parse_args()
+    if args.blocks < 2 or not 0 < args.ms <= 60000 or args.size < 1:
+        parser.error('Require blocks >= 2, 0 < ms <= 60000, size >= 1')
+    client = args.client.resolve(strict=True)
+    libraries = {'A': args.baseline_library.resolve(strict=True),
+                 'B': args.candidate_library.resolve(strict=True)}
+    extension = '.dylib' if platform.system() == 'Darwin' else '.so'
+    files = {k: v / ('libSwiftSoup' + extension) for k, v in libraries.items()}
+    raw_path = Path(str(args.output) + '.jsonl')
+    meta_path = Path(str(args.output) + '-metadata.json')
+    if raw_path.exists() or meta_path.exists():
+        parser.error('Refusing to overwrite an existing run')
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    allowed = sorted(os.sched_getaffinity(0)) if hasattr(os, 'sched_getaffinity') else []
+    cpu = allowed[0] if allowed else None
+    if cpu is not None:
+        os.sched_setaffinity(0, {cpu})
+    environment = {k: v for k, v in os.environ.items()
+                   if not k.startswith(('SWIFTSOUP_', 'SWIFT_DETERMINISTIC'))
+                   and k not in ('LD_PRELOAD', 'DYLD_INSERT_LIBRARIES', 'LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH')}
+    loader_variable = 'DYLD_LIBRARY_PATH' if extension == '.dylib' else 'LD_LIBRARY_PATH'
+
+    def run(label: str, workload: str, iterations: int, verify: bool = False):
+        actual = 'A' if args.aa else label
+        child = dict(environment, **{loader_variable: str(libraries[actual])})
+        command = [str(client), '--workload', workload, '--iterations', str(iterations),
+                   '--size', str(args.size), '--warmups', '3']
+        if verify:
+            command.append('--verify')
+        started = time.time()
+        result = subprocess.run(command, env=child, capture_output=True, text=True, timeout=180)
+        if result.returncode or result.stderr:
+            raise RuntimeError({'command': command, 'status': result.returncode,
+                                'stdout': result.stdout, 'stderr': result.stderr})
+        if verify:
+            return result.stdout
+        sample = json.loads(result.stdout)
+        if sample['iterations'] != iterations or sample['nanoseconds'] <= 0:
+            raise RuntimeError('Invalid sample: ' + result.stdout)
+        sample.update(label=label, actual_label=actual, command=command,
+                      library=str(files[actual]), timestamp=started)
+        return sample
+
+    metadata = {'platform': platform.platform(), 'cpu': cpu, 'allowed_cpus': allowed,
+                'aa': args.aa, 'blocks': args.blocks, 'target_ms': args.ms, 'size': args.size,
+                'client_sha256': sha256(client),
+                'libraries': {k: {'path': str(v), 'sha256': sha256(v)} for k, v in files.items()},
+                'verification_sha256': {}, 'calibration': {}}
+    for workload in args.workloads:
+        observed_a = run('A', workload, 1, True)
+        observed_b = run('B', workload, 1, True)
+        if observed_a != observed_b:
+            raise RuntimeError('Complete public output mismatch: ' + workload)
+        metadata['verification_sha256'][workload] = hashlib.sha256(observed_a.encode()).hexdigest()
+        calibration = [run(label, workload, 20) for label in ['A', 'B']]
+        fastest = min(s['nanoseconds'] / s['iterations'] for s in calibration)
+        iterations = max(1, min(2000000, round(args.ms * 1e6 / fastest)))
+        metadata['calibration'][workload] = {'samples': calibration, 'iterations': iterations}
+    with meta_path.open('x') as stream:
+        json.dump(metadata, stream, indent=2)
+    with raw_path.open('x') as stream:
+        for workload in args.workloads:
+            iterations = metadata['calibration'][workload]['iterations']
+            for block in range(args.blocks):
+                order = ['A', 'B', 'B', 'A'] if block % 2 == 0 else ['B', 'A', 'A', 'B']
+                samples = []
+                for position, label in enumerate(order):
+                    sample = run(label, workload, iterations)
+                    sample.update(block=block, position=position)
+                    samples.append(sample)
+                    stream.write(json.dumps(sample) + '\n')
+                    stream.flush()
+                if len({s['checksum'] for s in samples}) != 1:
+                    raise RuntimeError('Timed checksum mismatch: ' + workload)
+            print('Completed', workload, flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/compare_exclusion.py
+++ b/Tools/compare_exclusion.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and one
+unchanged public client. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+import numpy as np
+from scipy.stats import t
+
+WORKLOADS = {
+    'exclusion': ['not-8', 'not-128', 'not-512', 'not-2048', 'not-8192',
+                  'sparse-control', 'descendant-control', 'parse-not', 'parse-control'],
+}
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    a.output.mkdir(parents=True,exist_ok=False)
+    client=a.client.resolve()
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(client),*args],env=variables[k],check=True,capture_output=True,text=True)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    if verify['A'] != verify['B']: raise RuntimeError('Full observable outputs differ; refusing to benchmark')
+    observed=json.loads(verify['A'])
+    if not observed: raise RuntimeError('Empty verification output')
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':hashlib.sha256(client.read_bytes()).hexdigest(),
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    names=a.workloads or WORKLOADS[a.suite]
+    if any(w not in WORKLOADS[a.suite] for w in names): raise ValueError('Unknown workload')
+    calibration=[]; iterations={}; expected={}
+    for w in names:
+        speeds=[]
+        for k in paths:
+            sample=json.loads(launch(k,[w,'4']))
+            calibration.append({'revision':k,**sample})
+            speeds.append(sample['elapsed_ns']/sample['iterations'])
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+        iterations[w]=max(4,min(2_000_000,math.ceil(a.ms*1e6/min(speeds))))
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=json.loads(launch(k,[w,str(iterations[w])]))
+                    if data['expected'] != expected[w] or data['checksum'] != expected[w]*iterations[w]: raise RuntimeError('Timed checksum changed')
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                assert len(times)==2
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':iterations[w]}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_independent_hotspots.py
+++ b/Tools/compare_independent_hotspots.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and one
+unchanged public client. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+import numpy as np
+from scipy.stats import t
+
+WORKLOADS = {
+    'position': ['index-wide', 'index-mixed', 'nth-select', 'parse-nth', 'custom-parent', 'parse-control'],
+    'css': ['css-short', 'css-long', 'css-slash', 'css-comments', 'clean-styled', 'parse-clean', 'clean-plain'],
+}
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    a.output.mkdir(parents=True,exist_ok=False)
+    client=a.client.resolve()
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(client),*args],env=variables[k],check=True,capture_output=True,text=True)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    if verify['A'] != verify['B']: raise RuntimeError('Full observable outputs differ; refusing to benchmark')
+    observed=json.loads(verify['A'])
+    if not observed: raise RuntimeError('Empty verification output')
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':hashlib.sha256(client.read_bytes()).hexdigest(),
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    names=a.workloads or WORKLOADS[a.suite]
+    if any(w not in WORKLOADS[a.suite] for w in names): raise ValueError('Unknown workload')
+    calibration=[]; iterations={}; expected={}
+    for w in names:
+        speeds=[]
+        for k in paths:
+            sample=json.loads(launch(k,[w,'4']))
+            calibration.append({'revision':k,**sample})
+            speeds.append(sample['elapsed_ns']/sample['iterations'])
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+        iterations[w]=max(4,min(2_000_000,math.ceil(a.ms*1e6/min(speeds))))
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=json.loads(launch(k,[w,str(iterations[w])]))
+                    if data['expected'] != expected[w] or data['checksum'] != expected[w]*iterations[w]: raise RuntimeError('Timed checksum changed')
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                assert len(times)==2
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':iterations[w]}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_ordered_insertion.py
+++ b/Tools/compare_ordered_insertion.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and one
+unchanged public client. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+import numpy as np
+from scipy.stats import t
+
+WORKLOADS = {
+    'ordered': ['head-16', 'middle-16', 'head-128', 'middle-128',
+                'head-1024', 'middle-1024', 'tail-128', 'duplicate-128', 'parse-control'],
+}
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    a.output.mkdir(parents=True,exist_ok=False)
+    client=a.client.resolve()
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(client),*args],env=variables[k],check=True,capture_output=True,text=True)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    if verify['A'] != verify['B']: raise RuntimeError('Full observable outputs differ; refusing to benchmark')
+    observed=json.loads(verify['A'])
+    if not observed: raise RuntimeError('Empty verification output')
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':hashlib.sha256(client.read_bytes()).hexdigest(),
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    names=a.workloads or WORKLOADS[a.suite]
+    if any(w not in WORKLOADS[a.suite] for w in names): raise ValueError('Unknown workload')
+    calibration=[]; iterations={}; expected={}
+    for w in names:
+        speeds=[]
+        for k in paths:
+            sample=json.loads(launch(k,[w,'4']))
+            calibration.append({'revision':k,**sample})
+            speeds.append(sample['elapsed_ns']/sample['iterations'])
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+        iterations[w]=max(4,min(2_000_000,math.ceil(a.ms*1e6/min(speeds))))
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=json.loads(launch(k,[w,str(iterations[w])]))
+                    if data['expected'] != expected[w] or data['checksum'] != expected[w]*iterations[w]: raise RuntimeError('Timed checksum changed')
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                assert len(times)==2
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':iterations[w]}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_pattern_reuse.py
+++ b/Tools/compare_pattern_reuse.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Balanced fresh-process Pattern A/B and same-binary A/A; no dependencies.
+
+Compile baseline/candidate shipping libraries identically and compile the
+identical Swift client source separately against each module. Pattern layout
+          changes without library evolution, so swapping libraries under one old client
+          is invalid. Compilation and correctness suites must
+finish before this driver starts. Unused Pattern construction is reported
+with fixed iterations: its very short baseline is not a precision benchmark.
+"""
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import statistics
+import subprocess
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--baseline-library', type=pathlib.Path, required=True)
+    p.add_argument('--candidate-library', type=pathlib.Path, required=True)
+    p.add_argument('--baseline-client', type=pathlib.Path, required=True)
+    p.add_argument('--candidate-client', type=pathlib.Path, required=True)
+    p.add_argument('--output', type=pathlib.Path, required=True)
+    a = p.parse_args()
+    a.output.mkdir(parents=True, exist_ok=False)
+    if hasattr(os, 'sched_getaffinity'):
+        os.sched_setaffinity(0, {min(os.sched_getaffinity(0))})
+    loader = 'DYLD_LIBRARY_PATH' if platform.system() == 'Darwin' else 'LD_LIBRARY_PATH'
+    libraries = {'A': a.baseline_library.resolve(), 'B': a.candidate_library.resolve()}
+    clients = {'A': a.baseline_client.resolve(), 'B': a.candidate_client.resolve()}
+    records = []
+    def run(role, workload, count, stage, pair, logical_role=None):
+        env = dict(os.environ)
+        env[loader] = str(libraries[role])
+        result = json.loads(subprocess.check_output([str(clients[role]), '--workload', workload, '--iterations', str(count)], env=env, text=True))
+        if result['iterations'] != count or result['elapsed_ns'] <= 0:
+            raise RuntimeError('Invalid timing record')
+        result.update(role=role, logical_role=logical_role or role, stage=stage, pair=pair)
+        records.append(result)
+        with (a.output / 'raw.jsonl').open('a') as out:
+            out.write(json.dumps(result, sort_keys=True) + '\n')
+        return result
+    summary = {}
+    for workload in ['reused', 'validated', 'fresh', 'parse', 'unused']:
+        ca = run('A', workload, 2, 'calibration', -1)
+        cb = run('B', workload, 2, 'calibration', -1)
+        if ca['checksum'] != cb['checksum']:
+            raise RuntimeError('Output mismatch during calibration')
+        count = 8 if workload == 'unused' else max(2, min(4096, int(150000000 / min(ca['ns_per_op'], cb['ns_per_op']))))
+        summary[workload] = {}
+        for stage, pairs in [('aa', 8), ('ab', 12)]:
+            ratios = []
+            for pair in range(pairs):
+                roles = ['A', 'B'] if pair % 2 == 0 else ['B', 'A']
+                observed = {}
+                for role in roles:
+                    observed[role] = run('A' if stage == 'aa' else role, workload, count, stage, pair, logical_role=role)
+                if observed['A']['checksum'] != observed['B']['checksum']:
+                    raise RuntimeError('Output mismatch')
+                ratios.append(observed['B']['ns_per_op'] / observed['A']['ns_per_op'] - 1)
+            summary[workload][stage] = {'pairs': pairs, 'median_percent_change': 100 * statistics.median(ratios),
+                                       'faster_pairs': sum(r < 0 for r in ratios), 'paired_changes': ratios}
+    identities = {'platform': platform.platform(), 'client_sha256': {role: hashlib.sha256(client.read_bytes()).hexdigest() for role, client in clients.items()}}
+    for role, directory in libraries.items():
+        identities[role] = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in directory.glob('libSwiftSoup.*')}
+    (a.output / 'summary.json').write_text(json.dumps({'identities': identities, 'results': summary}, indent=2) + '\n')
+    print(json.dumps(summary, indent=2))
+if __name__ == '__main__':
+    main()

--- a/Tools/compare_sibling_endpoints.py
+++ b/Tools/compare_sibling_endpoints.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Compare complete release clients using balanced fresh processes; no third-party dependencies."""
+import argparse, hashlib, json, math, os, pathlib, random, statistics, subprocess, sys, time
+
+CASES = ['single','first-8','first-256','first-2048','last-256','last-2048','first-mixed','fallback','parse-endpoints','parse-control']
+T95 = {2:12.706204736,3:4.302652730,4:3.182446305,5:2.776445105,6:2.570581836,7:2.446911851,8:2.364624252,9:2.306004135,10:2.262157163,11:2.228138852,12:2.200985160,13:2.178812830,14:2.160368656,15:2.144786688,16:2.131449546}
+
+def main():
+    ap=argparse.ArgumentParser(description=__doc__)
+    for k in ['baseline-client','candidate-client','baseline-library','candidate-library','output']: ap.add_argument('--'+k,required=True)
+    ap.add_argument('--blocks',type=int,choices=range(2,17),default=8)
+    ap.add_argument('--ms',type=float,default=160)
+    ap.add_argument('--cpu',type=int)
+    ap.add_argument('--aa',action='store_true')
+    ap.add_argument('--cases',default=','.join(CASES))
+    args=ap.parse_args()
+    if args.ms < 40: ap.error('--ms must be at least 40')
+    names=args.cases.split(',')
+    if not names or any(n not in CASES for n in names): ap.error('unknown/empty case set')
+    if args.cpu is not None and hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{args.cpu})
+    root=pathlib.Path(args.output); root.mkdir(parents=True,exist_ok=False)
+    binaries={'A':str(pathlib.Path(args.baseline_client).resolve()),'B':str(pathlib.Path(args.candidate_client).resolve())}
+    libraries={'A':str(pathlib.Path(args.baseline_library).resolve()),'B':str(pathlib.Path(args.candidate_library).resolve())}
+    if args.aa: binaries['B']=binaries['A']; libraries['B']=libraries['A']
+    def run(side, case, iterations=None):
+        env=os.environ.copy(); env['DYLD_LIBRARY_PATH' if sys.platform=='darwin' else 'LD_LIBRARY_PATH']=libraries[side]
+        cmd=[binaries[side],case]+([] if iterations is None else [str(iterations)])
+        proc=subprocess.run(cmd,env=env,stdout=subprocess.PIPE,stderr=subprocess.PIPE,timeout=120,check=True)
+        if proc.stderr: (root/'stderr.log').open('ab').write(proc.stderr)
+        if iterations is None: return proc.stdout
+        row=json.loads(proc.stdout)
+        if row['case']!=case or row['iterations']!=iterations or row['checksum']!=row['expected']*iterations or row['ns']<=0: raise RuntimeError('invalid timing/consumption record')
+        return row
+    for side in ['A','B']: (root/f'outputs-{side}.json').write_bytes(run(side,'--verify'))
+    assert (root/'outputs-A.json').read_bytes()==(root/'outputs-B.json').read_bytes(), 'Output differs'
+    manifest={'args':vars(args),'binaries':binaries,'libraries':libraries,'python':sys.version,'platform':sys.platform,'timestamp':time.time(),'cpu_affinity':sorted(os.sched_getaffinity(0)) if hasattr(os,'sched_getaffinity') else None,'sha256':{k:hashlib.sha256(pathlib.Path(v).read_bytes()).hexdigest() for k,v in binaries.items()},'output_sha256':hashlib.sha256((root/'outputs-A.json').read_bytes()).hexdigest()}
+    (root/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    counts={}; calibration=[]; expected={}
+    for case in names:
+        for side in ['A','B']:
+            n=1
+            while True:
+                row=run(side,case,n); calibration.append(dict(row,side=side)); expected[(side,case)]=row['expected']
+                if row['ns']>=30_000_000 or n>=20_000_000: break
+                n=min(20_000_000,n*max(2,min(8,math.ceil(30_000_000/row['ns']))))
+            n=max(1,min(20_000_000,round(n*args.ms*1_000_000/row['ns'])))
+            row=run(side,case,n); calibration.append(dict(row,side=side,validation=True))
+            if row['ns'] < args.ms*600_000 and n<20_000_000:
+                n=min(20_000_000,math.ceil(n*args.ms*1_000_000/row['ns']))
+                calibration.append(dict(run(side,case,n),side=side,validation=True))
+            counts[(side,case)]=n
+        assert expected[('A',case)]==expected[('B',case)], 'Checksum expectation differs'
+    (root/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    rng=random.Random(36936); records=[]
+    with (root/'raw.jsonl').open('w') as out:
+        for block in range(args.blocks):
+            shuffled=names.copy(); rng.shuffle(shuffled)
+            order='ABBA' if block%2==0 else 'BAAB'
+            for case in shuffled:
+                for slot,side in enumerate(order):
+                    row=dict(run(side,case,counts[(side,case)]),side=side,block=block,slot=slot)
+                    assert row['expected']==expected[(side,case)]
+                    records.append(row); out.write(json.dumps(row)+'\n'); out.flush()
+            print(f'completed block {block+1}/{args.blocks}',flush=True)
+    summary=[]
+    for case in names:
+        data=[r for r in records if r['case']==case]
+        logs={side:[math.log(r['ns']/r['iterations']/1e6) for r in data if r['side']==side] for side in ['A','B']}
+        differences=[]
+        for block in range(args.blocks):
+            byside={side:[math.log(r['ns']/r['iterations']) for r in data if r['side']==side and r['block']==block] for side in ['A','B']}
+            assert len(byside['A'])==len(byside['B'])==2
+            differences.append(statistics.mean(byside['B'])-statistics.mean(byside['A']))
+        mean=statistics.mean(differences); margin=T95[args.blocks]*statistics.stdev(differences)/math.sqrt(args.blocks)
+        row={'case':case,'baseline_ms':math.exp(statistics.mean(logs['A'])),'candidate_ms':math.exp(statistics.mean(logs['B'])),'less_time_percent':100*(1-math.exp(mean)),'ci95_less_time_percent':[100*(1-math.exp(mean+margin)),100*(1-math.exp(mean-margin))],'batch_ms_range':[min(r['ns']/1e6 for r in data),max(r['ns']/1e6 for r in data)],'blocks':args.blocks}
+        summary.append(row)
+        print(json.dumps(row),flush=True)
+    (root/'summary.json').write_text(json.dumps(summary,indent=2))
+
+if __name__=='__main__': main()

--- a/Tools/compare_tokenqueue_search.py
+++ b/Tools/compare_tokenqueue_search.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Fresh-process release comparisons with full output verification and balanced order.
+
+Requires Python 3, NumPy and SciPy. Uses already-built dynamic libraries and one
+unchanged public client. Never build or profile concurrently with timed runs.
+"""
+import argparse, hashlib, json, math, os, platform, random, subprocess, time
+from pathlib import Path
+import numpy as np
+from scipy.stats import t
+
+WORKLOADS = {"search": ['early-ascii', 'tiny-ascii', 'late-ascii-2048', 'late-japanese-128', 'late-japanese-512', 'late-japanese-2048', 'miss-japanese-512', 'mixed-graphemes', 'offset-japanese', 'canonical-match', 'numeric-parse-512', 'normal-parse-control']}
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--client',type=Path,required=True)
+    p.add_argument('--baseline-library',type=Path,required=True)
+    p.add_argument('--candidate-library',type=Path,required=True)
+    p.add_argument('--suite',choices=WORKLOADS,required=True)
+    p.add_argument('--output',type=Path,required=True)
+    p.add_argument('--blocks',type=int,default=8)
+    p.add_argument('--ms',type=int,default=250)
+    p.add_argument('--cpu',type=int,default=0)
+    p.add_argument('--aa',action='store_true')
+    p.add_argument('--workloads',nargs='+')
+    a=p.parse_args()
+    if a.blocks < 2 or a.ms < 1: p.error('blocks must be >=2 and ms >=1')
+    a.output.mkdir(parents=True,exist_ok=False)
+    client=a.client.resolve()
+    paths={'A':a.baseline_library.resolve(),'B':(a.baseline_library if a.aa else a.candidate_library).resolve()}
+    variables={k:dict(os.environ) for k in paths}
+    libvar='DYLD_LIBRARY_PATH' if platform.system()=='Darwin' else 'LD_LIBRARY_PATH'
+    for k,path in paths.items(): variables[k][libvar]=str(path)
+    if hasattr(os,'sched_setaffinity'): os.sched_setaffinity(0,{a.cpu})
+    def launch(k,args):
+        result=subprocess.run([str(client),*args],env=variables[k],check=True,capture_output=True,text=True)
+        if result.stderr: raise RuntimeError(result.stderr)
+        return result.stdout
+    verify={k:launch(k,['--verify']) for k in paths}
+    for k,s in verify.items(): (a.output/f'outputs-{k}.json').write_text(s)
+    if verify['A'] != verify['B']: raise RuntimeError('Full observable outputs differ; refusing to benchmark')
+    observed=json.loads(verify['A'])
+    if not observed: raise RuntimeError('Empty verification output')
+    manifest={'arguments':{k:str(v) if isinstance(v,Path) else v for k,v in vars(a).items()},'platform':platform.platform(),
+              'client_sha256':hashlib.sha256(client.read_bytes()).hexdigest(),
+              'library_sha256':{k:hashlib.sha256((v/('libSwiftSoup.dylib' if platform.system()=='Darwin' else 'libSwiftSoup.so')).read_bytes()).hexdigest() for k,v in paths.items()},
+              'output_sha256':hashlib.sha256(verify['A'].encode()).hexdigest(),'verification_records':len(observed),'created_unix':time.time()}
+    (a.output/'manifest.json').write_text(json.dumps(manifest,indent=2))
+    names=a.workloads or WORKLOADS[a.suite]
+    if any(w not in WORKLOADS[a.suite] for w in names): raise ValueError('Unknown workload')
+    calibration=[]; iterations={"A":{},"B":{}}; expected={}
+    for w in names:
+        speeds=[]
+        for k in paths:
+            sample=json.loads(launch(k,[w,'4']))
+            calibration.append({'revision':k,**sample})
+            speeds.append(sample['elapsed_ns']/sample['iterations'])
+            iterations[k][w]=max(4,min(2_000_000,math.ceil(a.ms*1e6/speeds[-1])))
+            if w in expected and sample['expected'] != expected[w]: raise RuntimeError('Checksum mismatch')
+            expected[w]=sample['expected']
+        # Calibrate each revision separately: avoid timing an enormous baseline
+        # batch merely because the candidate eliminates quadratic index walks.
+    (a.output/'calibration.json').write_text(json.dumps(calibration,indent=2))
+    records=[]; rng=random.Random(962409)
+    with open(a.output/'raw.jsonl','w') as log:
+        for block in range(a.blocks):
+            workloads=names.copy(); rng.shuffle(workloads)
+            for w in workloads:
+                order='ABBA' if block%2==0 else 'BAAB'
+                for slot,k in enumerate(order):
+                    data=json.loads(launch(k,[w,str(iterations[k][w])]))
+                    if data['expected'] != expected[w] or data['checksum'] != expected[w]*iterations[k][w]: raise RuntimeError('Timed checksum changed')
+                    record={'block':block,'slot':slot,'revision':k,**data}
+                    records.append(record); log.write(json.dumps(record)+'\n'); log.flush()
+            print(f'{a.suite} {"AA" if a.aa else "AB"}: completed block {block+1}/{a.blocks}',flush=True)
+    summary=[]
+    for w in names:
+        means=[]
+        for block in range(a.blocks):
+            pair={}
+            for k in paths:
+                times=[x['elapsed_ns']/x['iterations']/1e6 for x in records if x['workload']==w and x['block']==block and x['revision']==k]
+                assert len(times)==2
+                pair[k]=float(np.mean(np.log(times)))
+            means.append(pair)
+        deltas=np.array([x['B']-x['A'] for x in means]); center=float(np.mean(deltas))
+        margin=float(t.ppf(.975,len(deltas)-1)*np.std(deltas,ddof=1)/math.sqrt(len(deltas)))
+        result={'workload':w,'baseline_ms':float(np.exp(np.mean([x['A'] for x in means]))),'candidate_ms':float(np.exp(np.mean([x['B'] for x in means]))),
+                'less_time_pct':100*(1-math.exp(center)),'low_pct':100*(1-math.exp(center+margin)),'high_pct':100*(1-math.exp(center-margin)),
+                'blocks':a.blocks,'processes_per_revision':a.blocks*2,'iterations':{k:iterations[k][w] for k in paths}}
+        summary.append(result)
+    (a.output/'summary.json').write_text(json.dumps(summary,indent=2))
+    for x in summary: print(f"{x['workload']}: {x['less_time_pct']:.2f}% [{x['low_pct']:.2f}, {x['high_pct']:.2f}]",flush=True)
+
+if __name__=='__main__': main()

--- a/Tools/compare_whitespace_runs.py
+++ b/Tools/compare_whitespace_runs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Independent release-library A/B or A/A runs. Requires Python 3 and SciPy."""
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import random
+import statistics
+import subprocess
+import sys
+from scipy.stats import t
+
+
+def digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--baseline-library', required=True, type=Path)
+    p.add_argument('--candidate-library', required=True, type=Path)
+    p.add_argument('--client', required=True, type=Path)
+    p.add_argument('--output', required=True, type=Path)
+    p.add_argument('--blocks', type=int, default=12)
+    p.add_argument('--ms', type=float, default=500)
+    p.add_argument('--size', type=int, default=128)
+    p.add_argument('--workloads', nargs='+', default=['text-japanese', 'text-mixed', 'text-short', 'text-ascii', 'text-plain', 'textnode', 'owntext', 'parse-text', 'raw'])
+    p.add_argument('--aa', action='store_true')
+    a = p.parse_args()
+    if a.blocks < 3 or a.ms <= 0 or not 1 <= a.size <= 4096:
+        p.error('Need blocks >= 3, ms > 0, and size 1...4096')
+    a.output.mkdir(parents=True, exist_ok=False)
+    client = str(a.client.resolve(strict=True))
+    libs = {'baseline': a.baseline_library.resolve(strict=True),
+            'candidate': (a.baseline_library if a.aa else a.candidate_library).resolve(strict=True)}
+    affinity = None
+    if hasattr(os, 'sched_getaffinity'):
+        affinity = min(os.sched_getaffinity(0))
+        os.sched_setaffinity(0, {affinity})
+    ext = 'dylib' if sys.platform == 'darwin' else 'so'
+    key = 'DYLD_LIBRARY_PATH' if sys.platform == 'darwin' else 'LD_LIBRARY_PATH'
+    metadata = {'argv': sys.argv, 'platform': platform.platform(), 'python': sys.version,
+                'affinity_cpu': affinity, 'aa': a.aa, 'client': client, 'client_sha256': digest(client),
+                'libraries': {k: {'path': str(v), 'sha256': digest(v / ('libSwiftSoup.' + ext))} for k, v in libs.items()}}
+    (a.output / 'metadata.json').write_text(json.dumps(metadata, indent=2) + '\n')
+
+    def run(label, workload, iterations, verify=False):
+        command = [client, '--workload', workload, '--size', str(a.size), '--iterations', str(iterations)]
+        if verify:
+            command.append('--verify')
+        environment = os.environ.copy()
+        environment[key] = str(libs[label])
+        result = subprocess.run(command, env=environment, capture_output=True, timeout=180, check=True)
+        parsed = json.loads(result.stdout)
+        return parsed, result.stdout, command
+
+    calibrations = []
+    counts = {}
+    checksums = {}
+    for workload in a.workloads:
+        reference = None
+        sample_times = []
+        for label in libs:
+            value, raw, _ = run(label, workload, 1, True)
+            (a.output / f'{workload}-{label}-output.json').write_bytes(raw)
+            if reference is not None and raw != reference:
+                raise RuntimeError(f'Full output mismatch: {workload}')
+            reference = raw
+            checksums[workload] = value['checksum']
+            value, _, command = run(label, workload, 64)
+            calibrations.append({'label': label, 'command': command, **value})
+            sample_times.append(value['ns_per_op'])
+        counts[workload] = max(1, math.ceil(a.ms * 1e6 / min(sample_times)))
+    (a.output / 'calibration.json').write_text(json.dumps(calibrations, indent=2) + '\n')
+    records = []
+    rng = random.Random(20260909)
+    with (a.output / 'raw.jsonl').open('w') as stream:
+        for block in range(a.blocks):
+            workloads = list(a.workloads)
+            rng.shuffle(workloads)
+            order = ['baseline', 'candidate', 'candidate', 'baseline'] if block % 2 == 0 else ['candidate', 'baseline', 'baseline', 'candidate']
+            for workload in workloads:
+                for slot, label in enumerate(order):
+                    value, _, command = run(label, workload, counts[workload])
+                    if value['checksum'] != checksums[workload] * counts[workload]:
+                        raise RuntimeError(f'Timed checksum mismatch: {workload}/{label}')
+                    row = {'block': block, 'slot': slot, 'label': label, 'command': command, **value}
+                    records.append(row)
+                    stream.write(json.dumps(row) + '\n')
+                    stream.flush()
+            print(f'Completed block {block + 1}/{a.blocks}', flush=True)
+    summary = []
+    for workload in a.workloads:
+        pairs = []
+        logs = {'baseline': [], 'candidate': []}
+        for block in range(a.blocks):
+            means = {}
+            for label in libs:
+                values = [math.log(r['ns_per_op']) for r in records if r['block'] == block and r['workload'] == workload and r['label'] == label]
+                assert len(values) == 2
+                logs[label].extend(values)
+                means[label] = statistics.mean(values)
+            pairs.append(means['candidate'] - means['baseline'])
+        center = statistics.mean(pairs)
+        half = float(t.ppf(0.975, len(pairs) - 1)) * statistics.stdev(pairs) / math.sqrt(len(pairs))
+        row = {'workload': workload, 'baseline_ms': math.exp(statistics.mean(logs['baseline'])) / 1e6,
+               'candidate_ms': math.exp(statistics.mean(logs['candidate'])) / 1e6,
+               'less_time_percent': 100 * (1 - math.exp(center)),
+               'ci95_low': 100 * (1 - math.exp(center + half)), 'ci95_high': 100 * (1 - math.exp(center - half)),
+               'blocks': len(pairs), 'processes_per_revision': 2 * len(pairs)}
+        summary.append(row)
+    (a.output / 'summary.json').write_text(json.dumps(summary, indent=2) + '\n')
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/tests/test_character_classification_runner.py
+++ b/Tools/tests/test_character_classification_runner.py
@@ -1,0 +1,83 @@
+"""Run with python3 -m unittest discover -s Tools/tests (no SciPy needed)."""
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location("classification_runner", Path(__file__).resolve().parents[1] / "compare_character_classification.py")
+runner = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(runner)
+
+
+class SampleValidationTests(unittest.TestCase):
+    def sample(self, **changes):
+        value = {"workload": "word-short", "iterations": 16, "elapsed_ns": 123456,
+                 "expected": 7, "checksum": 112}
+        value.update(changes)
+        return value
+
+    def test_valid_record_is_not_rewritten(self):
+        sample = self.sample()
+        self.assertIs(runner.validate_sample(sample, 'word-short', 16, 7), sample)
+
+    def test_wrong_iteration_count_is_rejected_even_with_plausible_checksum(self):
+        with self.assertRaisesRegex(ValueError, 'Iteration'):
+            runner.validate_sample(self.sample(iterations=1), 'word-short', 16, 7)
+
+    def test_zero_checksum_cannot_hide_wrong_iteration_count(self):
+        with self.assertRaisesRegex(ValueError, 'Iteration'):
+            runner.validate_sample(self.sample(iterations=1, expected=0, checksum=0), 'word-short', 16, 0)
+        runner.validate_sample(self.sample(expected=0, checksum=0), 'word-short', 16, 0)
+
+    def test_workload_must_match_the_requested_operation(self):
+        with self.assertRaisesRegex(ValueError, 'Workload'):
+            runner.validate_sample(self.sample(workload='parse-control'), 'word-short', 16)
+
+    def test_calibration_checks_the_checksum_too(self):
+        with self.assertRaisesRegex(ValueError, 'Checksum'):
+            runner.validate_sample(self.sample(checksum=111), 'word-short', 16)
+
+    def test_expected_value_cannot_drift(self):
+        with self.assertRaisesRegex(ValueError, 'Expected'):
+            runner.validate_sample(self.sample(expected=8, checksum=128), 'word-short', 16, 7)
+
+    def test_duration_must_be_positive(self):
+        for duration in (0, -1):
+            with self.subTest(duration=duration), self.assertRaises(ValueError):
+                runner.validate_sample(self.sample(elapsed_ns=duration), 'word-short', 16)
+
+    def test_counts_must_be_integers_not_coercible_values(self):
+        for key in ('iterations', 'elapsed_ns', 'expected', 'checksum'):
+            for value in (True, False, 16.0, '16', None, float('nan'), float('inf')):
+                with self.subTest(key=key, value=value), self.assertRaises(ValueError):
+                    runner.validate_sample(self.sample(**{key: value}), 'word-short', 16)
+
+    def test_schema_rejects_missing_extra_and_nonobject_values(self):
+        incomplete = self.sample()
+        incomplete.pop('checksum')
+        for sample in (None, [], incomplete, self.sample(extra=1)):
+            with self.subTest(sample=sample), self.assertRaises(ValueError):
+                runner.validate_sample(sample, 'word-short', 16)
+
+    def test_verifier_requires_complete_nonempty_record_array(self):
+        for value in (None, False, 1, 'nonempty', {}, {'x': 1}, [], [{}], [1]):
+            text = json.dumps(value)
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                runner.validate_outputs(text, text)
+        text = '[{"input":"a","word":"a"}]\n'
+        self.assertEqual(runner.validate_outputs(text, text), json.loads(text))
+
+    def test_verifier_uses_exact_bytes_not_just_json_equality(self):
+        with self.assertRaises(ValueError):
+            runner.validate_outputs('[{"a":1}]', '[{"a": 1}]')
+
+    def test_workloads_are_known_nonempty_and_unique(self):
+        for names in ([], ['unknown'], ['word-short', 'word-short']):
+            with self.subTest(names=names), self.assertRaises(ValueError):
+                runner.validate_workloads(names)
+        names = ['word-short', 'parse-control']
+        self.assertIs(runner.validate_workloads(names), names)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Part 8/8 of the SwiftSoup correctness/runtime reconciliation from lake-of-fire/SwiftSoup. Depends on #418. This PR targets that topic branch so its diff is incremental; review/merge the stack in order and retarget to master as prerequisites land.

Adds reusable benchmark drivers, comparison/noise checks and retained qualification reports for the preceding optimizations. Reports describe historical measurements on their recorded source/hosts; they are not new speedup measurements of these upstream PR commits. No runtime source changes.

Validation: No runtime changes; checked diff and task/document contents.

Built on current upstream `35f7e1b0049236edcc351c0f10e7beddd0d4e76c`; upstream PR #411 and its escaped-ID regression coverage are retained. Source is extracted from the reviewed fork tree `a197bd5620a062f210686541dd38499c1913d342` without importing its merge/publication-workflow history. Exact head: `9d65336fc5101732821576bb28c18fb21db29dd8`.

No new performance measurements are claimed for this integration under host load. Historical evidence is kept separate in part 8. This submission does not update upstream master or a release branch.

Stack order: #412 → #413 → #414 → #415 → #416 → #417 → #418 → #419.

Additional validation: 12 benchmark-runner unit tests passed (`PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s Tools/tests`); Python syntax and mise TOML parsing also passed. The complete stack matches the reviewed fork tree except for one trailing-whitespace-only cleanup in Attribute.swift. Historical commit snapshots referenced by the reports may require fetching from lake-of-fire/SwiftSoup.
